### PR TITLE
feature(nixl): pipeline parallelism for prefill/decode KV-cache transfer

### DIFF
--- a/tests/native/distributed/kv_connector/test_rbln_nixl_handshake_pp.py
+++ b/tests/native/distributed/kv_connector/test_rbln_nixl_handshake_pp.py
@@ -17,6 +17,7 @@
 # Exercises RblnNixlConnectorWorker._nixl_handshake with the ZMQ side-channel and
 # add_remote_agent mocked, so it needs neither a live NIXL peer nor nixl-rbln.
 
+import queue
 from collections import defaultdict
 from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
@@ -262,6 +263,9 @@ class TestPpHandshakeFanout:
             _handshake(w, sock)
 
     def test_swa_plus_pp_raises(self):
+        # The consumer's own guard, hit when it discovers a PP producer while it
+        # runs the SWA view-opt. TestPpConstraints covers the producer-side check
+        # in _check_pp_constraints; deleting either leaves its guard uncovered.
         w = _make_worker(sw_ratio=0.5)
         sock = _FakeSock(pp_size=2)
         with pytest.raises(RuntimeError, match="sliding-window"):
@@ -471,6 +475,14 @@ class TestShardReadPath:
         w.dst_num_blocks = {"eng": 8}
         w._recving_transfers = defaultdict(list)
         w._engine_last_active = {}
+        # What the base failure path reads: it logs with the engine id, looks the
+        # request's metadata up, queues the failure and the invalidated blocks.
+        w.engine_id = "local"
+        w._recving_metadata = {}
+        w._invalid_block_ids = queue.Queue()
+        w._failed_recv_reqs = queue.Queue()
+        w._is_hma_required = False
+        w.xfer_stats = MagicMock()
         # single group, 2 regions per shard
         w.kv_cache_config = MagicMock(kv_cache_groups=[0])
         w._shard_region_group_ids = {("eng", r): (0, 0) for r in range(pp_size)}
@@ -511,6 +523,26 @@ class TestShardReadPath:
         assert calls[1].args[1] == 101 and calls[1].args[3] == 201
         # completion: one handle per stage -> req done only when both finish.
         assert len(w._recving_transfers["r0"]) == 2
+
+    def test_a_failed_stage_leaves_no_handles_behind(self):
+        # A stage that fails takes the request with it, so nothing may stay in
+        # flight for it: get_finished() reports a failed request and drops its
+        # metadata, and a leftover handle completing later would report the same
+        # request a second time -- against metadata that is already gone.
+        w = self._read_worker(pp_size=3)
+        first = object()
+        w.nixl_wrapper.make_prepped_xfer.side_effect = [first, RuntimeError("boom")]
+
+        w._read_blocks_for_req("r0", self._meta([[1, 2]], [[3, 4]]))
+
+        assert w._recving_transfers["r0"] == []
+        # The stage that already submitted is released, and the third is never
+        # submitted -- the request is failed, not partially read.
+        w.nixl_wrapper.release_xfer_handle.assert_called_once_with(first)
+        assert w.nixl_wrapper.make_prepped_xfer.call_count == 2
+        # Reported failed exactly once, which is what the engine counts.
+        assert w._failed_recv_reqs.qsize() == 1
+        assert w._failed_recv_reqs.get_nowait() == "r0"
 
     def test_prefix_hit_notifies_each_stage_no_read(self):
         # Full prefix hit (empty local list): no read, one notif per stage.

--- a/tests/native/distributed/kv_connector/test_rbln_nixl_handshake_pp.py
+++ b/tests/native/distributed/kv_connector/test_rbln_nixl_handshake_pp.py
@@ -164,52 +164,55 @@ def _handshake(worker, sock, *, remote_tp_size=1, engine_id="eng"):
 
 
 class TestPpHandshakeFanout:
-    def test_single_stage_matches_base_shape(self):
-        # pp_size == 1: one shard queried, keyed by tp_rank (global_rank).
+    @pytest.mark.parametrize("pp_size", [1, 2, 3])
+    def test_every_stage_is_queried_once_and_keyed_by_global_rank(self, pp_size):
+        # The fan-out itself, from the degenerate single stage up. pp_size comes
+        # from the pp_rank-0 shard, which is why that one must not be queried
+        # again for its own registration -- and at pp_size 1 the whole thing has
+        # to reduce to the base's single-shard shape, keyed by tp_rank.
         w = _make_worker()
-        sock = _FakeSock(pp_size=1)
-        result = _handshake(w, sock)
-        assert result == {0: "agent-0"}
-        assert sock.queried == [0]  # bootstrap only
-        assert w.add_remote_agent.call_count == 1
-        assert dict(w._remote_shard_layer_names["eng"]) == {0: ("layer.0",)}
+        sock = _FakeSock(pp_size=pp_size)
 
-    def test_pp_fans_out_over_stages(self):
-        # pp_size == 2: both stages queried and registered by global_rank.
-        w = _make_worker()
-        sock = _FakeSock(pp_size=2)
         result = _handshake(w, sock)
-        assert result == {0: "agent-0", 1: "agent-1"}
-        # rank 0 bootstrap (reused), rank 1 queried once.
-        assert sock.queried == [0, 1]
-        ranks = sorted(c.args[1] for c in w.add_remote_agent.call_args_list)
-        assert ranks == [0, 1]
+
+        assert result == {r: f"agent-{r}" for r in range(pp_size)}
+        assert sock.queried == list(range(pp_size))
+        assert sock.queried.count(0) == 1  # bootstrap reused, not re-queried
+        assert w.add_remote_agent.call_count == pp_size
         assert dict(w._remote_shard_layer_names["eng"]) == {
-            0: ("layer.0",),
-            1: ("layer.1",),
+            r: (f"layer.{r}",) for r in range(pp_size)
         }
-        assert w._remote_pp_size["eng"] == 2
+        assert w._remote_pp_size["eng"] == pp_size
 
-    def test_bootstrap_reuses_first_query(self):
-        # The pp_rank-0 shard is queried exactly once (bootstrap reused).
+    @pytest.mark.parametrize(
+        ("local_band", "stage_layers"),
+        [
+            # Even split: this decode rank owns the second stage's single layer.
+            (["layer.1"], None),
+            # Uneven split (5 layers / 2 -> [3, 2]): this rank is the smaller last
+            # stage, so the peer stage is the LARGER one. Regression for the
+            # symmetric-uneven handshake crash: add_remote_agent indexes the local
+            # block_len_per_layer by the remote region position, so a larger
+            # non-overlapping peer must be skipped before it runs, not after.
+            (
+                ["layer.3", "layer.4"],
+                [["layer.0", "layer.1", "layer.2"], ["layer.3", "layer.4"]],
+            ),
+        ],
+        ids=["even", "uneven_larger_peer"],
+    )
+    def test_handshake_registers_only_overlapping_stages(
+        self, local_band, stage_layers
+    ):
+        # Of the two producer stages only the one this rank's band overlaps is
+        # handshaked and registered for reading. The other is skipped BEFORE
+        # add_remote_agent; its layer names are still recorded during enumeration.
         w = _make_worker()
-        sock = _FakeSock(pp_size=3)
-        _handshake(w, sock)
-        assert sock.queried == [0, 1, 2]
-        assert sock.queried.count(0) == 1
+        w.local_seen_layer_names = local_band
+        sock = _FakeSock(pp_size=2, stage_layers=stage_layers)
 
-    def test_handshake_registers_only_overlapping_stages(self):
-        # Decode-PP: this rank owns only layer.1, so of the two producer stages
-        # only stage 1 overlaps -> only it is handshaked (add_remote_agent) and
-        # registered for reading. The non-overlapping stage 0 is skipped BEFORE
-        # add_remote_agent so its base FA-remote build never runs (it would index
-        # the local block_len_per_layer out of range under an uneven split);
-        # its layer names are still recorded during enumeration.
-        w = _make_worker()
-        w.local_seen_layer_names = ["layer.1"]  # this decode rank's band
-        sock = _FakeSock(pp_size=2)
         result = _handshake(w, sock)
-        # Only the overlapping stage (1) is handshaked and read.
+
         assert result == {1: "agent-1"}
         assert [c.args[1] for c in w.add_remote_agent.call_args_list] == [1]
         assert set(w._remote_shard_layer_names["eng"]) == {0, 1}  # both enumerated
@@ -227,27 +230,6 @@ class TestPpHandshakeFanout:
         assert sorted(c.args[1] for c in w.add_remote_agent.call_args_list) == [0, 1]
         assert w._overlapping_ranks["eng"] == [0, 1]  # only owned stages read
         assert w._register_shard_read_state.call_count == 2
-
-    def test_symmetric_uneven_skips_larger_nonoverlapping_peer(self):
-        # Symmetric PP with an uneven layer split (e.g. 5 layers / 2 = [3, 2]):
-        # this decode rank is the *smaller* last stage and owns only its own
-        # layers. The peer producer stage is *larger* and does not overlap, so it
-        # must be skipped entirely -- add_remote_agent (and hence the base
-        # FA-remote build, which indexes the local block_len_per_layer by the
-        # remote region position) never runs on it. Regression for the
-        # symmetric-uneven PP4-PP4 handshake out-of-range crash.
-        w = _make_worker()
-        # stage 0 = 3 layers (larger), stage 1 = 2 layers (this rank, smaller).
-        stage_layers = [["layer.0", "layer.1", "layer.2"], ["layer.3", "layer.4"]]
-        w.local_seen_layer_names = ["layer.3", "layer.4"]  # this rank's own stage
-        sock = _FakeSock(pp_size=2, stage_layers=stage_layers)
-        result = _handshake(w, sock)
-        # Only this rank's own (overlapping) stage is handshaked/registered; the
-        # larger non-overlapping peer (stage 0) is skipped, not crashed.
-        assert result == {1: "agent-1"}
-        assert [c.args[1] for c in w.add_remote_agent.call_args_list] == [1]
-        assert w._overlapping_ranks["eng"] == [1]
-        assert w._register_shard_read_state.call_count == 1
 
     def test_partial_overlap_raises(self):
         # Prefill pipeline size not an integer multiple of the decode pipeline
@@ -352,15 +334,19 @@ class TestShardLocalRegions:
         with pytest.raises(AssertionError, match="not divisible"):
             w._regions_per_layer()
 
-    def test_shard_local_region_ids_kv_split(self):
-        # rpl=2: layer L -> regions [2L, 2L+1] (layer-major).
-        w = self._worker(["l0", "l1", "l2", "l3"], num_regions=8)
-        assert w._shard_local_region_ids(("l2", "l3")) == [4, 5, 6, 7]
-        assert w._shard_local_region_ids(("l0",)) == [0, 1]
-
-    def test_shard_local_region_ids_no_split(self):
-        w = self._worker(["l0", "l1", "l2", "l3"], num_regions=4)
-        assert w._shard_local_region_ids(("l1", "l2")) == [1, 2]
+    @pytest.mark.parametrize(
+        ("num_regions", "names", "expected"),
+        [
+            # rpl=2 (K/V split): layer L -> regions [2L, 2L+1], layer-major.
+            (8, ("l2", "l3"), [4, 5, 6, 7]),
+            (8, ("l0",), [0, 1]),
+            # rpl=1: the region index is the layer index.
+            (4, ("l1", "l2"), [1, 2]),
+        ],
+    )
+    def test_shard_local_region_ids(self, num_regions, names, expected):
+        w = self._worker(["l0", "l1", "l2", "l3"], num_regions=num_regions)
+        assert w._shard_local_region_ids(names) == expected
 
     @classmethod
     def _wired_worker(cls):

