### PR TITLE
refactor(worker): rename _build_forward_inputs to _maybe_build_mm_forward_inputs

### DIFF
--- a/vllm_rbln/v1/worker/optimum_model_runner.py
+++ b/vllm_rbln/v1/worker/optimum_model_runner.py
@@ -395,7 +395,7 @@ class RBLNOptimumModelRunner(
                         )
                 else:
                     with capture_ctx as model_reports:
-                        model_input = self._build_forward_inputs(model_input)
+                        model_input = self._maybe_build_mm_forward_inputs(model_input)
                         hidden_states = self.model(model_input)
                 if (
                     envs.VLLM_RBLN_METRICS
@@ -462,9 +462,13 @@ class RBLNOptimumModelRunner(
             return False
         return True
 
-    def _build_forward_inputs(
+    def _maybe_build_mm_forward_inputs(
         self, model_input: ModelInputForRBLN
     ) -> ModelInputForRBLN:
+        """Build multimodal forward inputs (embeddings, MRoPE positions).
+
+        Pass-through for models without multimodal support.
+        """
         model = self.model
         if not isinstance(model, RBLNOptimumMultimodalMixin):
             return model_input


### PR DESCRIPTION
Stacked on #933.

`_build_forward_inputs` only builds multimodal forward inputs (embeddings, MRoPE positions) and is a pass-through for every other model. The old name read like a mandatory input-building step for all models and overlapped with `_prepare_inputs`, which made the input-building flow in the optimum model runner hard to follow. The `maybe_` prefix follows the existing convention (`maybe_get_ec_connector_output`) for conditional pass-through helpers, and the `build_forward_inputs` core keeps the correspondence with the model-side `build_prefill_forward_inputs`.

Pure rename plus a docstring; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)