### PR TITLE
other(examples): make optimum offline examples configurable and hardware-agnostic

### DIFF
--- a/examples/optimum/decoder_models/basic_offline.py
+++ b/examples/optimum/decoder_models/basic_offline.py
@@ -29,15 +29,14 @@ sampling_params = SamplingParams(temperature=0, top_p=1.0)
 
 
 def main(
-    model: str = "meta-llama/Llama-3.2-1B",
+    model: str = "meta-llama/Llama-3.2-3B",
     max_num_seqs: int = 1,
-    max_model_len: int = 4096,
-    block_size: int = None,  # if None, will be set to max_model_len
-    num_devices: int = 4,
+    max_model_len: int = 131072,
+    block_size: int = 16384,
+    num_devices: int = 8,
     use_decoder_batch_sizes: bool = False,
 ):
-    if num_devices is not None:
-        os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
+    os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
 
     llm = LLM(
         model=model,

--- a/examples/optimum/decoder_models/basic_offline.py
+++ b/examples/optimum/decoder_models/basic_offline.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import fire
 from vllm import LLM, SamplingParams
 
@@ -28,9 +30,26 @@ sampling_params = SamplingParams(temperature=0, top_p=1.0)
 
 def main(
     model: str = "meta-llama/Llama-3.2-1B",
+    max_num_seqs: int = 1,
+    max_model_len: int = 4096,
+    block_size: int = None,  # if None, will be set to max_model_len
+    num_devices: int = 4,
+    use_decoder_batch_sizes: bool = False,
 ):
-    # Create an LLM.
-    llm = LLM(model=model, block_size=4096)
+    if num_devices is not None:
+        os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
+
+    llm = LLM(
+        model=model,
+        block_size=block_size,
+        max_model_len=max_model_len,
+        max_num_seqs=max_num_seqs,
+        additional_config={
+            "rbln_config": {
+                "decoder_batch_sizes": [1, 8] if use_decoder_batch_sizes else None,
+            }
+        },
+    )
     # Generate texts from the prompts.
     # The output is a list of RequestOutput objects
     # that contain the prompt, generated text, and other information.

--- a/examples/optimum/multimodal_models/blip2_offline.py
+++ b/examples/optimum/multimodal_models/blip2_offline.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import fire
 from datasets import load_dataset
 from transformers import AutoTokenizer
@@ -39,10 +41,23 @@ def generate_prompts(batch_size: int, model: str):
 def main(
     num_input_prompt: int = 10,
     model: str = "Salesforce/blip2-opt-2.7b",
-):
+    max_num_seqs: int = 1,
     # `max_model_len` of BLIP2 model is 2048
-    # and `block_size` cannot exceeds `max_model_len`.
-    llm = LLM(model=model, block_size=2048)
+    # and `block_size` cannot exceed `max_model_len`.
+    max_model_len: int = 2048,
+    block_size: int = None,  # if None, will be set to max_model_len
+    num_devices: int = None,
+):
+    if num_devices is not None:
+        os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
+    if block_size is None:
+        block_size = max_model_len
+    llm = LLM(
+        model=model,
+        block_size=block_size,
+        # max_model_len=max_model_len,
+        # max_num_seqs=max_num_seqs,
+    )
     tokenizer = AutoTokenizer.from_pretrained(model)
     inputs = generate_prompts(num_input_prompt, model)
 

