### PR TITLE
fix(nixl): key KV handshake metadata by (pp_rank, tp_rank)

### DIFF
--- a/tests/native/v1/worker/test_rbln_worker.py
+++ b/tests/native/v1/worker/test_rbln_worker.py
@@ -23,6 +23,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 from torch._dynamo.exc import BackendCompilerFailed
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorBase_V1
 from vllm.v1.worker.worker_base import CompilationTimes, WorkerBase
 
 import vllm_rbln.v1.worker.rbln_worker as wm
@@ -654,3 +655,55 @@ class TestInitWorkerDistributedEnvironment:
     def test_auto_port_sets_rccl_env(self, monkeypatch):
         _, _, rccl = self._run(monkeypatch, auto_port=True, has_torch_rbln=True)
         assert rccl == "1"
+
+
+class TestHandshakeMetadata:
+    # The producer half of vllm's handshake contract: EngineCore merges these
+    # per-worker dicts and hands the result to the connector.
+    @staticmethod
+    def _metadata(
+        make_worker,
+        monkeypatch,
+        *,
+        pp_rank=0,
+        tp_rank=0,
+        metadata="META",
+        has_group=True,
+    ):
+        worker = make_worker()
+        monkeypatch.setattr(wm, "has_kv_transfer_group", lambda: has_group)
+        monkeypatch.setattr(
+            wm,
+            "get_kv_transfer_group",
+            lambda: SimpleNamespace(get_handshake_metadata=lambda: metadata),
+        )
+        monkeypatch.setattr(
+            wm, "get_tp_group", lambda: SimpleNamespace(rank_in_group=tp_rank)
+        )
+        monkeypatch.setattr(
+            wm, "get_pp_group", lambda: SimpleNamespace(rank_in_group=pp_rank)
+        )
+        return worker.get_kv_connector_handshake_metadata()
+
+    def test_key_is_pp_tp_pair(self, make_worker, monkeypatch):
+        assert self._metadata(make_worker, monkeypatch, pp_rank=1, tp_rank=2) == {
+            (1, 2): "META"
+        }
+
+    def test_upstream_hook_takes_the_keys(self, make_worker, monkeypatch):
+        # Runs vllm's own implementation over the merged dict, so a contract
+        # change upstream fails here instead of at engine-core init.
+        merged = self._metadata(make_worker, monkeypatch, tp_rank=1)
+        received: dict = {}
+        KVConnectorBase_V1.set_xfer_handshake_metadata_pp_aware(
+            SimpleNamespace(set_xfer_handshake_metadata=received.update), merged
+        )
+        assert received == {1: "META"}
+
+    def test_returns_none_without_kv_transfer_group(self, make_worker, monkeypatch):
+        assert self._metadata(make_worker, monkeypatch, has_group=False) is None
+
+    def test_returns_none_when_connector_has_no_metadata(
+        self, make_worker, monkeypatch
+    ):
+        assert self._metadata(make_worker, monkeypatch, metadata=None) is None

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -43,6 +43,9 @@ from vllm.distributed.kv_transfer import (
     get_kv_transfer_group,
     has_kv_transfer_group,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorHandshakeMetadata,
+)
 from vllm.distributed.parallel_state import get_pp_group, get_tp_group
 from vllm.platforms import current_platform
 from vllm.profiler.wrapper import TorchProfilerWrapper
@@ -373,8 +376,13 @@ class RBLNWorker(WorkerBase):
 
         return available_memory_estimate
 
-    def get_kv_connector_handshake_metadata(self) -> dict | None:
-        """Get KV connector metadata from this worker if available."""
+    def get_kv_connector_handshake_metadata(
+        self,
+    ) -> dict[tuple[int, int], KVConnectorHandshakeMetadata] | None:
+        """Get KV connector metadata from this worker if available.
+
+        Returned dict is keyed by ``(pp_rank, tp_rank)``.
+        """
 
         if not has_kv_transfer_group():
             return None