--- a/tests/native/distributed/kv_connector/test_rbln_nixl_handshake_pp.py
+++ b/tests/native/distributed/kv_connector/test_rbln_nixl_handshake_pp.py
@@ -1,0 +1,798 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Unit coverage: RBLN NIXL PP-aware consumer handshake fan-out.
+#
+# Exercises RblnNixlConnectorWorker._nixl_handshake with the ZMQ side-channel and
+# add_remote_agent mocked, so it needs neither a live NIXL peer nor nixl-rbln.
+
+from collections import defaultdict
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import msgspec
+import pytest
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl import NixlAgentMetadata
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+    NixlHandshakePayload,
+)
+
+import vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.worker as W
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.connector import (
+    RblnNixlConnector,
+)
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.metadata import (
+    RblnNixlAgentMetadata,
+    rbln_pp_compat_hash,
+)
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.worker import (
+    RblnNixlConnectorWorker,
+)
+
+
+def _encode_payload(
+    pp_rank,
+    pp_size,
+    *,
+    engine_id="eng",
+    compat="HASH",
+    layers_per_stage=1,
+    layer_names=None,
+):
+    if layer_names is None:
+        layer_names = [
+            f"layer.{pp_rank * layers_per_stage + j}" for j in range(layers_per_stage)
+        ]
+    meta = RblnNixlAgentMetadata(
+        engine_id=engine_id,
+        agent_metadata=b"agent",
+        kv_caches_base_addr=[0x1000],
+        device_id=0,
+        num_blocks=4,
+        block_lens=[8192],
+        kv_cache_layout="HND",
+        block_size=16,
+        ssm_sizes=(0, 0),
+        attn_backend_name="RBLN",
+        physical_blocks_per_logical_kv_block=1,
+        pp_rank=pp_rank,
+        pp_size=pp_size,
+        registered_layer_names=list(layer_names),
+    )
+    payload = NixlHandshakePayload(
+        compatibility_hash=compat,
+        agent_metadata_bytes=msgspec.msgpack.Encoder().encode(meta),
+    )
+    return msgspec.msgpack.Encoder().encode(payload)
+
+
+class _FakeSock:
+    # ZMQ REQ stand-in: replies to (GET_META_MSG, rank) with rank's payload.
+    #
+    # TP is 1 in these tests, so global_rank == pp_rank.
+
+    def __init__(
+        self,
+        pp_size,
+        *,
+        engine_id="eng",
+        compat="HASH",
+        layers_per_stage=1,
+        stage_layers=None,
+    ):
+        self.pp_size = pp_size
+        self.engine_id = engine_id
+        self.compat = compat
+        self.layers_per_stage = layers_per_stage
+        # Optional per-stage layer-name lists (for uneven splits); indexed by
+        # global_rank. When None, stages advertise a uniform layers_per_stage.
+        self.stage_layers = stage_layers
+        self.queried = []
+        self._last = None
+
+    def setsockopt(self, *a):
+        pass
+
+    def send(self, msg):
+        _, rank = msgspec.msgpack.decode(msg)
+        self.queried.append(rank)
+        self._last = rank
+
+    def recv(self):
+        return _encode_payload(
+            self._last,
+            self.pp_size,
+            engine_id=self.engine_id,
+            compat=self.compat,
+            layers_per_stage=self.layers_per_stage,
+            layer_names=(
+                self.stage_layers[self._last] if self.stage_layers is not None else None
+            ),
+        )
+
+
+def _make_worker(*, tp_target_ranks=(0,), sw_ratio=None, compat="HASH"):
+    w = object.__new__(RblnNixlConnectorWorker)
+    w.use_host_buffer = True  # skip current_platform.set_device
+    w.transfer_topo = MagicMock()
+    w.transfer_topo.handshake_target_ranks.return_value = list(tp_target_ranks)
+    w.compat_hash = compat
+    w.enforce_compat_hash = True
+    w._sw_ratio = sw_ratio
+    w._remote_shard_layer_names = defaultdict(dict)
+    w._remote_pp_size = {}
+    w._overlapping_ranks = defaultdict(list)
+    # Full-model consumer: owns every producer stage's layer, so every stage
+    # overlaps (the fan-out default). _FakeSock advertises stage i as "layer.i".
+    w.local_seen_layer_names = ["layer.0", "layer.1", "layer.2"]
+    w.add_remote_agent = MagicMock(side_effect=lambda meta, rank, tps: f"agent-{rank}")
+    # Per-shard local handle building is exercised in TestShardLocalRegions;
+    # stub it here so the fan-out tests stay focused on stage enumeration.
+    w._register_shard_read_state = MagicMock()
+    return w
+
+
+@contextmanager
+def _patched_socket(sock):
+    @contextmanager
+    def fake_zmq_ctx(_type, _path):
+        yield sock
+
+    with (
+        patch.object(W, "zmq_ctx", fake_zmq_ctx),
+        patch.object(W, "make_zmq_path", lambda *a: "tcp://x"),
+        patch.object(W, "current_platform", MagicMock()),
+    ):
+        yield
+
+
+def _handshake(worker, sock, *, remote_tp_size=1, engine_id="eng"):
+    with _patched_socket(sock):
+        return worker._nixl_handshake("h", 1234, remote_tp_size, engine_id)
+
+
+class TestPpHandshakeFanout:
+    def test_single_stage_matches_base_shape(self):
+        # pp_size == 1: one shard queried, keyed by tp_rank (global_rank).
+        w = _make_worker()
+        sock = _FakeSock(pp_size=1)
+        result = _handshake(w, sock)
+        assert result == {0: "agent-0"}
+        assert sock.queried == [0]  # bootstrap only
+        assert w.add_remote_agent.call_count == 1
+        assert dict(w._remote_shard_layer_names["eng"]) == {0: ("layer.0",)}
+
+    def test_pp_fans_out_over_stages(self):
+        # pp_size == 2: both stages queried and registered by global_rank.
+        w = _make_worker()
+        sock = _FakeSock(pp_size=2)
+        result = _handshake(w, sock)
+        assert result == {0: "agent-0", 1: "agent-1"}
+        # rank 0 bootstrap (reused), rank 1 queried once.
+        assert sock.queried == [0, 1]
+        ranks = sorted(c.args[1] for c in w.add_remote_agent.call_args_list)
+        assert ranks == [0, 1]
+        assert dict(w._remote_shard_layer_names["eng"]) == {
+            0: ("layer.0",),
+            1: ("layer.1",),
+        }
+        assert w._remote_pp_size["eng"] == 2
+
+    def test_bootstrap_reuses_first_query(self):
+        # The pp_rank-0 shard is queried exactly once (bootstrap reused).
+        w = _make_worker()
+        sock = _FakeSock(pp_size=3)
+        _handshake(w, sock)
+        assert sock.queried == [0, 1, 2]
+        assert sock.queried.count(0) == 1
+
+    def test_handshake_registers_only_overlapping_stages(self):
+        # Decode-PP: this rank owns only layer.1, so of the two producer stages
+        # only stage 1 overlaps -> only it is handshaked (add_remote_agent) and
+        # registered for reading. The non-overlapping stage 0 is skipped BEFORE
+        # add_remote_agent so its base FA-remote build never runs (it would index
+        # the local block_len_per_layer out of range under an uneven split);
+        # its layer names are still recorded during enumeration.
+        w = _make_worker()
+        w.local_seen_layer_names = ["layer.1"]  # this decode rank's band
+        sock = _FakeSock(pp_size=2)
+        result = _handshake(w, sock)
+        # Only the overlapping stage (1) is handshaked and read.
+        assert result == {1: "agent-1"}
+        assert [c.args[1] for c in w.add_remote_agent.call_args_list] == [1]
+        assert set(w._remote_shard_layer_names["eng"]) == {0, 1}  # both enumerated
+        assert w._overlapping_ranks["eng"] == [1]
+        assert w._register_shard_read_state.call_count == 1
+
+    def test_multiple_ratio_registers_k_stages(self):
+        # prefill_pp=4, decode_pp=2 (k=2): this decode rank owns 2 producer
+        # stages' layers, so only those 2 are handshaked/registered; the other
+        # two non-overlapping stages are skipped before add_remote_agent.
+        w = _make_worker()
+        w.local_seen_layer_names = ["layer.0", "layer.1"]  # this rank's band
+        sock = _FakeSock(pp_size=4)  # stages advertise layer.0..layer.3
+        _handshake(w, sock)
+        assert sorted(c.args[1] for c in w.add_remote_agent.call_args_list) == [0, 1]
+        assert w._overlapping_ranks["eng"] == [0, 1]  # only owned stages read
+        assert w._register_shard_read_state.call_count == 2
+
+    def test_symmetric_uneven_skips_larger_nonoverlapping_peer(self):
+        # Symmetric PP with an uneven layer split (e.g. 5 layers / 2 = [3, 2]):
+        # this decode rank is the *smaller* last stage and owns only its own
+        # layers. The peer producer stage is *larger* and does not overlap, so it
+        # must be skipped entirely -- add_remote_agent (and hence the base
+        # FA-remote build, which indexes the local block_len_per_layer by the
+        # remote region position) never runs on it. Regression for the
+        # symmetric-uneven PP4-PP4 handshake out-of-range crash.
+        w = _make_worker()
+        # stage 0 = 3 layers (larger), stage 1 = 2 layers (this rank, smaller).
+        stage_layers = [["layer.0", "layer.1", "layer.2"], ["layer.3", "layer.4"]]
+        w.local_seen_layer_names = ["layer.3", "layer.4"]  # this rank's own stage
+        sock = _FakeSock(pp_size=2, stage_layers=stage_layers)
+        result = _handshake(w, sock)
+        # Only this rank's own (overlapping) stage is handshaked/registered; the
+        # larger non-overlapping peer (stage 0) is skipped, not crashed.
+        assert result == {1: "agent-1"}
+        assert [c.args[1] for c in w.add_remote_agent.call_args_list] == [1]
+        assert w._overlapping_ranks["eng"] == [1]
+        assert w._register_shard_read_state.call_count == 1
+
+    def test_partial_overlap_raises(self):
+        # Prefill pipeline size not an integer multiple of the decode pipeline
+        # size: a producer stage's layer band straddles this decode rank's band
+        # (partial overlap) -> reject.
+        w = _make_worker()
+        # Producer: 2 stages x 2 layers -> stage0=[layer.0,layer.1],
+        # stage1=[layer.2,layer.3]. This decode rank owns a misaligned band
+        # [layer.1, layer.2], so stage0 partially overlaps (owns layer.1 only).
+        w.local_seen_layer_names = ["layer.1", "layer.2"]
+        sock = _FakeSock(pp_size=2, layers_per_stage=2)
+        with pytest.raises(RuntimeError, match="partially overlaps"):
+            _handshake(w, sock)
+
+    def test_swa_plus_pp_raises(self):
+        w = _make_worker(sw_ratio=0.5)
+        sock = _FakeSock(pp_size=2)
+        with pytest.raises(RuntimeError, match="sliding-window"):
+            _handshake(w, sock)
+
+    def test_tp_plus_pp_raises(self):
+        w = _make_worker(tp_target_ranks=(0,))
+        sock = _FakeSock(pp_size=2)
+        with pytest.raises(RuntimeError, match="tensor parallel"):
+            _handshake(w, sock, remote_tp_size=2)
+
+    def test_compat_hash_mismatch_raises(self):
+        w = _make_worker(compat="LOCAL")
+        sock = _FakeSock(pp_size=1, compat="REMOTE")
+        with pytest.raises(RuntimeError, match="compatibility hash"):
+            _handshake(w, sock)
+
+    def test_engine_id_mismatch_raises(self):
+        w = _make_worker()
+        sock = _FakeSock(pp_size=1, engine_id="other")
+        with pytest.raises(RuntimeError, match="engine ID"):
+            _handshake(w, sock, engine_id="eng")
+
+
+class TestLocalRegionIndicesForLayerNames:
+    # Name-based matching of a producer shard's layers to local region
+    # indices.
+
+    @staticmethod
+    def _worker(local_names):
+        w = object.__new__(RblnNixlConnectorWorker)
+        w.local_seen_layer_names = list(local_names)
+        return w
+
+    def test_contiguous_shard(self):
+        w = self._worker(["l0", "l1", "l2", "l3"])
+        assert w._local_region_indices_for_layer_names(["l2", "l3"]) == [2, 3]
+        assert w._local_region_indices_for_layer_names(["l0", "l1"]) == [0, 1]
+
+    def test_full_model_consumer_maps_all(self):
+        names = [f"l{i}" for i in range(4)]
+        w = self._worker(names)
+        assert w._local_region_indices_for_layer_names(names) == [0, 1, 2, 3]
+
+    def test_repeated_names_resolved_by_occurrence(self):
+        # HMA pools can register a name more than once; match by occurrence.
+        w = self._worker(["a", "a", "b"])
+        assert w._local_region_indices_for_layer_names(["a", "b", "a"]) == [0, 2, 1]
+
+    def test_zero_overlap_returns_empty(self):
+        # A producer stage entirely outside this rank's band -> empty: the
+        # stage is read by whichever rank owns it, not here.
+        w = self._worker(["l0", "l1"])
+        assert w._local_region_indices_for_layer_names(["l2"]) == []
+
+    def test_decode_shard_maps_only_owned_band(self):
+        # Decode-PP rank owns layers [l4..l7]: producer stages outside its band
+        # map empty; stages inside map to this rank's local indices.
+        w = self._worker(["l4", "l5", "l6", "l7"])
+        assert w._local_region_indices_for_layer_names(["l0", "l1"]) == []
+        assert w._local_region_indices_for_layer_names(["l4", "l5"]) == [0, 1]
+        assert w._local_region_indices_for_layer_names(["l6", "l7"]) == [2, 3]
+
+
+class TestShardLocalRegions:
+    # Layer-name -> local region-index expansion and the per-shard local
+    # xfer handle (region subset).
+
+    @staticmethod
+    def _worker(local_names, num_regions):
+        w = object.__new__(RblnNixlConnectorWorker)
+        w.local_seen_layer_names = list(local_names)
+        w.num_regions = num_regions
+        return w
+
+    def test_regions_per_layer(self):
+        w = self._worker(["l0", "l1", "l2", "l3"], num_regions=8)
+        assert w._regions_per_layer() == 2  # K/V split
+        w2 = self._worker(["l0", "l1"], num_regions=2)
+        assert w2._regions_per_layer() == 1
+
+    def test_regions_per_layer_non_divisible_raises(self):
+        w = self._worker(["l0", "l1", "l2"], num_regions=8)
+        with pytest.raises(AssertionError, match="not divisible"):
+            w._regions_per_layer()
+
+    def test_shard_local_region_ids_kv_split(self):
+        # rpl=2: layer L -> regions [2L, 2L+1] (layer-major).
+        w = self._worker(["l0", "l1", "l2", "l3"], num_regions=8)
+        assert w._shard_local_region_ids(("l2", "l3")) == [4, 5, 6, 7]
+        assert w._shard_local_region_ids(("l0",)) == [0, 1]
+
+    def test_shard_local_region_ids_no_split(self):
+        w = self._worker(["l0", "l1", "l2", "l3"], num_regions=4)
+        assert w._shard_local_region_ids(("l1", "l2")) == [1, 2]
+
+    def test_register_shard_local_xfer_handler_covers_subset(self):
+        w = self._worker(["l0", "l1", "l2", "l3"], num_regions=8)  # rpl=2
+        w.block_size = 16
+        w.num_blocks = 4
+        w.device_id = 0
+        w.engine_id = "eng"
+        w.tp_rank = 0
+        w._has_mamba = False
+        w.nixl_memory_type = "DRAM"
+        w.kv_caches_base_addr = {"eng": {0: [1000 * i for i in range(8)]}}
+        w.block_len_per_layer = [64] * 8
+        w.transfer_topo = MagicMock()
+        w.transfer_topo.is_kv_layout_blocks_first = False
+        w.get_backend_aware_kv_block_len = MagicMock(return_value=64)
+        w.nixl_wrapper = MagicMock()
+        w.nixl_wrapper.prep_xfer_dlist.return_value = 42
+
+        handle, blocks = w._register_shard_local_xfer_handler(16, ("l2", "l3"))
+
+        assert handle == 42
+        # shard regions [4,5,6,7] x num_blocks 4 = 16 descriptors.
+        assert len(blocks) == 16
+        # first desc: region 4 base addr (4000), block 0.
+        assert blocks[0] == (4000, 64, 0)
+        # block 1 of region 4: base + 1*stride(64).
+        assert blocks[1] == (4000 + 64, 64, 0)
+        # regions used are exactly the shard's (no addr below 4000).
+        assert min(a for a, _, _ in blocks) == 4000
+
+
+class TestShardReadPath:
+    # Per-stage read loop + shard descriptor ids.
+
+    def test_get_block_descs_ids_for_shard(self):
+        # 0-based descs over the shard's regions; group_id picks the block
+        # group. Single group -> region_id * num_blocks + block_ids[0].
+        w = object.__new__(RblnNixlConnectorWorker)
+        w._shard_region_group_ids = {("eng", 1): (0, 0, 0, 0)}  # 4 regions, group 0
+        descs = w._get_block_descs_ids_for_shard(
+            "eng", 1, num_blocks=10, block_ids=[[2, 5]]
+        )
+        # region r contributes r*10 + [2,5]: [2,5, 12,15, 22,25, 32,35]
+        assert list(descs) == [2, 5, 12, 15, 22, 25, 32, 35]
+
+    def test_get_block_descs_ids_for_shard_empty_group(self):
+        w = object.__new__(RblnNixlConnectorWorker)
+        w._shard_region_group_ids = {("eng", 0): (0, 0)}
+        descs = w._get_block_descs_ids_for_shard("eng", 0, num_blocks=4, block_ids=[[]])
+        assert descs.size == 0
+
+    @staticmethod
+    def _read_worker(pp_size):
+        w = object.__new__(RblnNixlConnectorWorker)
+        w._remote_pp_size = {"eng": pp_size}
+        # Full-model decode: every stage overlaps. Decode-PP subsets this (see
+        # test_reads_only_overlapping_stages).
+        w._overlapping_ranks = {"eng": list(range(pp_size))}
+        w._has_mamba = False  # non-Mamba scope: _apply_prefix_caching end-trims
+        w.world_size = 1
+        w.num_blocks = 8
+        w.dst_num_blocks = {"eng": 8}
+        w._recving_transfers = defaultdict(list)
+        w._engine_last_active = {}
+        # single group, 2 regions per shard
+        w.kv_cache_config = MagicMock(kv_cache_groups=[0])
+        w._shard_region_group_ids = {("eng", r): (0, 0) for r in range(pp_size)}
+        w.src_xfer_handles_by_remote = {("eng", r, 16): 100 + r for r in range(pp_size)}
+        w.dst_xfer_side_handles = {"eng": {r: 200 + r for r in range(pp_size)}}
+        w._remote_agents = {"eng": {r: f"agent{r}" for r in range(pp_size)}}
+        topo = MagicMock()
+        topo.get_engine_info.return_value = MagicMock(
+            remote_tp_size=1, remote_block_size=16, remote_physical_blocks_per_logical=1
+        )
+        topo.tp_ratio.return_value = 1
+        topo.block_size_ratio.return_value = 1
+        w.transfer_topo = topo
+        w._logical_to_remote_kernel_block_ids = lambda ids, _n: ids
+        w.nixl_wrapper = MagicMock()
+        w.nixl_wrapper.make_prepped_xfer.side_effect = lambda *a, **k: object()
+        return w
+
+    def _meta(self, local_ids, remote_ids):
+        remote = MagicMock()
+        remote.engine_id = "eng"
+        remote.request_id = "r0"
+        remote.block_ids = remote_ids
+        meta = MagicMock()
+        meta.remote = remote
+        meta.local_physical_block_ids = local_ids
+        return meta
+
+    def test_reads_every_stage(self):
+        # pp_size=2 -> one prepped READ per stage, each with its own shard
+        # handles; the request accrues one transfer handle per stage.
+        w = self._read_worker(pp_size=2)
+        w._read_blocks_for_req("r0", self._meta([[1, 2]], [[3, 4]]))
+        assert w.nixl_wrapper.make_prepped_xfer.call_count == 2
+        # stage 0 uses local handle 100 / remote 200; stage 1 -> 101 / 201.
+        calls = w.nixl_wrapper.make_prepped_xfer.call_args_list
+        assert calls[0].args[1] == 100 and calls[0].args[3] == 200
+        assert calls[1].args[1] == 101 and calls[1].args[3] == 201
+        # completion: one handle per stage -> req done only when both finish.
+        assert len(w._recving_transfers["r0"]) == 2
+
+    def test_prefix_hit_notifies_each_stage_no_read(self):
+        # Full prefix hit (empty local list): no read, one notif per stage.
+        w = self._read_worker(pp_size=2)
+        w._read_blocks_for_req("r0", self._meta([], [[3, 4]]))
+        assert w.nixl_wrapper.make_prepped_xfer.call_count == 0
+        assert w.nixl_wrapper.send_notif.call_count == 2
+        assert len(w._recving_transfers["r0"]) == 0
+
+    def test_partial_prefix_hit_trims_remote_per_stage(self):
+        # Partial hit: D allocated only the uncached suffix (1 block) while the
+        # remote prompt is 3 blocks, so the remote is end-trimmed to the last
+        # block -> local/remote desc counts match per stage and the read fires.
+        w = self._read_worker(pp_size=2)
+        w._read_blocks_for_req("r0", self._meta([[7]], [[3, 4, 7]]))
+        assert w.nixl_wrapper.make_prepped_xfer.call_count == 2
+        for c in w.nixl_wrapper.make_prepped_xfer.call_args_list:
+            local_descs, remote_descs = c.args[2], c.args[4]
+            assert len(local_descs) == len(remote_descs)
+            # 2 regions per shard x 1 (trimmed) block = 2 descriptors.
+            assert len(remote_descs) == 2
+        assert len(w._recving_transfers["r0"]) == 2
+
+    def test_reads_only_overlapping_stages(self):
+        # Decode-PP (m=4, n=2): this rank owns 2 of the 4 producer stages, so
+        # it READs only its overlapping stages; the other two are neither read
+        # nor notified (another decode rank owns and notifies them).
+        w = self._read_worker(pp_size=4)
+        w._overlapping_ranks = {"eng": [0, 1]}  # this rank's band = stages 0,1
+        w._read_blocks_for_req("r0", self._meta([[1, 2]], [[3, 4]]))
+        assert w.nixl_wrapper.make_prepped_xfer.call_count == 2
+        # only stages 0,1 local handles used (100, 101); never 102/103.
+        used = {c.args[1] for c in w.nixl_wrapper.make_prepped_xfer.call_args_list}
+        assert used == {100, 101}
+        assert w.nixl_wrapper.send_notif.call_count == 0
+        assert len(w._recving_transfers["r0"]) == 2
+
+    def test_prefix_hit_notifies_only_overlapping_stages(self):
+        # Full prefix hit under decode-PP: notify only this rank's stages.
+        w = self._read_worker(pp_size=4)
+        w._overlapping_ranks = {"eng": [0, 1]}
+        w._read_blocks_for_req("r0", self._meta([], [[3, 4]]))
+        assert w.nixl_wrapper.make_prepped_xfer.call_count == 0
+        assert w.nixl_wrapper.send_notif.call_count == 2  # only stages 0,1
+        notified = {c.args[0] for c in w.nixl_wrapper.send_notif.call_args_list}
+        assert notified == {"agent0", "agent1"}
+
+
+class TestValidateRemoteAgentHandshake:
+    # PP-aware handshake validation. The base
+    # ``_validate_remote_agent_handshake`` asserts matching P/D region counts
+    # (`len(remote.kv_caches_base_addr) == len(self.block_len_per_layer)`), which
+    # a layer-sharded PP producer necessarily violates against a full-model
+    # consumer. Regression for that end-to-end AssertionError.
+
+    @staticmethod
+    def _consumer(*, num_layers=28, dst_num_blocks=8):
+        # Full-model host-bounce consumer: num_regions = num_layers * 2 (K/V),
+        # so regions-per-layer = 2.
+        w = object.__new__(RblnNixlConnectorWorker)
+        w.local_seen_layer_names = [f"l{i}" for i in range(num_layers)]
+        w.num_regions = num_layers * 2
+        w.block_len_per_layer = [64] * (num_layers * 2)
+        w.dst_num_blocks = {"eng": dst_num_blocks}
+        topo = MagicMock()
+        topo.get_engine_info.return_value = MagicMock(remote_tp_size=1)
+        topo.block_size_ratio.return_value = 1
+        w.transfer_topo = topo
+        return w
+
+    @staticmethod
+    def _meta(*, pp_size, n_regions, num_blocks=8, block_size=16):
+        m = MagicMock()
+        m.pp_size = pp_size
+        m.engine_id = "eng"
+        m.kv_caches_base_addr = [1000 * i for i in range(n_regions)]
+        m.num_blocks = num_blocks
+        m.block_size = block_size
+        return m
+
+    def test_pp_shard_wellformed_passes(self):
+        # 28-layer model, PP2 -> each stage owns 14 layers = 28 regions,
+        # a valid sub-multiple of the local 56. Base assert would fire (28!=56).
+        w = self._consumer(num_layers=28)
+        w._validate_remote_agent_handshake(
+            self._meta(pp_size=2, n_regions=28), remote_tp_size=1
+        )  # no raise
+
+    def test_pp_shard_region_count_not_multiple_of_rpl_raises(self):
+        w = self._consumer(num_layers=28)  # regions-per-layer = 2
+        with pytest.raises(AssertionError, match="sub-multiple"):
+            w._validate_remote_agent_handshake(
+                self._meta(pp_size=2, n_regions=27), remote_tp_size=1
+            )
+
+    def test_pp_shard_larger_than_full_model_raises(self):
+        w = self._consumer(num_layers=28)  # full model = 56 regions
+        with pytest.raises(AssertionError, match="sub-multiple"):
+            w._validate_remote_agent_handshake(
+                self._meta(pp_size=2, n_regions=58), remote_tp_size=1
+            )
+
+    def test_pp_with_tp_raises(self):
+        w = self._consumer()
+        w.transfer_topo.get_engine_info.return_value = MagicMock(remote_tp_size=2)
+        with pytest.raises(AssertionError, match="TP=1"):
+            w._validate_remote_agent_handshake(
+                self._meta(pp_size=2, n_regions=28), remote_tp_size=2
+            )
+
+    def test_pp_block_size_mismatch_raises(self):
+        w = self._consumer()
+        w.transfer_topo.block_size_ratio.return_value = 2
+        with pytest.raises(AssertionError, match="block sizes"):
+            w._validate_remote_agent_handshake(
+                self._meta(pp_size=2, n_regions=28), remote_tp_size=1
+            )
+
+    def test_pp_num_blocks_mismatch_raises(self):
+        w = self._consumer(dst_num_blocks=8)
+        with pytest.raises(AssertionError):
+            w._validate_remote_agent_handshake(
+                self._meta(pp_size=2, n_regions=28, num_blocks=16), remote_tp_size=1
+            )
+
+    def test_non_pp_delegates_to_base(self):
+        # pp_size == 1 must fall through to the upstream validation untouched.
+        w = self._consumer()
+        base = RblnNixlConnectorWorker.__bases__[0]
+        with patch.object(base, "_validate_remote_agent_handshake") as base_val:
+            w._validate_remote_agent_handshake(
+                self._meta(pp_size=1, n_regions=56), remote_tp_size=1
+            )
+        base_val.assert_called_once()
+
+
+class TestPpConstraints:
+    # Reject PP + unsupported features early.
+
+    @staticmethod
+    def _worker(*, pp_size, cross_layers=False, has_mamba=False, sw_ratio=None):
+        w = object.__new__(RblnNixlConnectorWorker)
+        w.vllm_config = MagicMock()
+        w.vllm_config.parallel_config.pipeline_parallel_size = pp_size
+        w.transfer_topo = MagicMock()
+        w.transfer_topo.cross_layers_blocks = cross_layers
+        w._has_mamba = has_mamba
+        w._sw_ratio = sw_ratio
+        return w
+
+    def test_no_pp_is_noop(self):
+        # pp_size == 1: even with otherwise-unsupported features, no raise.
+        self._worker(
+            pp_size=1, cross_layers=True, has_mamba=True, sw_ratio=2
+        )._check_pp_constraints()
+
+    def test_plain_pp_ok(self):
+        self._worker(pp_size=2)._check_pp_constraints()
+
+    def test_cross_layers_pp_raises(self):
+        with pytest.raises(RuntimeError, match="cross-layer-blocks"):
+            self._worker(pp_size=2, cross_layers=True)._check_pp_constraints()
+
+    def test_mamba_pp_raises(self):
+        with pytest.raises(RuntimeError, match="Mamba"):
+            self._worker(pp_size=2, has_mamba=True)._check_pp_constraints()
+
+    def test_swa_pp_raises(self):
+        with pytest.raises(RuntimeError, match="sliding-window"):
+            self._worker(pp_size=2, sw_ratio=2)._check_pp_constraints()
+
+
+class TestPublishPpHandshakeMetadata:
+    # The shared producer-side helper used by BOTH the D2D and the
+    # host-bounce paths, so PP metadata is advertised regardless of transport.
+
+    @staticmethod
+    def _base_meta():
+        return NixlAgentMetadata(
+            engine_id="eng",
+            agent_metadata=b"agent",
+            kv_caches_base_addr=[0x1000, 0x2000],
+            device_id=0,
+            num_blocks=4,
+            block_lens=[8192, 8192],
+            kv_cache_layout="HND",
+            block_size=16,
+            ssm_sizes=(0, 0),
+            attn_backend_name="RBLN",
+            physical_blocks_per_logical_kv_block=1,
+        )
+
+    def _publish(self, *, pp_rank, pp_size, layer_names):
+        w = object.__new__(RblnNixlConnectorWorker)
+        w.compat_hash = "BASE"
+        # _check_pp_constraints reads these; a plain PP producer passes.
+        w.vllm_config = MagicMock()
+        w.vllm_config.parallel_config.pipeline_parallel_size = pp_size
+        w.transfer_topo = MagicMock()
+        w.transfer_topo.cross_layers_blocks = False
+        w._has_mamba = False
+        w._sw_ratio = None
+        pp_group = MagicMock()
+        pp_group.rank_in_group = pp_rank
+        pp_group.world_size = pp_size
+        with patch.object(W, "get_pp_group", return_value=pp_group):
+            w._publish_pp_handshake_metadata(self._base_meta(), layer_names)
+        return w
+
+    def test_wraps_base_and_folds_compat(self):
+        w = self._publish(pp_rank=1, pp_size=2, layer_names=["l7", "l8"])
+        # compat hash folded with the RBLN PP version and mirrored into payload.
+        assert w.compat_hash == rbln_pp_compat_hash("BASE")
+        assert w.xfer_handshake_metadata.compatibility_hash == w.compat_hash
+        decoded = msgspec.msgpack.Decoder(RblnNixlAgentMetadata).decode(
+            w.xfer_handshake_metadata.agent_metadata_bytes
+        )
+        # base fields preserved ...
+        assert decoded.engine_id == "eng"
+        assert decoded.block_lens == [8192, 8192]
+        assert decoded.kv_caches_base_addr == [0x1000, 0x2000]
+        # ... and PP fields populated.
+        assert (decoded.pp_rank, decoded.pp_size) == (1, 2)
+        assert decoded.registered_layer_names == ["l7", "l8"]
+
+    def test_single_stage_defaults(self):
+        # pp_size == 1 still folds compat but advertises no-PP layer fields.
+        w = self._publish(pp_rank=0, pp_size=1, layer_names=["l0"])
+        decoded = msgspec.msgpack.Decoder(RblnNixlAgentMetadata).decode(
+            w.xfer_handshake_metadata.agent_metadata_bytes
+        )
+        assert (decoded.pp_rank, decoded.pp_size) == (0, 1)
+
+
+class TestSetXferHandshakeMetadataPpAware:
+    # Producer side: every (pp_rank, tp_rank) shard must reach the side channel.
+    #
+    # EngineCore hands the merged worker dicts to
+    # ``set_xfer_handshake_metadata_pp_aware``. The base implementation rejects
+    # pp_rank > 0 and keys by tp_rank alone; this connector flattens the pair into
+    # the rank a consumer asks for in ``_nixl_handshake``.
+    #
+
+    @staticmethod
+    def _connector(tp_size):
+        c = object.__new__(RblnNixlConnector)
+        vllm_config = MagicMock()
+        vllm_config.parallel_config.tensor_parallel_size = tp_size
+        c._vllm_config = vllm_config
+        return c
+
+    def _flatten(self, metadata, *, tp_size):
+        c = self._connector(tp_size)
+        with patch.object(RblnNixlConnector, "set_xfer_handshake_metadata") as forward:
+            c.set_xfer_handshake_metadata_pp_aware(metadata)
+        forward.assert_called_once()
+        return forward.call_args[0][0]
+
+    def test_single_stage_reduces_to_tp_rank(self):
+        # pp_size == 1: flat rank == tp_rank, i.e. the base behavior.
+        assert self._flatten({(0, 0): "m0", (0, 1): "m1"}, tp_size=2) == {
+            0: "m0",
+            1: "m1",
+        }
+
+    def test_pp_stages_get_distinct_flat_ranks(self):
+        assert self._flatten({(0, 0): "s0", (1, 0): "s1"}, tp_size=1) == {
+            0: "s0",
+            1: "s1",
+        }
+        assert self._flatten(
+            {(0, 0): "a", (0, 1): "b", (1, 0): "c", (1, 1): "d"}, tp_size=2
+        ) == {0: "a", 1: "b", 2: "c", 3: "d"}
+
+    def test_pp_rank_gt_zero_is_accepted(self):
+        # The base would raise here; a PP-aware connector must not.
+        assert self._flatten({(3, 0): "s3"}, tp_size=1) == {3: "s3"}
+
+    def test_collision_is_rejected(self):
+        # A tp_size disagreeing with the reported ranks would silently drop a
+        # shard; fail loudly instead.
+        with pytest.raises(ValueError, match="Duplicate handshake metadata"):
+            self._flatten({(0, 1): "a", (1, 0): "b"}, tp_size=1)
+
+
+class TestEngineLivenessAndCleanup:
+    # TTL eviction (base, engine_ttl=3600s by default) tears a remote engine's
+    # state down once its timestamp goes stale, so the PP read path must refresh
+    # it and cleanup must cover the per-stage state this worker adds.
+
+    def test_read_marks_remote_active(self):
+        w = TestShardReadPath._read_worker(pp_size=2)
+        w._read_blocks_for_req("r0", TestShardReadPath()._meta([[1, 2]], [[3, 4]]))
+        assert "eng" in w._engine_last_active
+
+    def test_prefix_hit_read_marks_remote_active(self):
+        # A full prefix hit sends notifs only -- still activity.
+        w = TestShardReadPath._read_worker(pp_size=2)
+        w._read_blocks_for_req("r0", TestShardReadPath()._meta([], [[3, 4]]))
+        assert "eng" in w._engine_last_active
+
+    def test_cleanup_purges_per_stage_state_and_releases_handles(self):
+        w = object.__new__(RblnNixlConnectorWorker)
+        w.nixl_wrapper = MagicMock()
+        w.src_xfer_handles_by_remote = {
+            ("eng", 0, 16): 100,
+            ("eng", 1, 16): 101,
+            ("other", 0, 16): 300,
+        }
+        w._shard_region_group_ids = {
+            ("eng", 0): (0,),
+            ("eng", 1): (0,),
+            ("other", 0): (0,),
+        }
+        w._remote_shard_layer_names = defaultdict(dict, {"eng": {0: ("l0",)}})
+        w._overlapping_ranks = defaultdict(list, {"eng": [0, 1], "other": [0]})
+        w._remote_pp_size = {"eng": 2, "other": 1}
+
+        with patch.object(W.NixlPullConnectorWorker, "_cleanup_remote_engine") as base:
+            w._cleanup_remote_engine("eng")
+        base.assert_called_once_with("eng", log_eviction=True)
+
+        # This engine's stages are gone -- a re-handshake must not double-read.
+        assert "eng" not in w._overlapping_ranks
+        assert "eng" not in w._remote_pp_size
+        assert "eng" not in w._remote_shard_layer_names
+        assert [k for k in w.src_xfer_handles_by_remote if k[0] == "eng"] == []
+        assert [k for k in w._shard_region_group_ids if k[0] == "eng"] == []
+        # Local dlist handles are ours to release; one per stage.
+        assert sorted(
+            c.args[0] for c in w.nixl_wrapper.release_dlist_handle.call_args_list
+        ) == [100, 101]
+        # Other engines untouched.
+        assert w._overlapping_ranks["other"] == [0]
+        assert ("other", 0, 16) in w.src_xfer_handles_by_remote

