### PR TITLE
model: register Qwen3 MoE model (#916)

### DIFF
--- a/vllm_rbln/utils/optimum/registry.py
+++ b/vllm_rbln/utils/optimum/registry.py
@@ -32,6 +32,7 @@ _RBLN_GENERATION_MODELS: dict[str, tuple[str, str]] = {
     "Qwen2ForCausalLM": ("qwen2", "RBLNQwen2ForCausalLM"),
     "OPTForCausalLM": ("opt", "RBLNOPTForCausalLM"),
     "Qwen3ForCausalLM": ("qwen3", "RBLNQwen3ForCausalLM"),
+    "Qwen3MoeForCausalLM": ("qwen3_moe", "RBLNQwen3MoeForCausalLM"),
     "GptOssForCausalLM": ("gpt-oss", "RBLNGptOssForCausalLM"),
 }
 


### PR DESCRIPTION
Cherry-pick of #916 (squash 0394b0436b) from dev onto release-v0.11.1.post1.

- Registers Qwen3MoeForCausalLM → RBLNQwen3MoeForCausalLM in `vllm_rbln/utils/optimum/registry.py` (+1 line)
- Applied cleanly on release-v0.11.1 HEAD (2fcac61e); verified the resulting diff is identical to #916
- Confirmed `RBLNQwen3MoeForCausalLM` exists in optimum-rbln v0.11.1, so the registry entry resolves on the 0.11.1 pairing