@@ -385,8 +393,9 @@ class RBLNWorker(WorkerBase):
         if (metadata := connector.get_handshake_metadata()) is None:
             return None
 
+        pp_rank = get_pp_group().rank_in_group
         tp_rank = get_tp_group().rank_in_group
-        return {tp_rank: metadata}
+        return {(pp_rank, tp_rank): metadata}
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         return self.model_runner.get_kv_cache_spec()


### PR DESCRIPTION
## What breaks

Every disaggregated prefill/decode case with a NIXL-family connector dies at engine-core init on `dev`:

```
File "vllm/distributed/kv_transfer/kv_connector/v1/base.py", line 667, in <genexpr>
  if any(pp_rank != 0 for pp_rank, _ in metadata):
TypeError: cannot unpack non-iterable int object
```

## Why

`dev` moved the vllm pin 0.22.0 → 0.24.0, and 0.24.0 changed the **producer-side** contract for handshake metadata. `EngineCore.__init__` now merges the per-worker dicts and calls `set_xfer_handshake_metadata_pp_aware()`, whose default implementation is:

```python
def set_xfer_handshake_metadata_pp_aware(
    self, metadata: dict[tuple[int, int], KVConnectorHandshakeMetadata]
) -> None:
    if any(pp_rank != 0 for pp_rank, _ in metadata):
        raise ValueError(...)
    self.set_xfer_handshake_metadata(
        {tp_rank: meta for (_, tp_rank), meta in metadata.items()}
    )
```

`RBLNWorker.get_kv_connector_handshake_metadata()` still returned `{tp_rank: metadata}`, so iterating those keys unpacks an `int`.

In vllm 0.22.0 the pp-aware hook does not exist at all — `set_xfer_handshake_metadata(metadata: dict[int, ...])` is the only contract there, and `{tp_rank: metadata}` is the *correct* shape. So this is not a latent bug that surfaced; it is the 0.24.0 bump arriving without its adaptation.

## Fix

Two lines in the producer. **The consumer side needs nothing** — 0.24.0's default implementation already accepts a non-PP connector, as long as every `pp_rank` is 0, and flattens the pair back itself.

## Why it was not caught earlier

The failure is a property of the pairing, not of either side alone:

| vllm | hook the engine calls | key shape it expects | `{tp_rank: …}` |
|---|---|---|---|
| 0.22.0 | `set_xfer_handshake_metadata` | `dict[int, …]` | correct |
| 0.24.0 | `set_xfer_handshake_metadata_pp_aware` | `dict[tuple[int, int], …]` | **TypeError** |

Any CI that holds vllm at 0.22.0 stays green, because at that pin the current shape is the right one. The break is only visible where `dev`'s 0.24.0 pin is actually resolved. That asymmetry is what identified the version boundary rather than a code regression.

## Relation to #901

#901 carries this same correction as part of pipeline-parallel KV transfer. This PR extracts just the two lines so the regression is not gated on that feature landing — #901 keeps its own review, and rebasing it over this is a no-op for the changed lines.

The test is #901's handshake test, trimmed to what this change alone guarantees (PP-stage merge coverage stays with the feature). It is mock-based — no device, no peer. `test_upstream_hook_takes_the_keys` drives vllm's own `set_xfer_handshake_metadata_pp_aware` over the merged dict, so a further upstream contract change fails there instead of at engine-core init.

## Verification

Not run locally: no vllm wheel for this platform, so `pytest` cannot import `vllm_rbln` here. `ruff check`, `ruff format`, `typos` and `mypy` pass via pre-commit.

End-to-end validation was run out-of-band against a disaggregated prefill/decode deployment of a large MoE checkpoint at DP=4 with expert parallelism, on vllm 0.24.0 with this branch pinned and every other component frozen to the control's resolved version:

- **control** (this branch excluded): fails at engine-core init, `cannot unpack` × 12
- **this branch**: prefill and decode both reach ready, the NIXL handshake completes, and `cannot unpack` appears **0 times** in the prefill, decode, router and node logs

Reviewers who need the run artifacts: ask me internally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