--- a/tests/native/distributed/kv_connector/test_rbln_nixl_handshake_pp.py
+++ b/tests/native/distributed/kv_connector/test_rbln_nixl_handshake_pp.py
@@ -137,8 +137,8 @@ def _make_worker(*, tp_target_ranks=(0,), sw_ratio=None, compat="HASH"):
     # overlaps (the fan-out default). _FakeSock advertises stage i as "layer.i".
     w.local_seen_layer_names = ["layer.0", "layer.1", "layer.2"]
     w.add_remote_agent = MagicMock(side_effect=lambda meta, rank, tps: f"agent-{rank}")
-    # Per-shard local handle building is exercised in TestShardLocalRegions;
-    # stub it here so the fan-out tests stay focused on stage enumeration.
+    # Stubbed so the fan-out tests stay on stage enumeration; the body runs for
+    # real in TestShardLocalRegions::test_register_shard_read_state_keys_the_stage.
     w._register_shard_read_state = MagicMock()
     return w
 
@@ -358,8 +358,11 @@ class TestShardLocalRegions:
         w = self._worker(["l0", "l1", "l2", "l3"], num_regions=4)
         assert w._shard_local_region_ids(("l1", "l2")) == [1, 2]
 
-    def test_register_shard_local_xfer_handler_covers_subset(self):
-        w = self._worker(["l0", "l1", "l2", "l3"], num_regions=8)  # rpl=2
+    @classmethod
+    def _wired_worker(cls):
+        # Enough of the worker for the handle building to run for real: 4 layers
+        # over 8 regions (rpl=2), base addrs 1000 apart, prep_xfer_dlist -> 42.
+        w = cls._worker(["l0", "l1", "l2", "l3"], num_regions=8)
         w.block_size = 16
         w.num_blocks = 4
         w.device_id = 0
