### PR TITLE
other: Revert "fix(optimum): let rbln_overrides override vision-encoder submodule defaults"

### DIFF
--- a/vllm_rbln/model_executor/models/optimum/compilation/__init__.py
+++ b/vllm_rbln/model_executor/models/optimum/compilation/__init__.py
@@ -48,31 +48,22 @@ def _deep_merge(base: dict, overrides: dict) -> None:
             base[key] = value
 
 
-def _find_conflicts(
-    base: dict,
-    overrides: dict,
-    overridable: frozenset[str] = frozenset(),
-    _prefix: str = "",
-) -> list[str]:
+def _find_conflicts(base: dict, overrides: dict, _prefix: str = "") -> list[str]:
     """Return dotted paths where ``overrides`` would overwrite an existing
     value in ``base`` with a different one.
 
     Mirrors ``_deep_merge``'s traversal: nested dicts recurse, leaves compare
     by value. A key present only in ``overrides`` is not a conflict (the user
-    is adding a new knob, not clobbering a derived field). A path in
-    ``overridable`` is skipped along with everything under it — the model
-    declared that submodule user-overridable via its ``get_overridable``.
+    is adding a new knob, not clobbering a derived field).
     """
     conflicts: list[str] = []
     for key, value in overrides.items():
-        path = f"{_prefix}{key}"
-        if path in overridable:
-            continue
         if key not in base:
             continue
+        path = f"{_prefix}{key}"
         existing = base[key]
         if isinstance(value, dict) and isinstance(existing, dict):
-            conflicts.extend(_find_conflicts(existing, value, overridable, f"{path}."))
+            conflicts.extend(_find_conflicts(existing, value, f"{path}."))
         elif existing != value:
             conflicts.append(f"{path} (compiled={existing!r}, override={value!r})")
     return conflicts
@@ -102,10 +93,6 @@ class RBLNCompileSpec:
 
     model_cls: Any
     rbln_config: dict[str, Any]
-    # Submodules/paths the user may override despite the builder setting a default
-    # (compile-only knobs vllm never reads back). Declared per-model by the
-    # model's ``get_overridable``; consulted by ``_find_conflicts``.
-    overridable: frozenset[str] = frozenset()
 
     @classmethod
     def for_architecture(
@@ -165,13 +152,9 @@ class RBLNCompileSpec:
         # rbln_overrides must not overwrite fields vllm derives from its own
         # config (batch_size, max_seq_len, memory_budget, ...); a silent
         # mismatch would compile a model that disagrees with the runtime. Adding
-        # a new key not set by the builder is allowed, as is overwriting anything
-        # under a per-model overridable submodule (``spec.overridable``, e.g. a
-        # vision encoder's ``visual`` — knobs vllm never reads back).
+        # a new key not set by the builder is allowed.
         if rbln_overrides:
-            conflicts = _find_conflicts(
-                spec.rbln_config, rbln_overrides, overridable=spec.overridable
-            )
+            conflicts = _find_conflicts(spec.rbln_config, rbln_overrides)
             if conflicts:
                 raise ValueError(
                     "rbln_overrides conflict with vllm-derived compile config: "
@@ -267,16 +250,7 @@ class RBLNCompileSpec:
             memory_budget,
             prefill_chunk_size,
         )
-        # A model may declare submodules the user can freely override via a
-        # ``get_overridable()`` defined in its builder module (e.g. qwen exposes
-        # ``visual``); forward that set so the conflict check lets them win.
-        get_overridable = compile_fn.__globals__.get("get_overridable")
-        overridable = get_overridable() if get_overridable else frozenset()
-        return cls(
-            model_cls=model_cls,
-            rbln_config=rbln_config,
-            overridable=overridable,
-        )
+        return cls(model_cls=model_cls, rbln_config=rbln_config)
 
     @classmethod
     def _for_enc_dec(

--- a/vllm_rbln/model_executor/models/optimum/compilation/multimodal/exaone4_5.py
+++ b/vllm_rbln/model_executor/models/optimum/compilation/multimodal/exaone4_5.py
@@ -43,13 +43,3 @@ def get_param_exaone4_5(
     if prefill_chunk_size is not None:
         param["prefill_chunk_size"] = prefill_chunk_size
     return param
-
-
-def get_overridable() -> frozenset[str]:
-    """Submodules whose fields a user may override (see ``_find_conflicts``).
-
-    The ``visual`` (vision encoder) submodule is compile-only — vllm never reads
-    it back to size the runtime — so any of its fields may be overridden without
-    desyncing vllm and the compiled model.
-    """
-    return frozenset({"visual"})

--- a/vllm_rbln/model_executor/models/optimum/compilation/multimodal/llava.py
+++ b/vllm_rbln/model_executor/models/optimum/compilation/multimodal/llava.py
@@ -39,14 +39,3 @@ def get_param_llava(
 
 
 get_param_llava_next = get_param_llava
-
-
-def get_overridable() -> frozenset[str]:
-    """Submodules whose fields a user may override (see ``_find_conflicts``).
-
-    ``vision_tower`` is the vision encoder — compile-only, never read back by
-    vllm — so its fields are overridable. ``language_model`` is intentionally
-    NOT listed: vllm derives its batch_size / max_seq_len / block_size from that
-    submodule (see params.py), so those must stay protected.
-    """
-    return frozenset({"vision_tower"})

--- a/vllm_rbln/model_executor/models/optimum/compilation/multimodal/qwen.py
+++ b/vllm_rbln/model_executor/models/optimum/compilation/multimodal/qwen.py
@@ -53,13 +53,3 @@ def get_param_qwen2_vl(
 get_param_qwen2_5_vl = get_param_qwen2_vl
 get_param_qwen3_vl = get_param_qwen2_vl
 get_param_qwen3_vl_moe = get_param_qwen2_vl
-
-
-def get_overridable() -> frozenset[str]:
-    """Submodules whose fields a user may override (see ``_find_conflicts``).
-
-    The ``visual`` (vision encoder) submodule is compile-only — vllm never reads
-    it back to size the runtime — so any of its fields may be overridden without
-    desyncing vllm and the compiled model.
-    """
-    return frozenset({"visual"})


### PR DESCRIPTION
Reverts RBLN-SW/vllm-rbln#827