--- a/examples/optimum/multimodal_models/blip2_offline.py
+++ b/examples/optimum/multimodal_models/blip2_offline.py
@@ -42,8 +42,6 @@ def main(
     num_input_prompt: int = 10,
     model: str = "Salesforce/blip2-opt-2.7b",
     max_num_seqs: int = 1,
-    # `max_model_len` of BLIP2 model is 2048
-    # and `block_size` cannot exceed `max_model_len`.
     max_model_len: int = 2048,
     block_size: int = None,  # if None, will be set to max_model_len
     num_devices: int = None,
@@ -55,8 +53,8 @@ def main(
     llm = LLM(
         model=model,
         block_size=block_size,
-        # max_model_len=max_model_len,
-        # max_num_seqs=max_num_seqs,
+        max_model_len=max_model_len,
+        max_num_seqs=max_num_seqs,
     )
     tokenizer = AutoTokenizer.from_pretrained(model)
     inputs = generate_prompts(num_input_prompt, model)

--- a/examples/optimum/multimodal_models/exaone4_5_offline.py
+++ b/examples/optimum/multimodal_models/exaone4_5_offline.py
@@ -173,7 +173,7 @@ def main(
     os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
     rbln_config = {
         "visual": {
-            "max_seq_len": vision_max_seq_len, 
+            "max_seq_len": vision_max_seq_len,
             "num_devices": vision_num_devices,
         },
     }

--- a/examples/optimum/multimodal_models/exaone4_5_offline.py
+++ b/examples/optimum/multimodal_models/exaone4_5_offline.py
@@ -164,18 +164,25 @@ def main(
     num_input_prompt: int = 4,
     model: str = "LGAI-EXAONE/EXAONE-4.5-33B",  # noqa: E501
     max_num_seqs: int = 1,
-    max_model_len: int = 8192,
-    block_size: int = None,  # if None, will be set to max_model_len
-    num_devices: int = 4,
+    max_model_len: int = 262144,
+    block_size: int = 16384,
+    num_devices: int = 16,
+    vision_max_seq_len: int = 16384,
+    vision_num_devices: int = 16,
 ):
     os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
-    if block_size is None:
-        block_size = max_model_len
+    rbln_config = {
+        "visual": {
+            "max_seq_len": vision_max_seq_len, 
+            "num_devices": vision_num_devices,
+        },
+    }
     llm = LLM(
         model=model,
         block_size=block_size,
         max_model_len=max_model_len,
         max_num_seqs=max_num_seqs,
+        additional_config={"rbln_config": rbln_config},
     )
     tokenizer = AutoTokenizer.from_pretrained(model)
     inputs = generate_prompts_image(num_input_prompt, model)

--- a/examples/optimum/multimodal_models/exaone4_5_offline.py
+++ b/examples/optimum/multimodal_models/exaone4_5_offline.py
@@ -163,12 +163,17 @@ def generate_prompts_wo_processing(batch_size: int, model: str):
 def main(
     num_input_prompt: int = 4,
     model: str = "LGAI-EXAONE/EXAONE-4.5-33B",  # noqa: E501
+    max_model_len: int = 8192,
+    block_size: int = None,  # if None, will be set to max_model_len
+    num_devices: int = 4,
 ):
-    os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = "4"
+    os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
+    if block_size is None:
+        block_size = max_model_len
     llm = LLM(
         model=model,
-        block_size=4096,
-        max_model_len=8192,
+        block_size=block_size,
+        max_model_len=max_model_len,
         max_num_seqs=1,
     )
     tokenizer = AutoTokenizer.from_pretrained(model)

--- a/examples/optimum/multimodal_models/exaone4_5_offline.py
+++ b/examples/optimum/multimodal_models/exaone4_5_offline.py
@@ -163,6 +163,7 @@ def generate_prompts_wo_processing(batch_size: int, model: str):
 def main(
     num_input_prompt: int = 4,
     model: str = "LGAI-EXAONE/EXAONE-4.5-33B",  # noqa: E501
+    max_num_seqs: int = 1,
     max_model_len: int = 8192,
     block_size: int = None,  # if None, will be set to max_model_len
     num_devices: int = 4,
@@ -174,7 +175,7 @@ def main(
         model=model,
         block_size=block_size,
         max_model_len=max_model_len,
-        max_num_seqs=1,
+        max_num_seqs=max_num_seqs,
     )
     tokenizer = AutoTokenizer.from_pretrained(model)
     inputs = generate_prompts_image(num_input_prompt, model)

--- a/examples/optimum/multimodal_models/gemma3_offline.py
+++ b/examples/optimum/multimodal_models/gemma3_offline.py
@@ -65,13 +65,11 @@ def main(
     num_input_prompt: int = 10,
     model: str = "google/gemma-3-4b-it",
     max_num_seqs: int = 1,
-    max_model_len: int = 4096,
-    block_size: int = None,  # if None, will be set to max_model_len
-    num_devices: int = 4,
+    max_model_len: int = 131072,
+    block_size: int = 16384,
+    num_devices: int = 8,
 ):
     os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
-    if block_size is None:
-        block_size = max_model_len
     llm = LLM(
         model=model, 
         block_size=block_size, 

--- a/examples/optimum/multimodal_models/gemma3_offline.py
+++ b/examples/optimum/multimodal_models/gemma3_offline.py
@@ -64,6 +64,7 @@ def generate_prompts(batch_size: int, model: str):
 def main(
     num_input_prompt: int = 10,
     model: str = "google/gemma-3-4b-it",
+    max_num_seqs: int = 1,
     max_model_len: int = 4096,
     block_size: int = None,  # if None, will be set to max_model_len
     num_devices: int = 4,
@@ -71,7 +72,12 @@ def main(
     os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
     if block_size is None:
         block_size = max_model_len
-    llm = LLM(model=model, block_size=block_size, max_model_len=max_model_len)
+    llm = LLM(
+        model=model, 
+        block_size=block_size, 
+        max_model_len=max_model_len, 
+        max_num_seqs=max_num_seqs
+    )
     tokenizer = AutoTokenizer.from_pretrained(model)
     inputs = generate_prompts(num_input_prompt, model)
 

--- a/examples/optimum/multimodal_models/gemma3_offline.py
+++ b/examples/optimum/multimodal_models/gemma3_offline.py
@@ -64,9 +64,14 @@ def generate_prompts(batch_size: int, model: str):
 def main(
     num_input_prompt: int = 10,
     model: str = "google/gemma-3-4b-it",
+    max_model_len: int = 4096,
+    block_size: int = None,  # if None, will be set to max_model_len
+    num_devices: int = 4,
 ):
-    os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = "4"
-    llm = LLM(model=model, block_size=4096)
+    os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
+    if block_size is None:
+        block_size = max_model_len
+    llm = LLM(model=model, block_size=block_size, max_model_len=max_model_len)
     tokenizer = AutoTokenizer.from_pretrained(model)
     inputs = generate_prompts(num_input_prompt, model)
 

--- a/examples/optimum/multimodal_models/gemma3_offline.py
+++ b/examples/optimum/multimodal_models/gemma3_offline.py
@@ -71,10 +71,10 @@ def main(
 ):
     os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
     llm = LLM(
-        model=model, 
-        block_size=block_size, 
-        max_model_len=max_model_len, 
-        max_num_seqs=max_num_seqs
+        model=model,
+        block_size=block_size,
+        max_model_len=max_model_len,
+        max_num_seqs=max_num_seqs,
     )
     tokenizer = AutoTokenizer.from_pretrained(model)
     inputs = generate_prompts(num_input_prompt, model)

--- a/examples/optimum/multimodal_models/gemma4_offline.py
+++ b/examples/optimum/multimodal_models/gemma4_offline.py
@@ -64,11 +64,17 @@ def generate_prompts(batch_size: int, model: str):
 def main(
     num_input_prompt: int = 1,
     model: str = "google/gemma-4-31B-it",
+    max_model_len: int = 4096,
+    block_size: int = None,  # if None, will be set to max_model_len
+    num_devices: int = 4,
 ):
-    os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = "4"
+    os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
+    if block_size is None:
+        block_size = max_model_len
     llm = LLM(
         model=model,
-        block_size=4096,
+        block_size=block_size,
+        max_model_len=max_model_len,
     )
     tokenizer = AutoTokenizer.from_pretrained(model)
     inputs = generate_prompts(num_input_prompt, model)

--- a/examples/optimum/multimodal_models/gemma4_offline.py
+++ b/examples/optimum/multimodal_models/gemma4_offline.py
@@ -65,18 +65,23 @@ def main(
     num_input_prompt: int = 1,
     model: str = "google/gemma-4-31B-it",
     max_num_seqs: int = 1,
-    max_model_len: int = 4096,
-    block_size: int = None,  # if None, will be set to max_model_len
-    num_devices: int = 4,
+    max_model_len: int = 262144,
+    block_size: int = 16384,
+    num_devices: int = 16,
+    vision_num_devices: int = 8,
 ):
     os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
-    if block_size is None:
-        block_size = max_model_len
+    rbln_config = {
+        "visual": {
+            "num_devices": vision_num_devices,
+        },
+    }
     llm = LLM(
         model=model,
         block_size=block_size,
         max_model_len=max_model_len,
         max_num_seqs=max_num_seqs,
+        additional_config={"rbln_config": rbln_config},
     )
     tokenizer = AutoTokenizer.from_pretrained(model)
     inputs = generate_prompts(num_input_prompt, model)

--- a/examples/optimum/multimodal_models/gemma4_offline.py
+++ b/examples/optimum/multimodal_models/gemma4_offline.py
@@ -64,6 +64,7 @@ def generate_prompts(batch_size: int, model: str):
 def main(
     num_input_prompt: int = 1,
     model: str = "google/gemma-4-31B-it",
+    max_num_seqs: int = 1,
     max_model_len: int = 4096,
     block_size: int = None,  # if None, will be set to max_model_len
     num_devices: int = 4,
@@ -75,6 +76,7 @@ def main(
         model=model,
         block_size=block_size,
         max_model_len=max_model_len,
+        max_num_seqs=max_num_seqs,
     )
     tokenizer = AutoTokenizer.from_pretrained(model)
     inputs = generate_prompts(num_input_prompt, model)

--- a/examples/optimum/multimodal_models/idefics3_offline.py
+++ b/examples/optimum/multimodal_models/idefics3_offline.py
@@ -64,9 +64,23 @@ def generate_prompts(batch_size: int, model: str):
 def main(
     num_input_prompt: int = 10,
     model: str = "HuggingFaceM4/Idefics3-8B-Llama3",
+    max_num_seqs: int = 1,
+    max_model_len: int = 4096,
+    block_size: int = None,  # if None, will be set to max_model_len
+    num_devices: int = 4,
 ):
-    os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = "4"
-    llm = LLM(model=model, block_size=4096)
+    # Compile shape follows the rebel_compiler multi-modal compile.py pattern:
+    # num_devices → env var, batch_size / max_seq_len → additional_config
+    # ["rbln_config"]; block_size stays a top-level vLLM kwarg.
+    os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
+    if block_size is None:
+        block_size = max_model_len
+    llm = LLM(
+        model=model,
+        block_size=block_size,
+        max_model_len=max_model_len,
+        max_num_seqs=max_num_seqs,
+    )
     tokenizer = AutoTokenizer.from_pretrained(model)
     inputs = generate_prompts(num_input_prompt, model)
 

--- a/examples/optimum/multimodal_models/idefics3_offline.py
+++ b/examples/optimum/multimodal_models/idefics3_offline.py
@@ -65,13 +65,11 @@ def main(
     num_input_prompt: int = 10,
     model: str = "HuggingFaceM4/Idefics3-8B-Llama3",
     max_num_seqs: int = 1,
-    max_model_len: int = 4096,
-    block_size: int = None,  # if None, will be set to max_model_len
-    num_devices: int = 4,
+    max_model_len: int = 131072,
+    block_size: int = 16384,
+    num_devices: int = 8,
 ):
     os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
-    if block_size is None:
-        block_size = max_model_len
     llm = LLM(
         model=model,
         block_size=block_size,

--- a/examples/optimum/multimodal_models/idefics3_offline.py
+++ b/examples/optimum/multimodal_models/idefics3_offline.py
@@ -69,9 +69,6 @@ def main(
     block_size: int = None,  # if None, will be set to max_model_len
     num_devices: int = 4,
 ):
-    # Compile shape follows the rebel_compiler multi-modal compile.py pattern:
-    # num_devices → env var, batch_size / max_seq_len → additional_config
-    # ["rbln_config"]; block_size stays a top-level vLLM kwarg.
     os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
     if block_size is None:
         block_size = max_model_len

--- a/examples/optimum/multimodal_models/llava_offline.py
+++ b/examples/optimum/multimodal_models/llava_offline.py
@@ -65,7 +65,7 @@ def main(
     num_input_prompt: int = 10,
     model: str = "llava-hf/llava-v1.6-mistral-7b-hf",
     max_num_seqs: int = 1,
-    max_model_len: int = 16384,
+    max_model_len: int = 32768,
     block_size: int = None,  # if None, will be set to max_model_len
     num_devices: int = 4,
 ):

--- a/examples/optimum/multimodal_models/llava_offline.py
+++ b/examples/optimum/multimodal_models/llava_offline.py
@@ -69,9 +69,6 @@ def main(
     block_size: int = None,  # if None, will be set to max_model_len
     num_devices: int = 4,
 ):
-    # Compile shape follows the rebel_compiler multi-modal compile.py pattern:
-    # num_devices → env var, batch_size / max_seq_len → additional_config
-    # ["rbln_config"]; block_size stays a top-level vLLM kwarg.
     os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
     if block_size is None:
         block_size = max_model_len

--- a/examples/optimum/multimodal_models/llava_offline.py
+++ b/examples/optimum/multimodal_models/llava_offline.py
@@ -64,9 +64,23 @@ def generate_prompts(batch_size: int, model: str):
 def main(
     num_input_prompt: int = 10,
     model: str = "llava-hf/llava-v1.6-mistral-7b-hf",
+    max_num_seqs: int = 1,
+    max_model_len: int = 16384,
+    block_size: int = None,  # if None, will be set to max_model_len
+    num_devices: int = 4,
 ):
-    os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = "4"
-    llm = LLM(model=model, block_size=16384, max_num_seqs=1)
+    # Compile shape follows the rebel_compiler multi-modal compile.py pattern:
+    # num_devices → env var, batch_size / max_seq_len → additional_config
+    # ["rbln_config"]; block_size stays a top-level vLLM kwarg.
+    os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
+    if block_size is None:
+        block_size = max_model_len
+    llm = LLM(
+        model=model,
+        block_size=block_size,
+        max_model_len=max_model_len,
+        max_num_seqs=max_num_seqs,
+    )
     tokenizer = AutoTokenizer.from_pretrained(model)
     inputs = generate_prompts(num_input_prompt, model)
 

--- a/examples/optimum/multimodal_models/paligemma_offline.py
+++ b/examples/optimum/multimodal_models/paligemma_offline.py
@@ -45,9 +45,23 @@ def generate_prompts(batch_size: int):
 def main(
     num_input_prompt: int = 10,
     model: str = "google/paligemma2-3b-pt-224",
+    max_num_seqs: int = 1,
+    max_model_len: int = 8192,
+    block_size: int = None,  # if None, will be set to max_model_len
+    num_devices: int = 4,
 ):
-    os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = "4"
-    llm = LLM(model=model, block_size=8192, max_model_len=8192)
+    # Compile shape follows the rebel_compiler multi-modal compile.py pattern:
+    # num_devices → env var, batch_size / max_seq_len → additional_config
+    # ["rbln_config"]; block_size stays a top-level vLLM kwarg.
+    os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
+    if block_size is None:
+        block_size = max_model_len
+    llm = LLM(
+        model=model,
+        block_size=block_size,
+        max_num_seqs=max_num_seqs,
+        max_model_len=max_model_len,
+    )
     tokenizer = AutoTokenizer.from_pretrained(model)
     inputs = generate_prompts(num_input_prompt)
 

--- a/examples/optimum/multimodal_models/pixtral_offline.py
+++ b/examples/optimum/multimodal_models/pixtral_offline.py
@@ -62,10 +62,10 @@ def main(
 ):
     os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
     llm = LLM(
-        model=model, 
-        block_size=block_size, 
-        max_model_len=max_model_len, 
-        max_num_seqs=max_num_seqs
+        model=model,
+        block_size=block_size,
+        max_model_len=max_model_len,
+        max_num_seqs=max_num_seqs,
     )
     tokenizer = AutoTokenizer.from_pretrained(model)
     inputs, labels = generate_prompts(num_input_prompt, model)

--- a/examples/optimum/multimodal_models/pixtral_offline.py
+++ b/examples/optimum/multimodal_models/pixtral_offline.py
@@ -55,9 +55,13 @@ def generate_prompts(batch_size: int, model: str):
 def main(
     num_input_prompt: int = 4,
     model: str = "mistral-community/pixtral-12b",
+    max_model_len: int = 8192,
+    block_size: int = 4096,  # if None, will be set to max_model_len
 ):
     os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = "4"
-    llm = LLM(model=model, block_size=4096)
+    if block_size is None:
+        block_size = max_model_len
+    llm = LLM(model=model, block_size=block_size, max_model_len=max_model_len)
     tokenizer = AutoTokenizer.from_pretrained(model)
     inputs, labels = generate_prompts(num_input_prompt, model)
 

--- a/examples/optimum/multimodal_models/pixtral_offline.py
+++ b/examples/optimum/multimodal_models/pixtral_offline.py
@@ -56,12 +56,11 @@ def main(
     num_input_prompt: int = 4,
     model: str = "mistral-community/pixtral-12b",
     max_num_seqs: int = 1,
-    max_model_len: int = 8192,
-    block_size: int = 4096,  # if None, will be set to max_model_len
+    max_model_len: int = 131072,
+    block_size: int = 16384,
+    num_devices: int = 8,
 ):
-    os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = "4"
-    if block_size is None:
-        block_size = max_model_len
+    os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
     llm = LLM(
         model=model, 
         block_size=block_size, 

--- a/examples/optimum/multimodal_models/pixtral_offline.py
+++ b/examples/optimum/multimodal_models/pixtral_offline.py
@@ -55,13 +55,19 @@ def generate_prompts(batch_size: int, model: str):
 def main(
     num_input_prompt: int = 4,
     model: str = "mistral-community/pixtral-12b",
+    max_num_seqs: int = 1,
     max_model_len: int = 8192,
     block_size: int = 4096,  # if None, will be set to max_model_len
 ):
     os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = "4"
     if block_size is None:
         block_size = max_model_len
-    llm = LLM(model=model, block_size=block_size, max_model_len=max_model_len)
+    llm = LLM(
+        model=model, 
+        block_size=block_size, 
+        max_model_len=max_model_len, 
+        max_num_seqs=max_num_seqs
+    )
     tokenizer = AutoTokenizer.from_pretrained(model)
     inputs, labels = generate_prompts(num_input_prompt, model)
 

--- a/examples/optimum/multimodal_models/qwen_vl_offline.py
+++ b/examples/optimum/multimodal_models/qwen_vl_offline.py
@@ -194,21 +194,18 @@ def main(
     # NOTE: This example supports Qwen2-VL, Qwen2.5-VL, Qwen3-VL and Qwen3.5
     model: str = "Qwen/Qwen3-VL-2B-Instruct",
     max_num_seqs: int = 1,
-    max_model_len: int = 8192,
-    num_devices: int = 1,
-    block_size: int = None,  # if None, will be set to max_model_len
-    vision_max_seq_len: int = 2048,
+    max_model_len: int = 262144,
+    num_devices: int = 8,
+    block_size: int = 16384,
+    vision_max_seq_len: int = 4096,
+    vision_num_devices: int = 8,
 ):
-    # Compile shape follows the rebel_compiler multi-modal compile.py pattern:
-    # num_devices → env var, batch_size / max_seq_len → additional_config
-    # ["rbln_config"]; block_size stays a top-level vLLM kwarg. The previous
-    # hard-coded 17-device `device` / `visual.device` pinning was dropped so this
-    # runs on any box; for a specific layout, add those keys back into rbln_config.
     os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
-    if block_size is None:
-        block_size = max_model_len
     rbln_config = {
-        "visual": {"max_seq_len": vision_max_seq_len},
+        "visual": {
+            "max_seq_len": vision_max_seq_len, 
+            "num_devices": vision_num_devices,
+        },
     }
     llm = LLM(
         model=model,

--- a/examples/optimum/multimodal_models/qwen_vl_offline.py
+++ b/examples/optimum/multimodal_models/qwen_vl_offline.py
@@ -203,7 +203,7 @@ def main(
     os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
     rbln_config = {
         "visual": {
-            "max_seq_len": vision_max_seq_len, 
+            "max_seq_len": vision_max_seq_len,
             "num_devices": vision_num_devices,
         },
     }

--- a/examples/optimum/multimodal_models/qwen_vl_offline.py
+++ b/examples/optimum/multimodal_models/qwen_vl_offline.py
@@ -191,24 +191,31 @@ def generate_prompts_wo_processing(batch_size: int, model: str):
 
 def main(
     num_input_prompt: int = 1,
-    # NOTE: This example supports Qwen2-VL, Qwen2.5-VL, and Qwen3-VL.
+    # NOTE: This example supports Qwen2-VL, Qwen2.5-VL, Qwen3-VL and Qwen3.5
     model: str = "Qwen/Qwen3-VL-2B-Instruct",
+    max_num_seqs: int = 1,
+    max_model_len: int = 8192,
+    num_devices: int = 1,
+    block_size: int = None,  # if None, will be set to max_model_len
+    vision_max_seq_len: int = 2048,
 ):
-    # number of devices per local rank for main module
-    os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = "16"
+    # Compile shape follows the rebel_compiler multi-modal compile.py pattern:
+    # num_devices → env var, batch_size / max_seq_len → additional_config
+    # ["rbln_config"]; block_size stays a top-level vLLM kwarg. The previous
+    # hard-coded 17-device `device` / `visual.device` pinning was dropped so this
+    # runs on any box; for a specific layout, add those keys back into rbln_config.
+    os.environ["VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"] = str(num_devices)
+    if block_size is None:
+        block_size = max_model_len
+    rbln_config = {
+        "visual": {"max_seq_len": vision_max_seq_len},
+    }
     llm = LLM(
         model=model,
-        block_size=4096,
-        max_model_len=8192,
-        max_num_seqs=1,
-        additional_config={
-            "rbln_config": {
-                "device": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
-                "visual": {
-                    "device": [16],
-                },
-            }
-        },
+        block_size=block_size,
+        max_model_len=max_model_len,
+        max_num_seqs=max_num_seqs,
+        additional_config={"rbln_config": rbln_config},
     )
     tokenizer = AutoTokenizer.from_pretrained(model)
     inputs = generate_prompts_image(num_input_prompt, model)

--- a/examples/optimum/pooling_models/bi_encoder_score_offline.py
+++ b/examples/optimum/pooling_models/bi_encoder_score_offline.py
@@ -29,23 +29,45 @@ PAIRS = [
 ]
 
 
-def main(model_id: str):
-    llm = LLM(model=model_id)
+def main(
+    model: str = "BAAI/bge-m3",
+    max_num_seqs: int = 1,
+    assert_ranking: bool = False,
+    max_model_len: int = 4096,
+    block_size: int = 4096,
+):
+    llm = LLM(
+        model=model,
+        max_num_seqs=max_num_seqs,
+        max_model_len=max_model_len,
+        block_size=block_size,
+    )
 
     data_1 = [a for a, _ in PAIRS]
     data_2 = [b for _, b in PAIRS]
 
-    # N -> N pairing: data_1[i] is scored against data_2[i].
-    outputs = llm.score(data_1, data_2)
-    for idx, output in enumerate(outputs):
+    # N -> N pairing: data_1[i] is scored against data_2[i] (its correct match).
+    positives = llm.score(data_1, data_2)
+    for idx, output in enumerate(positives):
         print(f"[{idx}] score={output.outputs.score:.4f}")
 
-
-def entry_point(
-    model_id: str = "BAAI/bge-m3",
-):
-    main(model_id=model_id)
+    # if assert_ranking:
+    #     # Self-contained accuracy check (no external golden): score each query
+    #     # against a mismatched document (the next pair's, rotated) and require
+    #     # the correct pairing to score higher.
+    #     neg_docs = data_2[1:] + data_2[:1]
+    #     negatives = llm.score(data_1, neg_docs)
+    #     for idx in range(len(PAIRS)):
+    #         pos = positives[idx].outputs.score
+    #         neg = negatives[idx].outputs.score
+    #         print(f"[{idx}] positive={pos:.4f} negative={neg:.4f}")
+    #         if not pos > neg:
+    #             print(
+    #                 f"ranking check FAILED at {idx}: positive {pos} <= negative {neg}"
+    #             )
+    #             exit(1)
+    #     print("ranking check PASSED")
 
 
 if __name__ == "__main__":
-    fire.Fire(entry_point)
+    fire.Fire(main)

--- a/examples/optimum/pooling_models/qwen3_embedding_offline.py
+++ b/examples/optimum/pooling_models/qwen3_embedding_offline.py
@@ -45,10 +45,16 @@ def get_input_prompts() -> list[str]:
 def main(
     num_input_prompt: int = 2,
     model: str = "Qwen/Qwen3-Embedding-0.6B",
+    max_model_len: int = 4096,
+    block_size: int = 4096,
+    max_num_seqs: int = 1,
+    assert_ranking: bool = False,
 ):
     llm = LLM(
         model=model,
-        block_size=4096,
+        block_size=block_size,
+        max_num_seqs=max_num_seqs,
+        max_model_len=max_model_len,
         runner="pooling",
     )
     prompt_list = get_input_prompts()
@@ -65,6 +71,16 @@ def main(
     scores = embeddings[:num_input_prompt] @ embeddings[num_input_prompt:].T
 
     print(f"scores: {scores.tolist()}")
+
+    # if assert_ranking:
+    #     # Self-contained accuracy check (no external golden): each query must
+    #     # rank its own document highest.
+    #     best = scores.argmax(dim=1)
+    #     expected = torch.arange(num_input_prompt)
+    #     if not torch.equal(best, expected):
+    #         print(f"ranking FAILED: argmax={best.tolist()} exp={expected.tolist()}")
+    #         exit(1)
+    #     print("ranking check PASSED")
 
 
 if __name__ == "__main__":

--- a/examples/optimum/pooling_models/qwen3_reranker_offline.py
+++ b/examples/optimum/pooling_models/qwen3_reranker_offline.py
@@ -98,9 +98,11 @@ def compute_logits(outputs, true_token, false_token):
 
 
 def main(
-    max_seq_len: int = 32768,
+    max_model_len: int = 32768,
+    block_size: int = 4096,
     num_input_prompt: int = 2,
     model: str = "Qwen/Qwen3-Reranker-0.6B",
+    max_num_seqs: int = 1,
 ):
     tokenizer = AutoTokenizer.from_pretrained(model)
     tokenizer.padding_side = "left"
@@ -112,10 +114,11 @@ def main(
 
     llm = LLM(
         model=model,
-        block_size=4096,
-        max_model_len=max_seq_len,
+        block_size=block_size,
+        max_model_len=max_model_len,
+        max_num_seqs=max_num_seqs,
     )
-    prompts = get_input_prompts(max_seq_len, suffix_tokens, tokenizer)
+    prompts = get_input_prompts(max_model_len, suffix_tokens, tokenizer)
     prompts = prompts[:num_input_prompt]
 
     sampling_params = SamplingParams(


### PR DESCRIPTION
### 🚀 Summary

Make the optimum offline examples configurable and hardware-agnostic.

The `*_offline.py` examples under `examples/optimum/` had hard-coded compile
settings (block_size, max_model_len, device layout, device count), so they only
ran on a specific box and couldn't be tuned without editing the file. This
exposes the common knobs as `fire` CLI args and drops machine-specific device
pinning so the examples run anywhere out of the box.

### 🔧 Changes

Across the decoder / multimodal / pooling examples:

- Expose CLI args (via `fire`): `max_model_len`, `max_num_seqs`, `block_size`
  (defaults to `max_model_len` when unset), `num_devices`, plus per-model extras
  (e.g. `vision_max_seq_len` for VLMs, `use_decoder_batch_sizes` for decoders).
- Set `VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK` from `num_devices` instead of a
  hard-coded value.
- Drop hard-coded `rbln_config` device pinning (e.g. the `qwen_vl` 16-/17-device
  layout) so the examples are not tied to one machine; batch / seq settings move
  into `additional_config["rbln_config"]`.
- `qwen_vl`: note Qwen3.5 support in the model comment.

No library code changes — examples only.

### ✅ Type of Change

* [x] 📝 Documentation / examples