@@ -374,6 +377,10 @@ class TestShardLocalRegions:
         w.get_backend_aware_kv_block_len = MagicMock(return_value=64)
         w.nixl_wrapper = MagicMock()
         w.nixl_wrapper.prep_xfer_dlist.return_value = 42
+        return w
+
+    def test_register_shard_local_xfer_handler_covers_subset(self):
+        w = self._wired_worker()
 
         handle, blocks = w._register_shard_local_xfer_handler(16, ("l2", "l3"))
 
@@ -386,6 +393,49 @@ class TestShardLocalRegions:
         assert blocks[1] == (4000 + 64, 64, 0)
         # regions used are exactly the shard's (no addr below 4000).
         assert min(a for a, _, _ in blocks) == 4000
+
+    def test_register_local_xfer_handler_routes_to_the_shard_path(self):
+        # The dispatch that puts a PP stage on the shard path: no SWA view opt,
+        # layer names present. Miss it and a stage registers the whole model's
+        # regions, so the descriptor math addresses layers it does not own. The
+        # no-names branch is upstream's and is covered by the non-PP tests.
+        w = self._wired_worker()
+        w._sw_ratio = None
+
+        with patch.object(
+            RblnNixlConnectorWorker, "_register_shard_local_xfer_handler"
+        ) as shard:
+            w.register_local_xfer_handler(16, registered_layer_names=("l2", "l3"))
+
+        shard.assert_called_once_with(16, ("l2", "l3"))
+
+    def test_register_shard_read_state_keys_the_stage(self):
+        # The read and cleanup paths look these two maps up by exactly these
+        # keys, and the fan-out tests reach this function as a stub -- so the
+        # real key shape is pinned here or nowhere: a swapped key order or a
+        # group-id tuple of the wrong length would leave both sides agreeing
+        # with their own fixtures.
+        w = self._wired_worker()
+        w.kv_cache_config = MagicMock(kv_cache_groups=[object()])
+        w.src_xfer_handles_by_remote = {}
+        w._shard_region_group_ids = {}
+
+        w._register_shard_read_state("eng", 2, 16, ("l2", "l3"))
+
+        assert w.src_xfer_handles_by_remote == {("eng", 2, 16): 42}
+        # One group id per region of the shard: layers l2,l3 x rpl 2 = 4.
+        assert w._shard_region_group_ids == {("eng", 2): (0, 0, 0, 0)}
+
+    def test_register_shard_read_state_rejects_multiple_groups(self):
+        # The single-group assumption is what makes the all-zero tuple above
+        # right; more than one group has to fail rather than mislabel regions.
+        w = self._wired_worker()
+        w.kv_cache_config = MagicMock(kv_cache_groups=[object(), object()])
+        w.src_xfer_handles_by_remote = {}
+        w._shard_region_group_ids = {}
+
+        with pytest.raises(AssertionError, match="single KV-cache group"):
+            w._register_shard_read_state("eng", 2, 16, ("l2", "l3"))
 
 
 class TestShardReadPath:
@@ -483,6 +533,25 @@ class TestShardReadPath:
             # 2 regions per shard x 1 (trimmed) block = 2 descriptors.
             assert len(remote_descs) == 2
         assert len(w._recving_transfers["r0"]) == 2
+
+    def test_single_stage_read_delegates_to_base(self):
+        # A producer that advertised pp_size 1 must read through the upstream
+        # path untouched -- the per-stage loop below would key handles the
+        # non-PP registration never wrote. Liveness is still stamped first,
+        # since TTL eviction must not consider this producer idle.
+        w = object.__new__(RblnNixlConnectorWorker)
+        w._engine_last_active = {}
+        w._remote_pp_size = {}  # unknown engine defaults to a single stage
+        w.transfer_topo = MagicMock()
+        meta = MagicMock()
+        meta.remote.engine_id = "eng"
+        base = RblnNixlConnectorWorker.__bases__[0]
+
+        with patch.object(base, "_read_blocks_for_req") as base_read:
+            w._read_blocks_for_req("r0", meta)
+
+        base_read.assert_called_once_with("r0", meta)
+        assert "eng" in w._engine_last_active
 
     def test_reads_only_overlapping_stages(self):
         # Decode-PP (m=4, n=2): this rank owns 2 of the 4 producer stages, so
@@ -685,6 +754,31 @@ class TestPublishPpHandshakeMetadata:
         # ... and PP fields populated.
         assert (decoded.pp_rank, decoded.pp_size) == (1, 2)
         assert decoded.registered_layer_names == ["l7", "l8"]
+
+    def test_register_kv_caches_wires_the_publish(self):
+        # The helper above is only useful if the registration path reaches it.
+        # Host-bounce is the path that does so directly (D2D defers to
+        # finalize_kv_cache_registration), and the ordered layer names it
+        # captures are what the consumer matches regions by.
+        w = object.__new__(RblnNixlConnectorWorker)
+        w.kv_buffer_device = "cpu"
+        w._use_rbln_nixl_backend = False
+        w.xfer_handshake_metadata = MagicMock(
+            agent_metadata_bytes=msgspec.msgpack.encode(self._base_meta())
+        )
+        w._publish_pp_handshake_metadata = MagicMock()
+        base = RblnNixlConnectorWorker.__bases__[0]
+        kv_caches = {"l0": MagicMock(), "l1": MagicMock()}
+
+        with patch.object(base, "register_kv_caches"):
+            w.register_kv_caches(kv_caches)
+
+        assert w.local_seen_layer_names == ["l0", "l1"]
+        w._publish_pp_handshake_metadata.assert_called_once()
+        published_meta, published_names = w._publish_pp_handshake_metadata.call_args[0]
+        # The base metadata is handed over decoded, not as bytes.
+        assert published_meta.engine_id == "eng"
+        assert list(published_names) == ["l0", "l1"]
 
     def test_single_stage_defaults(self):
         # pp_size == 1 still folds compat but advertises no-PP layer fields.

--- a/tests/native/distributed/kv_connector/test_rbln_nixl_metadata.py
+++ b/tests/native/distributed/kv_connector/test_rbln_nixl_metadata.py
@@ -1,0 +1,111 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Unit coverage for the RBLN NIXL PP metadata extension.
+#
+# Self-contained: exercises only ``rbln_nixl.metadata`` (base vLLM NIXL +
+# msgspec + hash), so it does not require the ``nixl-rbln`` install or a worker.
+
+import msgspec
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl import NixlAgentMetadata
+
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.metadata import (
+    RBLN_NIXL_PP_VERSION,
+    RblnNixlAgentMetadata,
+    rbln_pp_compat_hash,
+)
+
+_BASE_FIELDS = dict(
+    engine_id="engine-0",
+    agent_metadata=b"agent-bytes",
+    kv_caches_base_addr=[0x1000, 0x2000],
+    device_id=0,
+    num_blocks=64,
+    block_lens=[8192, 8192],
+    kv_cache_layout="HND",
+    block_size=16,
+    ssm_sizes=(0, 0),
+    attn_backend_name="RBLN_FLASH_ATTN",
+    physical_blocks_per_logical_kv_block=1,
+)
+
+
+def _make(**pp):
+    return RblnNixlAgentMetadata(**_BASE_FIELDS, **pp)
+
+
+class TestRblnNixlAgentMetadata:
+    def test_defaults_are_single_stage(self):
+        # Omitting PP fields yields the pp_size==1 (no-PP) values.
+        m = _make()
+        assert (m.pp_rank, m.pp_size) == (0, 1)
+        assert m.registered_layer_names == []
+
+    def test_roundtrip_preserves_pp_fields(self):
+        # msgspec encode→decode with the RBLN type preserves PP descriptors.
+        m = _make(
+            pp_rank=1,
+            pp_size=2,
+            registered_layer_names=["model.layers.14", "model.layers.15"],
+        )
+        enc = msgspec.msgpack.Encoder().encode(m)
+        back = msgspec.msgpack.Decoder(RblnNixlAgentMetadata).decode(enc)
+        assert back == m
+        assert back.pp_rank == 1
+        assert back.pp_size == 2
+        assert back.registered_layer_names == [
+            "model.layers.14",
+            "model.layers.15",
+        ]
+
+    def test_base_consumer_ignores_pp_fields(self):
+        # A blob encoded with the RBLN type decodes cleanly as the base
+        # ``NixlAgentMetadata`` (PP fields ignored) — backward compatible.
+        enc = msgspec.msgpack.Encoder().encode(_make(pp_rank=1, pp_size=2))
+        base = msgspec.msgpack.Decoder(NixlAgentMetadata).decode(enc)
+        assert base.engine_id == "engine-0"
+        assert base.num_blocks == 64
+        assert base.block_lens == [8192, 8192]
+        assert not hasattr(base, "pp_rank")
+
+    def test_registered_layer_names_order_preserved(self):
+        names = [f"model.layers.{i}" for i in range(14, 28)]
+        m = _make(pp_rank=1, pp_size=2, registered_layer_names=names)
+        back = msgspec.msgpack.Decoder(RblnNixlAgentMetadata).decode(
+            msgspec.msgpack.Encoder().encode(m)
+        )
+        assert back.registered_layer_names == names
+
+
+class TestRblnPpCompatHash:
+    def test_deterministic(self):
+        assert rbln_pp_compat_hash("BASE") == rbln_pp_compat_hash("BASE")
+
+    def test_differs_from_base(self):
+        # Folding the PP version must change the hash, so a PP-aware producer
+        # and a PP-unaware peer (base hash) do not match.
+        assert rbln_pp_compat_hash("BASE") != "BASE"
+
+    def test_distinguishes_base_hashes(self):
+        assert rbln_pp_compat_hash("hash-a") != rbln_pp_compat_hash("hash-b")
+
+    def test_version_is_folded(self, monkeypatch):
+        # Bumping RBLN_NIXL_PP_VERSION changes the hash (gates schema drift).
+        from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl import (
+            metadata as md,
+        )
+
+        h1 = md.rbln_pp_compat_hash("BASE")
+        monkeypatch.setattr(md, "RBLN_NIXL_PP_VERSION", RBLN_NIXL_PP_VERSION + 1)
+        assert md.rbln_pp_compat_hash("BASE") != h1

--- a/tests/native/distributed/kv_connector/test_rbln_nixl_scheduler.py
+++ b/tests/native/distributed/kv_connector/test_rbln_nixl_scheduler.py
@@ -109,7 +109,7 @@ class TestInit:
     ):
         # host-bounce ("cpu") stages through host DRAM; D2D ("rbln") does not.
         monkeypatch.setattr(
-            sm.NixlConnectorScheduler, "__init__", lambda self, *a, **k: None
+            sm.NixlPullConnectorScheduler, "__init__", lambda self, *a, **k: None
         )
         vllm_config = SimpleNamespace(
             kv_transfer_config=SimpleNamespace(kv_buffer_device=kv_buffer_device)

--- a/tests/native/distributed/kv_connector/test_rbln_nixl_scheduler.py
+++ b/tests/native/distributed/kv_connector/test_rbln_nixl_scheduler.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# RblnNixlConnectorScheduler: chunked-prefill save tracking in
-# build_connector_meta and the finished-request branches in request_finished.
-# Built bare with only the state its methods read.
+# RblnNixlConnectorScheduler: chunked-prefill save tracking and the
+# finished-request branches, exercised through the inherited entry points.
+# Built bare with only the state those paths read.
 
 from dataclasses import dataclass, field
 from types import SimpleNamespace
@@ -77,7 +77,7 @@ def _sched_output(req_id, block_ids, num_scheduled_tokens, *, is_new=True):
     )
 
 
-def _scheduler():
+def _scheduler(*, use_host_buffer=False):
     sched = object.__new__(RblnNixlConnectorScheduler)
     sched.vllm_config = MagicMock()
     sched.vllm_config.parallel_config.tensor_parallel_size = 1
@@ -86,7 +86,8 @@ def _scheduler():
     sched.kv_cache_config = MagicMock()
     sched.side_channel_host = "localhost"
     sched.side_channel_port = 5000
-    sched.use_host_buffer = False
+    # The save path is gated on this, so save tests must turn it on.
+    sched.use_host_buffer = use_host_buffer
     sched._is_hma_required = False  # get_sw_clipped_blocks (inherited) reads this
     sched.blocks_per_sw = [0]
     sched._kv_lease_duration = 30
@@ -96,6 +97,13 @@ def _scheduler():
     sched._reqs_in_batch = set()
     sched._reqs_not_processed = set()
     sched._block_ids_need_save = {}
+    # Base state the inherited entry points read.
+    sched._heartbeat_by_engine = {}
+    sched._heartbeat_req_engine = {}
+    sched._last_heartbeat_time = 0.0
+    sched._heartbeat_interval = 5
+    sched.is_bidirectional_kv_xfer_enabled = False
+    sched.decoder_kv_blocks_ttl = 480
     return sched
 
 
@@ -124,7 +132,7 @@ class TestBuildConnectorMeta:
     def test_single_step_prefill_saves_immediately(self):
         # A prefill that finishes in one step is added to the save metadata and
         # dropped from both tracking dicts.
-        sched = _scheduler()
+        sched = _scheduler(use_host_buffer=True)
         req = _Request("prefill", num_prompt_tokens=256)
         sched._reqs_need_save["prefill"] = req
 
@@ -138,7 +146,7 @@ class TestBuildConnectorMeta:
     def test_chunked_prefill_defers_save_to_final_chunk(self):
         # Partial chunks accumulate blocks in _block_ids_need_save and are NOT
         # saved; only the final chunk (prompt fully computed) saves and clears.
-        sched = _scheduler()
+        sched = _scheduler(use_host_buffer=True)
         req = _Request("chunked", num_prompt_tokens=512)
         sched._reqs_need_save["chunked"] = req
 
@@ -205,12 +213,12 @@ class TestRequestFinished:
         req.kv_transfer_params = {"foo": 1}
         assert sched.request_finished(req, ([1],)) == (False, None)
 
-    def test_non_length_capped_cleans_up_tracking(self):
-        # A remote-decode producer that did not finish LENGTH_CAPPED (e.g. an
-        # aborted partial prefill) stops being tracked and frees now.
+    def test_aborted_producer_cleans_up_tracking(self):
+        # A remote-decode producer that ended without completing its prefill
+        # stops being tracked and frees now -- there is no KV worth sending.
         sched = _scheduler()
         req = _Request("aborted", num_prompt_tokens=512)
-        req.status = RequestStatus.FINISHED_STOPPED
+        req.status = RequestStatus.FINISHED_ABORTED
         sched._reqs_need_save["aborted"] = req
         sched._block_ids_need_save["aborted"] = ([1, 2],)
 
@@ -219,6 +227,32 @@ class TestRequestFinished:
         assert "aborted" not in sched._reqs_need_save
         assert "aborted" not in sched._block_ids_need_save
         assert "aborted" in sched._reqs_not_processed
+
+    def test_stopped_prefill_is_transferred_like_length_capped(self):
+        # A producer whose single generated token happens to be a stop token
+        # finishes STOPPED rather than LENGTH_CAPPED. Its KV is just as valid,
+        # so it must still be handed to the decode side.
+        sched = _scheduler()
+        req = _Request("stopped", num_prompt_tokens=256)
+        req.status = RequestStatus.FINISHED_STOPPED
+
+        delay, params = sched.request_finished(req, ([1, 2, 3, 4],))
+        assert delay is True
+        assert params is not None
+        assert params["do_remote_prefill"] is True
+        assert "stopped" in sched._reqs_need_send
+        assert "stopped" not in sched._reqs_not_processed
+
+    def test_partial_save_state_is_dropped_when_the_request_ends(self):
+        # _block_ids_need_save only holds blocks for a prefill still being
+        # chunked; whatever survives to request_finished is stale.
+        sched = _scheduler()
+        req = _Request("leftover", num_prompt_tokens=256)
+        req.status = RequestStatus.FINISHED_LENGTH_CAPPED
+        sched._block_ids_need_save["leftover"] = ([9],)
+
+        sched.request_finished(req, ([1],))
+        assert "leftover" not in sched._block_ids_need_save
 
     def test_completed_prefill_delays_free_and_returns_remote_params(self):
         # A LENGTH_CAPPED remote-decode producer with real blocks delays the free

--- a/tests/native/distributed/kv_connector/test_rbln_nixl_worker.py
+++ b/tests/native/distributed/kv_connector/test_rbln_nixl_worker.py
@@ -65,11 +65,17 @@ def _build_worker(
         self.kv_cache_config = kv_cache_config
         self.kv_buffer_device = kv_buffer_device
         self._block_size = {}
+        # The real NixlPullConnectorWorker.__init__ sets this to None;
+        # register_kv_caches reads it after super().register_kv_caches().
+        self.xfer_handshake_metadata = None
 
     monkeypatch.setattr(NixlConnectorWorker, "__init__", fake_super_init)
 
     vllm_config = MagicMock()
     vllm_config.cache_config = CacheConfig(block_size=block_size)
+    # _check_pp_constraints compares pipeline_parallel_size <= 1; give it a real
+    # int (a MagicMock would raise TypeError). 1 == the non-PP default here.
+    vllm_config.parallel_config.pipeline_parallel_size = 1
     kv_cache_config = MagicMock()
     kv_cache_config.num_blocks = num_blocks
     kv_cache_config.kv_cache_groups = [

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/connector.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/connector.py
@@ -20,10 +20,11 @@ from vllm.distributed.kv_transfer.kv_connector.utils import (
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
+    KVConnectorHandshakeMetadata,
     KVConnectorRole,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
-    NixlConnector,
+    NixlPullConnector,
 )
 
 import vllm_rbln.envs as envs
@@ -44,7 +45,7 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
-class RblnNixlConnector(NixlConnector, SupportsKVCacheRegistrationFinalize):
+class RblnNixlConnector(NixlPullConnector, SupportsKVCacheRegistrationFinalize):
     """RBLN's NIXL KV connector. A single `RblnNixlConnectorWorker` runs
     both paths and branches internally on
     `kv_transfer_config.kv_buffer_device`:
@@ -89,6 +90,34 @@ class RblnNixlConnector(NixlConnector, SupportsKVCacheRegistrationFinalize):
             self.connector_worker = RblnNixlConnectorWorker(
                 vllm_config, self.engine_id, kv_cache_config
             )
+
+    def set_xfer_handshake_metadata_pp_aware(
+        self, metadata: dict[tuple[int, int], KVConnectorHandshakeMetadata]
+    ) -> None:
+        """Serve every producer shard, including pipeline-parallel stages.
+
+        The base implementation rejects `pp_rank > 0` and drops the pipeline
+        rank, keying the side channel by `tp_rank` alone; PP stages would then
+        overwrite each other. This connector's side channel identifies a shard
+        by the flat rank `pp_rank * tp_size + tp_rank` -- what a consumer asks
+        for in `RblnNixlConnectorWorker._nixl_handshake` -- so flatten the pair
+        here. `tp_size` is this (producer) engine's, matching the workers that
+        produced these entries. Reduces to `tp_rank` at `pp_size == 1`, i.e. the
+        base behavior.
+        """
+        tp_size = self._vllm_config.parallel_config.tensor_parallel_size
+        flattened: dict[int, KVConnectorHandshakeMetadata] = {}
+        for (pp_rank, tp_rank), rank_metadata in metadata.items():
+            flat_rank = pp_rank * tp_size + tp_rank
+            if flat_rank in flattened:
+                raise ValueError(
+                    "Duplicate handshake metadata for flat rank "
+                    f"{flat_rank} (pp_rank={pp_rank}, tp_rank={tp_rank}); "
+                    f"tensor_parallel_size={tp_size} disagrees with the ranks "
+                    "reported by the workers."
+                )
+            flattened[flat_rank] = rank_metadata
+        self.set_xfer_handshake_metadata(flattened)
 
     def finalize_kv_cache_registration(self) -> None:
         """Run the worker's deferred NIXL registration after warm-up

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/metadata.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/metadata.py
@@ -1,0 +1,62 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RBLN-specific NIXL metadata: pipeline-parallel (PP) extensions.
+
+Isolated from upstream ``NixlAgentMetadata`` so the base struct and its
+compatibility hash stay untouched. Both P and D are RBLN, so a private version
+tag folded into the compat hash (``rbln_pp_compat_hash``) is enough to gate
+PP-aware peers against mismatched ones. Under PP the producer advertises, per
+(pp_rank, tp_rank) shard, the KV-cache layer names it owns; the consumer matches
+each shard to its local regions by name (owned range derived locally, not sent).
+"""
+
+from dataclasses import dataclass, field
+
+from vllm.config.utils import hash_factors
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl import NixlAgentMetadata
+
+# Bump on any incompatible change to the RBLN PP metadata schema/semantics.
+# Folded into the NIXL compatibility hash so a PP-aware producer and a
+# mismatched consumer fail the handshake cleanly (both ends are RBLN).
+RBLN_NIXL_PP_VERSION: int = 1
+
+
+@dataclass
+class RblnNixlAgentMetadata(NixlAgentMetadata):
+    """``NixlAgentMetadata`` + this producer stage's PP identity and the layer
+    names it owns.
+
+    New fields default to the ``pp_size == 1`` (no-PP) values so a blob decoded
+    by the base/older consumer (which uses ``NixlAgentMetadata`` and ignores the
+    extra fields) degrades to single-stage behavior. A PP-aware consumer decodes
+    with this type to read them and matches ``registered_layer_names`` against
+    its own local layers to place each shard's regions.
+    """
+
+    pp_rank: int = 0
+    pp_size: int = 1
+    # Registered KV-cache layer names, ordered as kv_caches_base_addr / block_lens.
+    registered_layer_names: list[str] = field(default_factory=list)
+
+
+def rbln_pp_compat_hash(base_hash: str) -> str:
+    """Fold the RBLN PP schema version into the upstream NIXL compat hash.
+
+    Keeps PP-aware RBLN peers from handshaking with PP-unaware / mismatched
+    ones without touching upstream ``compute_nixl_compatibility_hash``.
+    """
+    return hash_factors(
+        {"base": base_hash, "rbln_nixl_pp_version": RBLN_NIXL_PP_VERSION}
+    )

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/scheduler.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/scheduler.py
@@ -25,7 +25,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
     NixlConnectorMetadata,
-    NixlConnectorScheduler,
+    NixlPullConnectorScheduler,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     ReqId,
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
-class RblnNixlConnectorScheduler(NixlConnectorScheduler):
+class RblnNixlConnectorScheduler(NixlPullConnectorScheduler):
     """Implementation of Scheduler side methods"""
 
     def __init__(

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/scheduler.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/scheduler.py
@@ -12,16 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
 from typing import TYPE_CHECKING, Any
 
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.utils import (
     BlockIds,
     yield_req_data,
-)
-from vllm.distributed.kv_transfer.kv_connector.v1.base import (
-    KVConnectorMetadata,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
     NixlConnectorMetadata,
@@ -49,168 +45,85 @@ class RblnNixlConnectorScheduler(NixlPullConnectorScheduler):
     ) -> None:
         super().__init__(vllm_config, engine_id, kv_cache_config)
 
+        # NOTE(RBLN): the platform reports device_type "cpu" when device tensors
+        # are off, which the base reads as "no host staging" -- the very setup
+        # that needs it. Decide from the requested buffer device instead.
         self.use_host_buffer = vllm_config.kv_transfer_config.kv_buffer_device == "cpu"
 
+        # Blocks collected so far for a prefill that is still being chunked.
         self._block_ids_need_save: dict[ReqId, BlockIds] = {}
 
-    def build_connector_meta(
+    def _build_save_meta(
         self,
+        meta: NixlConnectorMetadata,
         scheduler_output: SchedulerOutput,
-    ) -> KVConnectorMetadata:
-        meta = NixlConnectorMetadata()
+    ) -> None:
+        """Stage a prefill's blocks in one save, once every chunk has landed.
 
-        for req_id, (req, block_ids) in self._reqs_need_recv.items():
+        NOTE(RBLN): the base saves each step's new blocks as they arrive. The
+        RBLN host copy moves whole blocks and transfers once, so blocks are
+        accumulated here and handed over when the prefill completes.
+        """
+        for req_id, new_block_id_groups, resumed in yield_req_data(scheduler_output):
+            req = self._reqs_need_save.get(req_id)
+            if req is None:
+                continue
+
             assert req.kv_transfer_params is not None
-            meta.add_new_req_to_recv(
-                request_id=req_id,
-                local_block_ids=block_ids,
-                kv_transfer_params=req.kv_transfer_params,
+            assert scheduler_output.num_scheduled_tokens is not None
+            num_scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
+
+            has_block_ids_to_save = req_id in self._block_ids_need_save
+            has_new_block_ids = new_block_id_groups is not None
+            # Blocks follow the chunks, so the closing one often adds none.
+            # Neither side holding any would stage a prefill without its KV.
+            assert has_block_ids_to_save or has_new_block_ids, (
+                "RBLN host-bounce save path reached with no blocks: "
+                f"req_id={req_id} resumed={resumed} "
+                f"num_computed={req.num_computed_tokens} "
+                f"num_prompt={req.num_prompt_tokens} "
+                f"num_scheduled={num_scheduled_tokens}"
             )
 
-        if self._reqs_need_save:
-            # NOTE: For the prefill side, there might be a chance that an early added
-            # request is a chunked prefill, so we need to check if new blocks are added
-            for req_id, new_block_id_groups, resumed in yield_req_data(
-                scheduler_output
-            ):
-                req_to_save = self._reqs_need_save.get(req_id)
-                if req_to_save is None:
-                    continue
+            if has_new_block_ids:
+                if resumed or not has_block_ids_to_save:
+                    # A resumed request re-sends its full block list, not a
+                    # delta, so appending would double-count.
+                    self._block_ids_need_save[req_id] = tuple(
+                        list(group) for group in new_block_id_groups
+                    )
+                else:
+                    for stored_group, new_group in zip(
+                        self._block_ids_need_save[req_id], new_block_id_groups
+                    ):
+                        stored_group.extend(new_group)
 
-                req = req_to_save
+            is_partial = (
+                req.num_computed_tokens + num_scheduled_tokens
+            ) < req.num_prompt_tokens
 
-                assert req.kv_transfer_params is not None
-                assert scheduler_output.num_scheduled_tokens is not None
-                num_scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
-
-                has_block_ids_to_save = req_id in self._block_ids_need_save
-                has_new_block_ids = new_block_id_groups is not None
-                # Blocks follow the chunks, so the closing one often adds none.
-                # Neither side holding any would stage a prefill without its KV.
-                assert has_block_ids_to_save or has_new_block_ids, (
-                    "RBLN host-bounce save path reached with no blocks: "
-                    f"req_id={req_id} resumed={resumed} "
-                    f"num_computed={req.num_computed_tokens} "
-                    f"num_prompt={req.num_prompt_tokens} "
-                    f"num_scheduled={num_scheduled_tokens}"
+            if not is_partial:
+                clipped_block_id_groups = self.get_sw_clipped_blocks(
+                    self._block_ids_need_save.pop(req_id)
                 )
-
-                if has_new_block_ids:
-                    if resumed or not has_block_ids_to_save:
-                        # A resumed request re-sends its full block list, not a
-                        # delta, so appending would double-count.
-                        self._block_ids_need_save[req_id] = tuple(
-                            list(group) for group in new_block_id_groups
-                        )
-                    else:
-                        for stored_group, new_group in zip(
-                            self._block_ids_need_save[req_id], new_block_id_groups
-                        ):
-                            stored_group.extend(new_group)
-                is_partial = (
-                    req.num_computed_tokens + num_scheduled_tokens
-                ) < req.num_prompt_tokens
-
-                if not is_partial:
-                    clipped_block_id_groups = self.get_sw_clipped_blocks(
-                        self._block_ids_need_save.pop(req_id)
-                    )
-                    meta.add_new_req_to_save(
-                        request_id=req_id,
-                        local_block_ids=clipped_block_id_groups,
-                        kv_transfer_params=req.kv_transfer_params,
-                    )
-                    # For non-partial prefills, once new req_meta is scheduled, it
-                    # can be removed from _reqs_need_save.
-                    # For partial prefill case, we will retain the request in
-                    # _reqs_need_save until all blocks are scheduled with req_meta.
-                    # Therefore, only pop if `not is_partial`.
-                    self._reqs_need_save.pop(req_id)
-
-        meta.reqs_to_send = self._reqs_need_send  # type: ignore[var-annotated, has-type]
-        meta.reqs_in_batch = self._reqs_in_batch  # type: ignore[var-annotated, has-type]
-        meta.reqs_not_processed = self._reqs_not_processed  # type: ignore[var-annotated, has-type]
-
-        # Clear the list once workers start the transfers
-        self._reqs_need_recv.clear()
-        self._reqs_in_batch = set()  # type: ignore[var-annotated]
-        self._reqs_not_processed = set()  # type: ignore[var-annotated]
-        self._reqs_need_send = {}  # type: ignore[var-annotated]
-
-        return meta
+                meta.add_new_req_to_save(
+                    request_id=req_id,
+                    local_block_ids=clipped_block_id_groups,
+                    kv_transfer_params=req.kv_transfer_params,
+                )
+                # For non-partial prefills, once new req_meta is scheduled, it
+                # can be removed from _reqs_need_save.
+                # For partial prefill case, we will retain the request in
+                # _reqs_need_save until all blocks are scheduled with req_meta.
+                # Therefore, only pop if `not is_partial`.
+                self._reqs_need_save.pop(req_id)
 
     def request_finished(
         self,
         request: "Request",
         block_ids: BlockIds,
     ) -> tuple[bool, dict[str, Any] | None]:
-        """
-        Once a request is finished, determine whether request blocks
-        should be freed now or will be sent asynchronously and freed later.
-        """
-        from vllm.v1.request import RequestStatus
-
-        params = request.kv_transfer_params
-        logger.debug(
-            "NIXLConnector request_finished(%s), request_status=%s, "
-            "kv_transfer_params=%s",
-            request.request_id,
-            request.status,
-            params,
-        )
-        if not params:
-            return False, None
-
-        if params.get("do_remote_prefill"):
-            # If do_remote_prefill is still True when the request is finished,
-            # update_state_after_alloc must not have been called (the request
-            # must have been aborted before it was scheduled).
-            # To avoid stranding the prefill blocks in the prefill instance,
-            # we must add empty block_ids to _reqs_need_recv so that our
-            # worker side will notify and free blocks in the prefill instance.
-            self._reqs_need_recv[request.request_id] = (request, [])
-            params["do_remote_prefill"] = False
-            return False, None
-
-        if not params.get("do_remote_decode"):
-            return False, None
-        if request.status != RequestStatus.FINISHED_LENGTH_CAPPED:
-            # Also include the case of a P/D Prefill request with immediate
-            # block free (eg abort). Stop tracking this request.
-            self._reqs_not_processed.add(request.request_id)
-            # Clear _reqs_need_save if a request is aborted as partial prefill.
-            self._reqs_need_save.pop(request.request_id, None)
-            self._block_ids_need_save.pop(request.request_id, None)
-            return False, None
-
-        # TODO: check whether block_ids actually ever be 0. If not we could
-        # remove the conditional below
-        delay_free_blocks = any(len(group) > 0 for group in block_ids)
-
-        if delay_free_blocks:
-            # Prefill request on remote. It will be read from D upon completion
-            logger.debug(
-                "NIXLConnector request_finished(%s) waiting for %d seconds "
-                "for remote decode to fetch blocks",
-                request.request_id,
-                self._kv_lease_duration,
-            )
-            self._reqs_need_send[request.request_id] = (
-                time.perf_counter() + self._kv_lease_duration
-            )
-            # NOTE HMA will "mark" empty/null blocks in groups with 0s (eg SWA ones),
-            # trimming down after allocating for the whole sequence length. Empty
-            # blocks are always at the start of the list.
-            # Here we "unpad" blocks to send the actual remote blocks to be read.
-            block_ids = self.get_sw_clipped_blocks(block_ids)
-
-        return delay_free_blocks, dict(
-            do_remote_prefill=True,
-            do_remote_decode=False,
-            remote_block_ids=block_ids,
-            remote_engine_id=self.engine_id,
-            remote_request_id=request.request_id,
-            remote_host=self.side_channel_host,
-            remote_port=self.side_channel_port,
-            tp_size=self.vllm_config.parallel_config.tensor_parallel_size,
-        )
+        # NOTE(RBLN): an entry surviving here belongs to a prefill that ended
+        # before its closing chunk, so the blocks accumulated for it are stale.
+        self._block_ids_need_save.pop(request.request_id, None)
+        return super().request_finished(request, block_ids)

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/scheduler.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/scheduler.py
@@ -70,34 +70,50 @@ class RblnNixlConnectorScheduler(NixlPullConnectorScheduler):
         if self._reqs_need_save:
             # NOTE: For the prefill side, there might be a chance that an early added
             # request is a chunked prefill, so we need to check if new blocks are added
-            for req_id, new_block_id_groups, _ in yield_req_data(scheduler_output):
+            for req_id, new_block_id_groups, resumed in yield_req_data(
+                scheduler_output
+            ):
                 req_to_save = self._reqs_need_save.get(req_id)
                 if req_to_save is None:
                     continue
-
-                # NOTE(RBLN): RBLN allocates the whole prefill blocks at once
-                # and does not resume prefill requests in P/D disaggregation scenario.
-                # save_to_host path will be deprecated in the future.
-                has_block_ids_to_save = req_id in self._block_ids_need_save
-                has_new_block_ids = new_block_id_groups is not None
-                assert has_block_ids_to_save ^ has_new_block_ids
-
-                if has_new_block_ids:
-                    self._block_ids_need_save[req_id] = new_block_id_groups
 
                 req = req_to_save
 
                 assert req.kv_transfer_params is not None
                 assert scheduler_output.num_scheduled_tokens is not None
                 num_scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
+
+                has_block_ids_to_save = req_id in self._block_ids_need_save
+                has_new_block_ids = new_block_id_groups is not None
+                # Blocks follow the chunks, so the closing one often adds none.
+                # Neither side holding any would stage a prefill without its KV.
+                assert has_block_ids_to_save or has_new_block_ids, (
+                    "RBLN host-bounce save path reached with no blocks: "
+                    f"req_id={req_id} resumed={resumed} "
+                    f"num_computed={req.num_computed_tokens} "
+                    f"num_prompt={req.num_prompt_tokens} "
+                    f"num_scheduled={num_scheduled_tokens}"
+                )
+
+                if has_new_block_ids:
+                    if resumed or not has_block_ids_to_save:
+                        # A resumed request re-sends its full block list, not a
+                        # delta, so appending would double-count.
+                        self._block_ids_need_save[req_id] = tuple(
+                            list(group) for group in new_block_id_groups
+                        )
+                    else:
+                        for stored_group, new_group in zip(
+                            self._block_ids_need_save[req_id], new_block_id_groups
+                        ):
+                            stored_group.extend(new_group)
                 is_partial = (
                     req.num_computed_tokens + num_scheduled_tokens
                 ) < req.num_prompt_tokens
 
                 if not is_partial:
-                    new_block_id_groups = self._block_ids_need_save.pop(req_id)
                     clipped_block_id_groups = self.get_sw_clipped_blocks(
-                        new_block_id_groups
+                        self._block_ids_need_save.pop(req_id)
                     )
                     meta.add_new_req_to_save(
                         request_id=req_id,

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/worker.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/worker.py
@@ -1116,6 +1116,11 @@ class RblnNixlConnectorWorker(NixlPullConnectorWorker):
             " (full prefix hit, notif only)" if prefix_hit else "",
         )
 
+        # Publish once and fail as one request: a handle visible while a later
+        # stage is still being prepped settles the request early, and the stages
+        # landing after that are a second completion with its metadata gone.
+        # A failed stage means recompute, so in-flight handles are released.
+        handles: list[int] = []
         for global_rank in self._overlapping_ranks[engine_id]:
             if prefix_hit:
                 agent_name = self._remote_agents[engine_id][global_rank]
@@ -1162,7 +1167,7 @@ class RblnNixlConnectorWorker(NixlPullConnectorWorker):
                     notif_msg=notif_id,
                 )
                 self.nixl_wrapper.transfer(handle)
-                self._recving_transfers[req_id].append(handle)
+                handles.append(handle)
             except Exception as e:
                 self._log_failure(
                     failure_type="transfer_setup_failed",
@@ -1172,4 +1177,10 @@ class RblnNixlConnectorWorker(NixlPullConnectorWorker):
                     dst_engine_id=engine_id,
                     remote_pp_rank=global_rank,
                 )
+                for submitted in handles:
+                    self.nixl_wrapper.release_xfer_handle(submitted)
                 self._handle_failed_transfer(req_id, handle)
+                return
+
+        if handles:
+            self._recving_transfers[req_id].extend(handles)

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/worker.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/worker.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
+from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
 import msgspec
 import numpy as np
 import rebel
 import torch
+import zmq
 from rebel.kv_cache import aligned_tensor
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.utils import (
@@ -30,15 +33,20 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
     NixlAgentMetadata,
-    NixlConnectorWorker,
+    NixlPullConnectorWorker,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+    GET_META_MSG,
     NixlHandshakePayload,
     compute_nixl_compatibility_hash,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import (
     compute_tp_mapping,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.utils import zmq_ctx
+from vllm.distributed.parallel_state import get_pp_group
+from vllm.platforms import current_platform
+from vllm.utils.network_utils import make_zmq_path
 from vllm.v1.kv_cache_interface import (
     MambaSpec,
     SlidingWindowSpec,
@@ -46,15 +54,20 @@ from vllm.v1.kv_cache_interface import (
 )
 
 import vllm_rbln.envs as envs
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.metadata import (
+    RblnNixlAgentMetadata,
+    rbln_pp_compat_hash,
+)
 from vllm_rbln.logger import init_logger
 
 if TYPE_CHECKING:
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import ReqMeta
     from vllm.v1.kv_cache_interface import KVCacheConfig
 
 logger = init_logger(__name__)
 
 
-class RblnNixlConnectorWorker(NixlConnectorWorker):
+class RblnNixlConnectorWorker(NixlPullConnectorWorker):
     """RBLN's KV connector worker.
 
     The runner filters `kv_caches` to one Full-attention canonical layer
@@ -68,17 +81,17 @@ class RblnNixlConnectorWorker(NixlConnectorWorker):
     `num_blocks`. Non-disagg serving is unaffected.
     """
 
+    compat_hash: str | None
+    xfer_handshake_metadata: NixlHandshakePayload | None
+
     def __init__(
         self, vllm_config: VllmConfig, engine_id: str, kv_cache_config: "KVCacheConfig"
     ) -> None:
         super().__init__(vllm_config, engine_id, kv_cache_config)
 
-        # Pick the NIXL transport backend.
-        #   * nixl-rbln installed  → use RBLN backend on both paths
-        #     (host-bounce DRAM_SEG / D2D VRAM_SEG via ibv_reg{,_dmabuf}_mr).
-        #   * nixl-rbln absent     → upstream defaults stand (UCX backend,
-        #     DRAM only). D2D (`kv_buffer_device="rbln"`) requires the
-        #     RBLN backend and is rejected here.
+        # nixl-rbln present -> RBLN backend (host-bounce DRAM_SEG / D2D VRAM_SEG);
+        # absent -> upstream UCX/DRAM defaults, and D2D (kv_buffer_device="rbln")
+        # is rejected below since it needs the RBLN backend.
         try:
             import nixl_rbln  # noqa: F401
 
@@ -109,6 +122,27 @@ class RblnNixlConnectorWorker(NixlConnectorWorker):
 
         self._pending_kv_caches: dict[str, torch.Tensor] | None = None
 
+        # --- Pipeline-parallel (PP) P/D state (empty / inert for pp_size == 1) ---
+        # Per remote producer shard, the ordered KV-cache layer names it owns,
+        # keyed by engine_id -> global_rank (= pp_rank * tp_size + tp_rank,
+        # == pp_rank when tensor parallelism is off).
+        self._remote_shard_layer_names: defaultdict[str, dict[int, tuple[str, ...]]] = (
+            defaultdict(dict)
+        )
+        # engine_id -> producer pp_size (discovered at handshake).
+        self._remote_pp_size: dict[str, int] = {}
+        # engine_id -> the producer stages (flat global ranks) whose layers this
+        # rank owns; drives _read_blocks_for_req.
+        self._overlapping_ranks: defaultdict[str, list[int]] = defaultdict(list)
+        # Per producer shard, a local xfer dlist scoped to that shard's local
+        # region subset, keyed by (engine_id, global_rank, block_size); and the
+        # shard's per-region KV-group ids, keyed by (engine_id, global_rank).
+        self.src_xfer_handles_by_remote: dict[tuple[str, int, int], int] = {}
+        self._shard_region_group_ids: dict[tuple[str, int], tuple[int, ...]] = {}
+        # Ordered local KV-cache layer names (one per layer), captured at
+        # register_kv_caches.
+        self.local_seen_layer_names: list[str] = []
+
         # Pin to logical values. Upstream would otherwise multiply by the
         # attention backend's kernel ratio, which doesn't reflect per-spec
         # ratios in hybrid models.
@@ -117,16 +151,11 @@ class RblnNixlConnectorWorker(NixlConnectorWorker):
         self._physical_blocks_per_logical_kv_block = 1
         self._logical_num_blocks = self.num_blocks
 
-        # SWA-side desc layout: publish a second `sliding_window`-length
-        # descriptor range alongside the Full-length range at the same
-        # NIXL base addresses, so SWA groups transport only the actually-
-        # populated prefix over RDMA (the runtime always pins SWA's
-        # kernel slot 0 at the block's base offset). Storage stays Full-
-        # tiled, host h2d/d2h still moves the full block — only
-        # `register_local_xfer_handler` / `add_remote_agent` /
-        # `_compute_desc_ids` consult `_sw_ratio` / `_group_specs`.
-        # `_sw_ratio is None` collapses every override to upstream's
-        # Full-only desc layout.
+        # SWA view-opt: publish a second sliding_window-length desc range at the
+        # same NIXL base addrs as the Full range, so SWA groups transport only the
+        # populated prefix (kernel slot 0 is pinned at the block base). Storage and
+        # host copies stay Full; _sw_ratio is None collapses to upstream Full-only.
+        # See the "Hybrid Full + SWA desc layout" section below.
         self._group_specs: list[Any] = []
         self._sw_ratio: int | None = None
         if envs.VLLM_RBLN_NIXL_SWA_VIEW_OPT:
@@ -168,6 +197,10 @@ class RblnNixlConnectorWorker(NixlConnectorWorker):
         fall straight through to upstream's UCX-backed registration —
         the host xfer buffers are plain DRAM in either case.
         """
+        # Capture the ordered local layer names before any deferral so the PP
+        # metadata publish (and the consumer-side name->region matching) can
+        # use them; the D2D path re-uses these at finalize time.
+        self.local_seen_layer_names = list(kv_caches.keys())
         if self.kv_buffer_device == "rbln":
             self._pending_kv_caches = kv_caches
             logger.info(
@@ -181,6 +214,13 @@ class RblnNixlConnectorWorker(NixlConnectorWorker):
 
             nixl_rbln.ensure_rbln_backend(self.nixl_wrapper, device_id=0)
         super().register_kv_caches(kv_caches)
+        # Re-wrap the base-published handshake metadata with this stage's PP
+        # identity + owned layer names (no-op degrade for pp_size == 1).
+        if self.xfer_handshake_metadata is not None:
+            base_agent_metadata = msgspec.msgpack.Decoder(NixlAgentMetadata).decode(
+                self.xfer_handshake_metadata.agent_metadata_bytes
+            )
+            self._publish_pp_handshake_metadata(base_agent_metadata, kv_caches.keys())
 
     def finalize_kv_cache_registration(self) -> None:
         """Run the deferred D2D registration. No-op on host-bounce and
@@ -368,6 +408,10 @@ class RblnNixlConnectorWorker(NixlConnectorWorker):
 
         self.num_regions = len(xfer.base_addrs)
         if self.transfer_topo.is_kv_layout_blocks_first:
+            # Blocks-first layout doubles the region count (K/V split), like the
+            # base's virtually_split_kv_in_blocks. The base's key-only MLA halving
+            # is skipped here -- _region_is_mla stays empty while add_remote_agent
+            # rejects MLA (MLA support would populate it here).
             self.num_regions *= 2
         self.num_descs = self.num_regions * self.num_blocks
 
@@ -402,54 +446,43 @@ class RblnNixlConnectorWorker(NixlConnectorWorker):
                 self._physical_blocks_per_logical_kv_block
             ),
         )
-        assert self.compat_hash is not None
-        encoder = msgspec.msgpack.Encoder()
-        self.xfer_handshake_metadata = NixlHandshakePayload(
-            compatibility_hash=self.compat_hash,
-            agent_metadata_bytes=encoder.encode(agent_metadata),
+        # Publish the handshake metadata wrapped with this stage's PP identity
+        # and owned layer names (degrades to no-PP for pp_size == 1).
+        self._publish_pp_handshake_metadata(
+            agent_metadata, self.device_kv_caches.keys()
         )
 
     # ------------------------------------------------------------------
     # Hybrid Full + SWA desc layout (RDMA payload only)
     # ------------------------------------------------------------------
     #
-    # The runner registers one canonical Full-attention layer per HMA
-    # pool, so the underlying NIXL memory regions are Full-sized
-    # (block_size bytes per region per block). When
-    # `VLLM_RBLN_NIXL_SWA_VIEW_OPT=1` is set and at least one group is
-    # SWA, two desc ranges are published at the same base addresses:
+    # Regions are Full-sized (one canonical Full layer per HMA pool). With
+    # VLLM_RBLN_NIXL_SWA_VIEW_OPT and >=1 SWA group, two desc ranges share the
+    # same base addrs: [0, N) Full-length, [N, 2N) sliding_window-length. SWA
+    # groups read only the prefix (slot 0 pinned at block base), so RDMA moves
+    # less; host h2d/d2h still copies the full block. _compute_desc_ids routes
+    # each group to its range; _sw_ratio is None collapses to Full-only.
     #
-    #   [0, num_full_descs):
-    #       Full-size descriptors (length `block_size`).  Read by
-    #       Full-attention groups.
-    #
-    #   [num_full_descs, 2 * num_full_descs):
-    #       SWA-size descriptors at the same base addresses (length
-    #       `sliding_window`).  Read by SWA groups, which only need the
-    #       first `sliding_window` bytes — the runtime always pins
-    #       SWA's kernel slot 0 at the block's base offset, so the SWA
-    #       payload is a contiguous prefix of the Full block.
-    #
-    # `_compute_desc_ids` routes per-group block lists into the
-    # right range. When `_sw_ratio is None` (env off, or no SWA group,
-    # or degenerate ratio == 1) every method below collapses to
-    # upstream's single Full-range layout.
-    #
-    # Host-side h2d/d2h still copies the full block — only the over-
-    # the-wire RDMA payload is trimmed.  The garbage tail SWA receives
-    # back into the SWA-layer block is never read by the kernel
-    # (attention reads only `[0, sliding_window)`), and the canonical
-    # filter guarantees the storage's Full alias is never co-allocated
-    # to the same block id (scheduler keeps Full/SWA block-id pools
-    # disjoint).
+    # The garbage tail SWA writes back is never read (kernel reads [0, sw)), and
+    # Full/SWA block-id pools stay disjoint so the Full alias is never aliased.
 
     def register_local_xfer_handler(
         self,
         block_size: int,
+        *,
+        registered_layer_names: tuple[str, ...] | list[str] | None = None,
     ) -> tuple[int, list[tuple[int, int, int]]]:
         if self._sw_ratio is None:
-            # No SWA view opt: upstream's Full-only desc layout applies.
-            return super().register_local_xfer_handler(block_size)
+            if registered_layer_names is None:
+                # No SWA view opt, no PP shard: upstream's Full-only layout.
+                return super().register_local_xfer_handler(block_size)
+            # PP shard — register only this producer stage's local regions.
+            return self._register_shard_local_xfer_handler(
+                block_size, registered_layer_names
+            )
+        assert registered_layer_names is None, (
+            "RBLN NIXL: SWA view-opt is not supported with pipeline parallelism"
+        )
         assert self.transfer_topo is not None
         assert not self.transfer_topo.is_kv_layout_blocks_first, (
             "RBLN NIXL connector only supports FA layout (K and V in "
@@ -663,3 +696,480 @@ class RblnNixlConnectorWorker(NixlConnectorWorker):
             group_arr = np.asarray(group)[None, :]
             all_descs.append((region_ids * num_blocks + group_arr + offset).flatten())
         return np.concatenate(all_descs) if all_descs else np.empty(0, dtype=int)
+
+    # ------------------------------------------------------------------
+    # Pipeline-parallel (PP) P/D over NIXL
+    # ------------------------------------------------------------------
+    #
+    # Under sync-scheduling PP the producer runs pipeline_parallel_size
+    # stages, each owning a contiguous band of layers. Every stage
+    # advertises its (pp_rank, tp_rank) shard and the KV-cache layer names
+    # it registered; the consumer matches each shard to its own local KV
+    # regions BY NAME (the owned layer range is derived locally on each
+    # side, never sent over the wire) and reads each overlapping shard with
+    # a shard-scoped local/remote descriptor pair. All of this collapses to
+    # the upstream single-stage path for pp_size == 1.
+
+    def _check_pp_constraints(self) -> None:
+        if self.vllm_config.parallel_config.pipeline_parallel_size <= 1:
+            return
+        assert self.transfer_topo is not None
+        if self.transfer_topo.cross_layers_blocks:
+            raise RuntimeError(
+                "RBLN NIXL: cross-layer-blocks mode is not supported with "
+                "pipeline_parallel_size > 1."
+            )
+        if self._has_mamba:
+            raise RuntimeError(
+                "RBLN NIXL: hybrid (Mamba/SSM) models are not supported with "
+                "pipeline_parallel_size > 1 over NIXL P/D."
+            )
+        if self._sw_ratio is not None:
+            raise RuntimeError(
+                "RBLN NIXL: sliding-window view-opt (VLLM_RBLN_NIXL_SWA_VIEW_OPT) "
+                "is not supported with pipeline_parallel_size > 1."
+            )
+
+    def _publish_pp_handshake_metadata(
+        self, base_meta: NixlAgentMetadata, registered_layer_names
+    ) -> None:
+        self._check_pp_constraints()
+        pp_size = self.vllm_config.parallel_config.pipeline_parallel_size
+        pp_rank = get_pp_group().rank_in_group if pp_size > 1 else 0
+        pp_meta = RblnNixlAgentMetadata(
+            engine_id=base_meta.engine_id,
+            agent_metadata=base_meta.agent_metadata,
+            device_id=base_meta.device_id,
+            kv_caches_base_addr=base_meta.kv_caches_base_addr,
+            num_blocks=base_meta.num_blocks,
+            block_lens=base_meta.block_lens,
+            kv_cache_layout=base_meta.kv_cache_layout,
+            block_size=base_meta.block_size,
+            ssm_sizes=base_meta.ssm_sizes,
+            attn_backend_name=base_meta.attn_backend_name,
+            physical_blocks_per_logical_kv_block=(
+                base_meta.physical_blocks_per_logical_kv_block
+            ),
+            pp_rank=pp_rank,
+            pp_size=pp_size,
+            registered_layer_names=list(registered_layer_names),
+        )
+        base_hash = self.compat_hash
+        assert base_hash is not None
+        self.compat_hash = rbln_pp_compat_hash(base_hash)
+        self.xfer_handshake_metadata = NixlHandshakePayload(
+            compatibility_hash=self.compat_hash,
+            agent_metadata_bytes=msgspec.msgpack.Encoder().encode(pp_meta),
+        )
+
+    def _query_agent_meta(
+        self, sock: "zmq.Socket", remote_rank: int, expected_engine_id: str
+    ) -> RblnNixlAgentMetadata:
+        sock.send(msgspec.msgpack.encode((GET_META_MSG, remote_rank)))
+        try:
+            handshake_payload = msgspec.msgpack.Decoder(NixlHandshakePayload).decode(
+                sock.recv()
+            )
+        except (msgspec.DecodeError, msgspec.ValidationError) as e:
+            raise RuntimeError(
+                "Failed to decode NixlHandshakePayload; this likely indicates an "
+                f"incompatibility between connector versions. Error: {e}"
+            ) from e
+        assert self.compat_hash is not None
+        if (
+            self.enforce_compat_hash
+            and handshake_payload.compatibility_hash != self.compat_hash
+        ):
+            raise RuntimeError(
+                "NIXL compatibility hash mismatch "
+                f"(local={self.compat_hash}, "
+                f"remote={handshake_payload.compatibility_hash}). Prefill and "
+                "decode instances have incompatible configurations (vLLM "
+                "version, model, dtype, KV cache layout, attention backend, "
+                "etc.). Disable this check with --kv-transfer-config "
+                '\'{"kv_connector_extra_config": '
+                '{"enforce_handshake_compat": false}}\''
+            )
+        try:
+            metadata = msgspec.msgpack.Decoder(RblnNixlAgentMetadata).decode(
+                handshake_payload.agent_metadata_bytes
+            )
+        except (msgspec.DecodeError, msgspec.ValidationError) as e:
+            raise RuntimeError(
+                f"Failed to decode RblnNixlAgentMetadata. Error: {e}"
+            ) from e
+        if metadata.engine_id != expected_engine_id:
+            raise RuntimeError(
+                "Remote NIXL agent engine ID mismatch. "
+                f"Expected {expected_engine_id}, received {metadata.engine_id}."
+            )
+        return metadata
+
+    def _nixl_handshake(
+        self,
+        host: str,
+        port: int,
+        remote_tp_size: int,
+        expected_engine_id: str,
+    ) -> dict[int, str]:
+        # Background thread needs a device context (see base _nixl_handshake).
+        if not self.use_host_buffer:
+            current_platform.set_device(self.device_id)
+
+        assert self.transfer_topo is not None
+        p_remote_tp_ranks = self.transfer_topo.handshake_target_ranks(remote_tp_size)
+        path = make_zmq_path("tcp", host, port)
+        remote_rank_to_agent_name: dict[int, str] = {}
+
+        with zmq_ctx(zmq.REQ, path) as sock:
+            sock.setsockopt(zmq.RCVTIMEO, 5000)  # ms; avoid hang on dead server
+
+            # Bootstrap: the first shard (pp_rank 0) advertises pp_size.
+            first_rank = p_remote_tp_ranks[0]
+            metas = {
+                first_rank: self._query_agent_meta(sock, first_rank, expected_engine_id)
+            }
+            pp_size = metas[first_rank].pp_size
+
+            if pp_size > 1:
+                if self._sw_ratio is not None:
+                    raise RuntimeError(
+                        "RBLN NIXL: sliding-window attention combined with "
+                        "pipeline-parallel P/D is not supported."
+                    )
+                if remote_tp_size > 1:
+                    raise RuntimeError(
+                        "RBLN NIXL: tensor parallelism (remote_tp_size>1) "
+                        "combined with pipeline-parallel P/D is not supported."
+                    )
+
+            for pp_rank in range(pp_size):
+                for remote_tp_rank in p_remote_tp_ranks:
+                    global_rank = pp_rank * remote_tp_size + remote_tp_rank
+                    if global_rank in metas:
+                        metadata = metas[global_rank]
+                    else:
+                        metadata = self._query_agent_meta(
+                            sock, global_rank, expected_engine_id
+                        )
+                    names = tuple(metadata.registered_layer_names)
+                    self._remote_shard_layer_names[expected_engine_id][global_rank] = (
+                        names
+                    )
+                    if pp_size == 1:
+                        # No pipeline parallelism: single-stage registration,
+                        # exactly as the non-PP path (read path also delegates to
+                        # base for pp_size == 1).
+                        remote_rank_to_agent_name[global_rank] = self.add_remote_agent(
+                            metadata, global_rank, remote_tp_size
+                        )
+                        continue
+
+                    # PP: only register producer stages whose layers this rank
+                    # owns. add_remote_agent indexes local block_len_per_layer by
+                    # the remote region position, safe only when n_remote <=
+                    # n_local (overlapping stages); a larger non-overlapping peer
+                    # would index out of range and is never read here -- skip it.
+                    indices = self._local_region_indices_for_layer_names(names)
+                    if 0 < len(indices) < len(names):
+                        raise RuntimeError(
+                            f"RBLN NIXL PP: producer stage {global_rank} "
+                            f"({len(names)} layers) partially overlaps this "
+                            f"decode rank's band ({len(indices)} owned). "
+                            "The prefill pipeline-parallel size must be >= "
+                            "the decode pipeline-parallel size and an integer "
+                            "multiple of it."
+                        )
+                    if not indices:
+                        continue
+                    remote_rank_to_agent_name[global_rank] = self.add_remote_agent(
+                        metadata, global_rank, remote_tp_size
+                    )
+                    self._register_shard_read_state(
+                        expected_engine_id,
+                        global_rank,
+                        metadata.block_size,
+                        names,
+                    )
+                    self._overlapping_ranks[expected_engine_id].append(global_rank)
+        self._remote_pp_size[expected_engine_id] = pp_size
+        return remote_rank_to_agent_name
+
+    def _register_shard_read_state(
+        self,
+        engine_id: str,
+        global_rank: int,
+        block_size: int,
+        registered_layer_names: tuple[str, ...],
+    ) -> None:
+        # Compute the local region ids once and reuse them for the handler
+        # (PP context is always the shard path: SWA + PP is rejected earlier).
+        region_ids = self._shard_local_region_ids(registered_layer_names)
+        handle, _ = self._register_shard_local_xfer_handler(
+            block_size, registered_layer_names, region_ids=region_ids
+        )
+        self.src_xfer_handles_by_remote[(engine_id, global_rank, block_size)] = handle
+        assert len(self.kv_cache_config.kv_cache_groups) == 1, (
+            "RBLN NIXL PP currently supports a single KV-cache group"
+        )
+        self._shard_region_group_ids[(engine_id, global_rank)] = (0,) * len(region_ids)
+
+    def _cleanup_remote_engine(
+        self, engine_id: str, *, log_eviction: bool = True
+    ) -> None:
+        """Drop this engine's per-stage PP state along with the base state.
+
+        The base clears only what it owns (remote agents, dst dlist handles,
+        base addrs, tp mappings, topology entry). Our per-stage dicts are keyed
+        by engine id too, and `_overlapping_ranks` is a *list*: leaving entries
+        behind means a re-handshake with the same engine id appends its stages
+        again and every block is then read twice. The local dlist handles we
+        prepped per stage are ours to release as well -- `register_local_xfer_
+        handler` builds a fresh one per stage, so nothing else refers to them.
+        """
+        for key in [k for k in self.src_xfer_handles_by_remote if k[0] == engine_id]:
+            self.nixl_wrapper.release_dlist_handle(
+                self.src_xfer_handles_by_remote.pop(key)
+            )
+        for skey in [k for k in self._shard_region_group_ids if k[0] == engine_id]:
+            del self._shard_region_group_ids[skey]
+        self._remote_shard_layer_names.pop(engine_id, None)
+        self._overlapping_ranks.pop(engine_id, None)
+        self._remote_pp_size.pop(engine_id, None)
+        super()._cleanup_remote_engine(engine_id, log_eviction=log_eviction)
+
+    def _local_region_indices_for_layer_names(
+        self, registered_layer_names: tuple[str, ...] | list[str]
+    ) -> list[int]:
+        positions_by_name: dict[str, list[int]] = defaultdict(list)
+        for local_idx, layer_name in enumerate(self.local_seen_layer_names):
+            positions_by_name[layer_name].append(local_idx)
+
+        occurrences_by_name: dict[str, int] = defaultdict(int)
+        local_indices: list[int] = []
+        for layer_name in registered_layer_names:
+            occurrence = occurrences_by_name[layer_name]
+            occurrences_by_name[layer_name] += 1
+            matches = positions_by_name.get(layer_name, [])
+            if occurrence >= len(matches):
+                continue
+            local_indices.append(matches[occurrence])
+        return local_indices
+
+    def _regions_per_layer(self) -> int:
+        num_layers = len(self.local_seen_layer_names)
+        assert num_layers > 0 and self.num_regions % num_layers == 0, (
+            f"num_regions={self.num_regions} not divisible by num_layers={num_layers}"
+        )
+        return self.num_regions // num_layers
+
+    def _shard_local_region_ids(
+        self, registered_layer_names: tuple[str, ...] | list[str]
+    ) -> list[int]:
+        rpl = self._regions_per_layer()
+        layer_indices = self._local_region_indices_for_layer_names(
+            registered_layer_names
+        )
+        return [layer_idx * rpl + k for layer_idx in layer_indices for k in range(rpl)]
+
+    def _register_shard_local_xfer_handler(
+        self,
+        block_size: int,
+        registered_layer_names: tuple[str, ...] | list[str],
+        region_ids: list[int] | None = None,
+    ) -> tuple[int, list[tuple[int, int, int]]]:
+        assert self.transfer_topo is not None
+        assert not self.transfer_topo.is_kv_layout_blocks_first, (
+            "RBLN NIXL connector only supports FA layout (K and V in separate "
+            "regions), not FlashInfer."
+        )
+        assert not self._has_mamba, "RBLN NIXL connector does not support Mamba."
+
+        block_size_ratio = self.block_size // block_size
+        num_blocks = self.num_blocks * block_size_ratio
+        all_base_addrs = self.kv_caches_base_addr[self.engine_id][self.tp_rank]
+        if region_ids is None:
+            region_ids = self._shard_local_region_ids(registered_layer_names)
+
+        blocks_data: list[tuple[int, int, int]] = []
+        for region_id in region_ids:
+            base_addr = all_base_addrs[region_id]
+            kv_block_len = (
+                self.get_backend_aware_kv_block_len(
+                    layer_idx=region_id, first_split=True, mamba_view=False
+                )
+                // block_size_ratio
+            )
+            stride = self.block_len_per_layer[region_id] // block_size_ratio
+            for block_id in range(num_blocks):
+                blocks_data.append(
+                    (base_addr + block_id * stride, kv_block_len, self.device_id)
+                )
+
+        descs = self.nixl_wrapper.get_xfer_descs(blocks_data, self.nixl_memory_type)
+        return (
+            self.nixl_wrapper.prep_xfer_dlist("NIXL_INIT_AGENT", descs),
+            blocks_data,
+        )
+
+    def _get_block_descs_ids_for_shard(
+        self,
+        engine_id: str,
+        global_rank: int,
+        num_blocks: int,
+        block_ids: BlockIds,
+    ) -> np.ndarray:
+        region_group_ids = self._shard_region_group_ids[(engine_id, global_rank)]
+        desc_ids: list[np.ndarray] = []
+        for region_id, group_id in enumerate(region_group_ids):
+            group_arr = np.asarray(block_ids[group_id], dtype=np.int64)
+            if group_arr.size == 0:
+                continue
+            desc_ids.append(region_id * num_blocks + group_arr)
+        if not desc_ids:
+            return np.empty(0, dtype=np.int64)
+        return np.concatenate(desc_ids)
+
+    def _validate_remote_agent_handshake(
+        self, nixl_agent_meta: NixlAgentMetadata, remote_tp_size: int
+    ) -> None:
+        if getattr(nixl_agent_meta, "pp_size", 1) <= 1:
+            super()._validate_remote_agent_handshake(nixl_agent_meta, remote_tp_size)
+            return
+
+        assert self.transfer_topo is not None
+        remote_engine_id = nixl_agent_meta.engine_id
+        remote_info = self.transfer_topo.get_engine_info(remote_engine_id)
+        assert remote_info.remote_tp_size == remote_tp_size == 1, (
+            "PP over NIXL P/D requires TP=1 on both sides."
+        )
+        assert self.transfer_topo.block_size_ratio(nixl_agent_meta.block_size) == 1, (
+            "PP over NIXL P/D requires equal P/D block sizes."
+        )
+        assert self.dst_num_blocks[remote_engine_id] == nixl_agent_meta.num_blocks
+        rpl = self._regions_per_layer()
+        n_remote = len(nixl_agent_meta.kv_caches_base_addr)
+        assert (
+            n_remote > 0
+            and n_remote % rpl == 0
+            and n_remote <= len(self.block_len_per_layer)
+        ), (
+            f"PP shard advertised {n_remote} KV regions, not a valid "
+            f"sub-multiple of this consumer's {len(self.block_len_per_layer)} "
+            f"regions (regions/layer={rpl})."
+        )
+
+    def _read_blocks_for_req(self, req_id: str, meta: "ReqMeta") -> None:
+        assert meta.remote is not None and self.transfer_topo is not None
+        engine_id = meta.remote.engine_id
+        # Mark this remote as active, as the base read path does. TTL eviction
+        # (_evict_stale_engines, default engine_ttl=3600s) treats an engine whose
+        # timestamp is older than the TTL as dead and tears its state down when
+        # the next remote engine appears; a producer we keep reading from must
+        # never look idle. Cleanup runs on this (main) thread, so no race.
+        self._engine_last_active[engine_id] = time.perf_counter()
+        pp_size = self._remote_pp_size.get(engine_id, 1)
+        if pp_size == 1:
+            return super()._read_blocks_for_req(req_id, meta)
+
+        remote_info = self.transfer_topo.get_engine_info(engine_id)
+        assert self.transfer_topo.tp_ratio(remote_info.remote_tp_size) == 1, (
+            "RBLN NIXL PP read path supports TP=1 only"
+        )
+        assert (
+            self.transfer_topo.block_size_ratio(remote_info.remote_block_size) == 1
+        ), "RBLN NIXL PP read path requires equal P/D block sizes"
+        remote_block_size = remote_info.remote_block_size
+
+        meta.remote.block_ids = self._logical_to_remote_kernel_block_ids(
+            meta.remote.block_ids, remote_info.remote_physical_blocks_per_logical
+        )
+        remote_block_ids = meta.remote.block_ids
+        local_block_ids = meta.local_physical_block_ids
+        notif_id = f"{meta.remote.request_id}:{self.world_size}".encode()
+        prefix_hit = len(local_block_ids) == 0
+        n_prompt_blocks = sum(len(g) for g in remote_block_ids)
+
+        if not prefix_hit:
+            # _apply_prefix_caching indexes per KV-cache group, so a group-count
+            # mismatch must fail loudly here rather than as an opaque IndexError.
+            assert (
+                len(remote_block_ids)
+                == len(local_block_ids)
+                == len(self.kv_cache_config.kv_cache_groups)
+            )
+            local_block_ids, remote_block_ids = self._apply_prefix_caching(
+                local_block_ids,
+                remote_block_ids,
+                remote_info.remote_physical_blocks_per_logical,
+            )
+
+        n_read_blocks = sum(len(g) for g in local_block_ids)
+        logger.info(
+            "PP read req %s: pp_size=%d prompt_blocks=%d read_blocks=%d "
+            "prefix_skipped=%d%s",
+            req_id,
+            pp_size,
+            n_prompt_blocks,
+            n_read_blocks,
+            n_prompt_blocks - n_read_blocks,
+            " (full prefix hit, notif only)" if prefix_hit else "",
+        )
+
+        for global_rank in self._overlapping_ranks[engine_id]:
+            if prefix_hit:
+                agent_name = self._remote_agents[engine_id][global_rank]
+                try:
+                    self.nixl_wrapper.send_notif(agent_name, notif_msg=notif_id)
+                except Exception as e:
+                    # Mirror the transfer path below: a dropped notification
+                    # leaves the remote blocks pinned until its timeout, so log
+                    # it and record the failure instead of surfacing raw.
+                    self._log_failure(
+                        failure_type="notification_failed",
+                        req_id=req_id,
+                        msg="Remote blocks will be freed after timeout",
+                        error=e,
+                        dst_engine_id=engine_id,
+                        remote_pp_rank=global_rank,
+                    )
+                    self.xfer_stats.record_failed_notification()
+                continue
+
+            remote_descs = self._get_block_descs_ids_for_shard(
+                engine_id,
+                global_rank,
+                self.dst_num_blocks[engine_id],
+                remote_block_ids,
+            )
+            local_descs = self._get_block_descs_ids_for_shard(
+                engine_id, global_rank, self.num_blocks, local_block_ids
+            )
+            assert len(local_descs) == len(remote_descs)
+            local_handle = self.src_xfer_handles_by_remote[
+                (engine_id, global_rank, remote_block_size)
+            ]
+            remote_handle = self.dst_xfer_side_handles[engine_id][global_rank]
+
+            handle = None
+            try:
+                handle = self.nixl_wrapper.make_prepped_xfer(
+                    "READ",
+                    local_handle,
+                    local_descs,
+                    remote_handle,
+                    remote_descs,
+                    notif_msg=notif_id,
+                )
+                self.nixl_wrapper.transfer(handle)
+                self._recving_transfers[req_id].append(handle)
+            except Exception as e:
+                self._log_failure(
+                    failure_type="transfer_setup_failed",
+                    req_id=req_id,
+                    msg="Marking blocks as invalid",
+                    error=e,
+                    dst_engine_id=engine_id,
+                    remote_pp_rank=global_rank,
+                )
+                self._handle_failed_transfer(req_id, handle)

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """A RBLN worker class."""
 
-import copy
 import os
 import time
 from types import NoneType
@@ -55,7 +54,6 @@ from vllm.tracing import instrument
 from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import (
-    EMPTY_MODEL_RUNNER_OUTPUT,
     AsyncModelRunnerOutput,
     DraftTokenIds,
     ModelRunnerOutput,
@@ -519,21 +517,12 @@ class RBLNWorker(WorkerBase):
         # NOTE(RBLN): DO NOT all_gather_group for RBLN pp
         get_pp_group().send_tensor_dict(output.tensors)
 
-        # For PP with a KV connector, surface the connector output the
-        # model runner attached to the intermediate tensors so finished
-        # send/recv notifications still propagate from non-last ranks.
-        kv_connector_output = output.kv_connector_output
-        if not kv_connector_output:
-            return None
-        if (
-            not kv_connector_output.finished_sending
-            and not kv_connector_output.finished_recving
-        ):
-            return EMPTY_MODEL_RUNNER_OUTPUT
-
-        empty_output = copy.copy(EMPTY_MODEL_RUNNER_OUTPUT)
-        empty_output.kv_connector_output = kv_connector_output
-        return empty_output
+        # Non-last PP rank: the model runner already surfaces this rank's
+        # KV-connector output through the two-phase sample_tokens() path
+        # (mirroring the upstream model runner). The engine consumes this
+        # execute_model result only for error propagation, so return None
+        # rather than emitting the same finished send/recv notifications here.
+        return None
 
     def take_draft_token_ids(self) -> DraftTokenIds | None:
         return self.model_runner.take_draft_token_ids()


### PR DESCRIPTION
> **Step 2 of 3** — split of #838 (*pipeline parallelism across the RBLN scheduler, runner, and NIXL KV-cache transfer*). This PR carries **section B** of #838: NIXL KV-cache transfer under PP. The PP-aware scheduler and runner it builds on are already on `dev`, so the diff here is only the NIXL changes.

### 🚀 Summary of Changes

#### Summary

Extend prefill→decode KV-cache transfer over NIXL to work when either side runs with pipeline parallelism. Before this, a reader would connect to producer stages it does not read from and index per-stage descriptors out of range. Each pipeline stage now advertises its own band of layers in the handshake, and a reader connects to — and builds descriptors for — only the producer stages whose layers fall within the band it owns.

#### What changed

**1. Per-stage layer-band handshake.** Each pipeline stage advertises its own band of layers in the handshake metadata; a reader connects to and pulls from only the producer stages whose layers fall within the band it owns. This covers both the **symmetric layout** (prefill and decode share a pipeline size, stage matched to stage) and the **fan-in layout** (a reader without pipeline parallelism aggregates several producer stages).

**2. Overlap-aware remote descriptor build.** Per-stage remote descriptors are built assuming a producer exposes no more regions than the reader owns — which holds only for the stages the reader actually reads from. Stages outside the reader's band (which can expose more regions when the layer count does not divide evenly across stages) are **skipped before that build**, so it never indexes out of range.

**3. Non-last-rank KV output via the two-phase path.** The KV-connector output for a non-last PP rank is surfaced through the runner's two-phase `sample_tokens()` path; `RBLNWorker.execute_model` returns `None` on non-last ranks instead of re-emitting the same finished send/recv notifications from an empty output, so every rank saves its own layers' KV exactly once.

**4. Unsupported combinations rejected at handshake.** TP together with PP, sliding-window attention together with PP, and unequal prefill/decode block sizes are rejected during the handshake. Transfers without pipeline parallelism keep the existing single-stage path unchanged.

**5. Handshake and notification robustness on the PP read path.** A dropped prefix-hit notification is logged and recorded (matching the transfer path in the same function) rather than surfacing raw; the handshake decode wraps its payload and agent-metadata errors and points a compatibility-hash mismatch at its opt-out config; the per-stage read-state registration computes its region ids once; and a read about to apply prefix caching asserts the local/remote/group block-id lengths agree, turning a group-count mismatch into a clear failure instead of an opaque index error.

**6. Host-staged save path re-synced with the base connector.** Two scheduler methods were near-copies of the base kept for one divergence each, so base behaviour added after those copies had been frozen out, and the two were entangled: the save bookkeeping lived in the copied metadata builder and the other method existed only to clear it. Now only the hook the base offers for the differing part is overridden — staging a prefill's blocks in a single save once every chunk has landed — and the rest is inherited. Two consequences a reviewer should look at: blocks are **accumulated as the chunks allocate them**, since a prompt spanning more than one block no longer arrives in one scheduler step and the previous one-shot assumption aborted the prefill engine; and a prefill that ends **stopped** rather than length-capped is now handed to the decode side instead of having its blocks freed with its KV never transferred. This path is used only when KV is staged through host memory.


#### Testing

- **Unit** — the chunked-prefill save accumulation and the finished-request outcomes for a stopped vs an aborted producer (`test_rbln_nixl_scheduler.py`); the NIXL per-stage layer-band handshake and overlap-skip read path (`test_rbln_nixl_handshake_pp.py`), handshake metadata PP fields (`test_rbln_nixl_metadata.py`), the PP-aware connector scheduler and worker (`test_rbln_nixl_scheduler.py`, `test_rbln_nixl_worker.py`).
- `pre-commit run --hook-stage manual` clean; connector/worker unit suites green.

#### Risk / compatibility

- NIXL transfers with `pipeline_parallel_size == 1` on both sides take the unchanged single-stage path.
- Unsupported PP combinations fail fast at the handshake rather than mis-transferring.
- Behaviour change: a producer prefill finishing on a stop condition now transfers its KV instead of being dropped from the transfer, so the decode side no longer has to re-prefill it.

#### Affected modules

NIXL KV connector, Worker.

---

### ✅ Type of Change

* [x] ✨ Feature (`feature`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


