### PR TITLE
docs(agent): set the conventions that keep agent-written changes reviewable

### DIFF
--- a/.claude/skills/debugging/SKILL.md
+++ b/.claude/skills/debugging/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: debugging
+description: Use when investigating a bug, a failing test, or unexpected behavior in vllm-rbln — the environment and model-path traps that make a reproduction lie, and the evidence rules that keep a wrong cause from looking confirmed.
+---
+
+# Debugging vllm-rbln
+
+Two things make a debugging session go wrong here: reproducing something other than the reported bug, and confirming a cause that is not the cause. This skill is about those. It does not restate general debugging method.
+
+## 1. Before you trust the reproduction
+
+Get a reproducer before changing anything, and narrow it to the smallest input and configuration that still fails.
+
+**If you cannot reproduce it, stop and report that.** Do not fix a bug you have not seen. An untested fix for an unverified report costs a reviewer more than no patch.
+
+Check these before concluding anything, because each one makes a reproduction silently exercise something other than what you think:
+
+- **`tests/native/` scrubs `VLLM_RBLN_*`.** Exported values do not reach it; the session options are the only way in. A knob you "set" may never have applied.
+- **`--device-tensor` is session-wide.** `platform.py` resolves it at module scope, so a per-test attempt to change it does nothing and the test still passes.
+- **Marks decide the process.** `use_device` and `model_compile` items run in a spawned child. A failure that only appears in one of the two contexts is about the process, not the logic.
+
+## 2. Make the evidence discriminate
+
+Evidence that fits your hypothesis is easy to find and proves nothing — a wrong cause has confirming evidence too. Force the evidence to choose between explanations: an observation that every candidate predicts has narrowed nothing.
+
+- **State what would be true if you are wrong**, and check that specifically.
+- **Predict the output before you run.** Write down what you expect. Matching means your model of the system is right; a surprise means it is wrong, and that is the finding.
+- **The cause must explain every symptom**, not just the loudest one. A leftover unexplained detail usually means a second cause or the wrong one.
+
+Report which parts you verified and which you inferred. Never state a hypothesis as a fact.
+
+## 3. Fix the cause, not its surroundings
+
+Change the thing that is wrong — not a caller, not a wrapper, not a guard around the symptom.
+
+A workaround is allowed when the real fix is out of reach, as long as it is declared: name the cause, say why the fix is out of reach, and get agreement. A patch under `patches/` is that shape, with the `reason` recording what upstream cannot express and review deciding whether to accept it. What is not allowed is a guard added because you could not find the cause.
+
+## 4. If the fix does not work, discard it
+
+Revert it and form another hypothesis. Do not stack a second patch on a failed first one.
+
+A failed fix is information: the cause was probably wrong. Go back to step 2 rather than making the current theory work harder.
+
+Never widen an exception, add a default, or skip a branch to make the failure go away. Reaching for that means you are fixing without a cause.
+
+## 5. Verify against the reproducer
+
+Run the reproducer again, plus the tests around the code you touched, and read the output. A fix that has not been run is not a fix. Say so plainly if you could not run it.
+
+## 6. Check both model paths
+
+- Which path does the bug live on?
+- Does the same defect exist on the other path?
+- Does the fix change behavior on the other path?
+
+Only `__init__.py` and `platform.py` branch on the flag. If the fix seems to need a new `if envs.VLLM_RBLN_USE_VLLM_MODEL` anywhere else, the shape is wrong — stop and ask.
+
+## 7. Report the gaps
+
+State explicitly what you could not build, run, or reproduce; hardware or models you did not have; and anything you inferred rather than verified.
+
+Tests that broke after your change are your regressions. Debug them. Do not stash or revert to check whether they also fail on `main`.

--- a/.claude/skills/finishing-a-change/SKILL.md
+++ b/.claude/skills/finishing-a-change/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: finishing-a-change
+description: Use before claiming a change is done, fixed, ready, or passing, and before writing a commit or PR — runs the checks, reviews the diff against the repository rules, and reports what was not done.
+---
+
+# Finishing a change
+
+By the time you get here the session is long and the instructions you read at the start have faded. Work through this list rather than from memory.
+
+## 1. Run the hooks
+
+```bash
+uvx pre-commit run --files <every file you changed>
+```
+
+`pre-commit` is not a project dependency; `uvx` is how it runs here. Read the output. Passing means you saw it pass.
+
+A new `.py` file must carry the Apache header, or `check-license-header` fails.
+
+## 2. Run the tests
+
+Run the tests covering what you changed, and include the command and its result in your reply. "Should pass" is not a result. If you could not run them, say that instead of implying you did.
+
+## 3. Read your own diff
+
+```bash
+git diff
+```
+
+Look for each of these:
+
+- **Files nobody asked for** — docs, examples, scripts, changelogs
+- **Scratch files** left over from iterating
+- **Single-use helpers** that should be inlined
+- **Abstractions** built for one call site
+- **Comments that narrate the code**, describe your changes, or address the reader
+- **Comments added to code you did not otherwise change**
+- **Swallowed failures** — `except Exception`, bare `except`, `except: pass`, an unrequested fallback or default
+- **`else` branches for cases that cannot happen** — should be `assert` or `raise`
+- **Dead leftovers** — renamed `_var`, unused re-exports, `# removed` comments
+- **Anything not in English**
+
+Repository-specific checks:
+
+- No new branch on `VLLM_RBLN_USE_VLLM_MODEL` outside `__init__.py` and `platform.py`.
+- A new env var must appear in **three** places in `envs.py`: the `TYPE_CHECKING` block, the `environment_variables` dict, and either `RBLN_COMPILE_ENV` or `RBLN_NON_COMPILE_ENV`.
+- No `model_compile`, `use_device`, or `maybe_use_device` mark under `tests/optimum/` — nothing gates them there.
+- No `test_*.py` under `tests/optimum/optimum_correctness/` — those are `fire` scripts.
+- No test that is skipped as a placeholder.
+
+## 4. Report what you did not do
+
+State it explicitly, every time:
+
+- Tests you could not run, and why
+- Hardware or models you did not have
+- Assumptions you could not verify
+- Parts of the request you left out
+
+An empty list is a claim. Only write it if it is true.
+
+## 5. Write the commit and PR
+
+- `type(scope): summary`, matching the existing history
+- Explain intent, not the diff
+- Say which model path or paths the change affects
+- English

--- a/.claude/skills/writing-tests/SKILL.md
+++ b/.claude/skills/writing-tests/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: writing-tests
+description: Use when adding or modifying tests under tests/native/ — covers placement, the model_compile/use_device/maybe_use_device marks, the session options, and proving a new test fails before the change it covers.
+---
+
+# Writing tests in the native suite
+
+## Scope
+
+This skill covers `tests/native/`, the vLLM-native path.
+
+For `tests/optimum/` the conventions are not settled. Do not carry the rules below into that suite — the marks and session options gate nothing there. Follow the patterns in the nearest existing directory, and ask before introducing a new one.
+
+## 1. Design before writing
+
+Answer these four before you write a line. If you cannot, ask instead of guessing.
+
+1. What is the module under test for?
+2. What is its input/output contract?
+3. What failure is this test guarding against?
+4. What is the cheapest level that catches that failure? Prefer unit over integration over whole-model.
+
+## 2. Where the file goes
+
+Mirror the source tree:
+
+```
+vllm_rbln/<path>/<module>.py  ->  tests/native/<path>/test_<module>.py
+```
+
+Root modules (`envs.py`, `platform.py`, …) get root-level files in `tests/native/`.
+
+Two directories are not mirrors. They hold whole-model tests, split by the question the test asks:
+
+- `compile/` — does it compile and run at all? Smoke over large models, no reference output.
+- `basic_correctness/` — is the output right? Greedy generation compared against an HF reference on small models.
+
+`compilation/` is the mirror of `vllm_rbln/compilation/` and holds unit tests only — option building, backend conformance, no NPU. A test that actually compiles a model belongs in one of the two directories above, not here.
+
+## 3. Marks
+
+Marks decide whether an item runs at all and whether it runs in this process or a fresh one. Getting one wrong is expensive, and the filename does not help — `conftest.py` reads only the mark.
+
+| Mark               | Effect                                                                          |
+| ------------------ | ------------------------------------------------------------------------------- |
+| `model_compile`    | Whole-model compile, minutes. Skipped unless `--model-compile`. Always spawned.  |
+| `use_device`       | Always opens the NPU. Always spawned.                                            |
+| `maybe_use_device` | Opens the NPU only under device tensors. Spawned when `device_type != "cpu"`.    |
+| none               | Runs in this process.                                                            |
+
+Spawning is not an optimization. A test that opens the device in the parent process pins it for the rest of the session, so `use_device` and `maybe_use_device` exist to force a fresh process.
+
+Compiling an individual op is deliberately left unmarked so it stays in the default lane. Only a whole-model compile takes `model_compile`.
+
+`--strict-markers` turns a misspelled mark into a collection error, so a wrong name fails loudly. A mark you leave off does not: forgetting `model_compile` puts a multi-minute test into the lane that runs on every PR.
+
+## 4. Naming end-to-end tests
+
+Name a file `*_e2e.py` when every test in it is a whole-model compile. Skip the suffix where the directory already says it — `basic_correctness/`, `compile/`.
+
+There is no `e2e/` directory today; four such files sit in four different subsystems, and one-file directories would be worse. When a single directory reaches three of them, move them into an `e2e/` subdirectory there, matching upstream's `tests/v1/e2e/`.
+
+## 5. Session options
+
+Read `tests/native/conftest.py` for the full text; the constraints that bite:
+
+- `--device-tensor {0,1}` is session-wide. `platform.py` resolves it at module scope and several modules copy the value into their own namespace, so it **cannot** be parametrized per test. Run the suite once per value.
+- `--num-hidden-layers N` builds only the first N decoder layers to cut compile time, and `hf_runner` truncates to the same N so comparisons stay like-for-like. Default is 3; `0` means the whole model.
+- The suite scrubs exported `VLLM_RBLN_*` variables. These options are the way in — do not read the environment directly to get around them.
+
+## 6. Reuse what is there
+
+Check before adding anything new:
+
+- `tests/native/conftest.py`, and the local `conftest.py` in your subdirectory
+- `tests/native/utils.py`, `runners.py`, `model_specs.py`, `vllm_config.py`
+- the `utils.py` beside your target, e.g. `v1/worker/utils.py`
+
+Shared helpers go in the `utils.py` nearest to their users. Do not add a new `helpers_*.py`.
+
+A new file needs the Apache header every other file carries, and a package directory needs an `__init__.py`. Copy both from a sibling.
+
+## 7. Prove the test fails
+
+A test that passes without the change covers nothing. Before you commit:
+
+```bash
+git stash push -- <production files only>
+uv run --no-sync pytest <your new test> -x   # must fail
+git stash pop
+```
+
+Watch it fail and read the failure — a test can fail for the wrong reason. If running it is impossible here, say so explicitly rather than assuming it is red.
+
+## 8. Reject these
+
+- Asserting a statically defined value against itself
+- Testing wiring with no behavior behind it
+- A negative test for logic that was removed
+- Duplicating the implementation's logic inside the test
+- Mocking what a real object or a temporary directory would do
+- A placeholder test that is skipped
+- A test diff larger than the code change it covers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,139 @@
+# Agent instructions for vllm-rbln
+
+vllm-rbln is a vLLM platform plugin for Rebellions NPUs. Source lives in `vllm_rbln/`, tests in `tests/`.
+
+Two documents own their subjects; read them rather than duplicating them here:
+
+- Environment setup, dependency and lockfile policy: `DEVELOPMENT.md`
+- PR process and issue labels: `CONTRIBUTING.md`
+
+## Commands
+
+Run everything through `uv`. Never use the system `python3` or a bare `pip`.
+
+```bash
+uv run --no-sync pytest tests/native/v1/worker/test_rbln_worker.py -x
+uvx pre-commit run --files <every file you changed>
+```
+
+Pick the narrowest test target that covers the change. `pre-commit` is not a project dependency, so run it through `uvx`. Passing `--files` explicitly keeps the run independent of what happens to be staged.
+
+A new `.py` file needs the Apache header that every other file carries; `check-license-header` rejects it otherwise. Copy the header from a neighbouring file.
+
+`tests/native/` defines three session options (see its `conftest.py`):
+
+- `--model-compile` — opt into whole-model compiles, minutes per test
+- `--device-tensor {0,1}` — session-wide, cannot be parametrized per test
+- `--num-hidden-layers N` — build only the first N decoder layers
+
+They do not exist in `tests/optimum/`.
+
+## Terms
+
+The codebase already has a word for each of these. Use it, and do not reach for a synonym because the sentence reads better.
+
+- **model path** — which model implementation runs. The two are the **optimum-rbln path** and the **vLLM-native path**; `optimum` and `native` are the short forms. Not "backend", not "mode". `torch.compile` describes how the native path works and is not its name.
+- **suite** — a top-level test tree: `tests/native/`, `tests/optimum/`.
+- **lane** — a slice of a suite selected by a flag, a mark, or the device mode: the default lane, the `--model-compile` lane, the cpu and device lanes.
+
+## Two model paths
+
+`VLLM_RBLN_USE_VLLM_MODEL` selects the model path at startup: unset or `0` is optimum-rbln, `1` is vLLM-native.
+
+| Path         | Owns                                                                        |
+| ------------ | --------------------------------------------------------------------------- |
+| optimum-rbln | `model_executor/models/optimum/`, `utils/optimum/`, `v1/worker/optimum_*.py` |
+| vLLM-native  | `patches/`, `compilation/`, `v1/worker/rbln_*.py`                            |
+| shared       | everything else                                                              |
+
+**`envs.py` defines the flag; only `__init__.py` and `platform.py` branch on it.** Do not branch on `VLLM_RBLN_USE_VLLM_MODEL` anywhere else. Path-specific code belongs in the module that path owns.
+
+- Say which path or paths you changed in the PR description.
+- A change to one path must not alter the other. If it appears to need both, stop and ask before writing code.
+- A new env var goes in three places in `envs.py`: the `TYPE_CHECKING` block, the `environment_variables` dict, and either `RBLN_COMPILE_ENV` or `RBLN_NON_COMPILE_ENV`. The two sets partition the mega-cache bundle key, and `test_mega_cache.py` asserts they cover every variable.
+- Suites carry the path: `tests/native/` sets it to `1` in its conftest and scrubs `VLLM_RBLN_*`; `tests/optimum/` has no suite-level conftest and takes the default. An exported `VLLM_RBLN_USE_VLLM_MODEL` therefore changes what `tests/optimum/` exercises without failing.
+- Do not set `VLLM_RBLN_USE_VLLM_MODEL` inside a test to escape its suite.
+
+## Patching upstream vLLM
+
+`vllm_rbln/patches/` adapts upstream vLLM for RBLN. Both mechanisms live in `patches/registry.py`, both take a required `reason`, and `register_ops()` applies registrations before patches — on the native path only.
+
+**Use upstream's own extension points first.** `@add_registration` wraps a callback that registers through a vLLM API: `base_cls.register_oot(...)`, a `PlatformEnum.OOT` entry in a kernel registry, and so on. `patches/oot.py` is the worked example. A registration survives an upstream refactor; a replaced symbol does not.
+
+**`@register_patch` overwrites an upstream symbol and is the last resort.** Use it only when no extension point exists, and make `reason` say what upstream cannot express — not what the replacement does. When you are unsure whether an extension point exists, ask instead of defaulting to a patch.
+
+- Never `setattr` an upstream symbol directly. Every replacement goes through the registry, which verifies that it took.
+- A new module under `patches/` must be added to the import list in `patches/__init__.py`. A decorator in a module nobody imports registers nothing.
+- Duplicate keys and duplicate targets raise. Two patches may share a target only when their `condition` predicates are mutually exclusive.
+- `priority` applies `0` first and `100` last, default `50`. `apply_immediately` patches at import time, for targets that import-time code snapshots before `apply_registered_patches()` runs; it cannot be combined with an explicit `priority`.
+- Pass `verify` when "the attribute is now our object" does not prove the patch took effect.
+
+## Language
+
+Everything in the repository is written in English: code, comments, docstrings, log and error messages, test names, docs, commit messages, PR titles and bodies. This extends the English requirement in `CONTRIBUTING.md`.
+
+Conversation with the user is not a repository artifact. Reply in the language the user writes in.
+
+## Scope
+
+- Look for an existing utility or mechanism before writing a significant amount of new code.
+- Do not create a helper that is called once. Inline it.
+- Do not build an abstraction for a single use. Three similar lines beat a premature abstraction.
+- Do not add error handling for states that cannot occur.
+- Do not create files nobody asked for — docs, examples, scripts, changelogs.
+- Delete the scratch files you made while iterating.
+- Prefer fixing the underlying problem over a local workaround, even when that means a larger refactor. If the refactor is out of scope, say so and ask.
+
+## Failure handling
+
+Code either succeeds or fails with a clear error.
+
+- Do not catch `Exception` or use a bare `except` to get past a problem.
+- `except: pass` and `except: continue` hide the failure. Do not write them.
+- Do not route a case that cannot happen into an `else`. Use `assert` or `raise`. An `if` is for two paths that both really occur.
+- Do not add a fallback, a default, or a silent recovery that was not asked for.
+- Delete removed code completely: no renamed `_var` leftovers, no dead re-exports, no `# removed` comments.
+
+## Comments
+
+- Do not restate what the code says. If a comment narrates the next line, delete it and let the name carry the meaning.
+- Do not describe your changes or address the reader in a comment. The commit message and the PR body are for that.
+- Do not add or edit comments in code you did not otherwise change.
+- Comments are for invariants, non-obvious constraints, and why an unusual approach was taken. These may be long; explain them properly. The module comments in `vllm_rbln/__init__.py` and `vllm_rbln/envs.py` are the intended level.
+- Assume the reader knows vLLM and RBLN hardware.
+
+## Tests
+
+- A test must fail without the change it covers. Verify that; do not assume it.
+- Cover what the change touched. Do not test pre-existing logic, third-party functions, or statically defined values.
+- If the test diff dwarfs the code change, cut scope.
+- Extend an existing file, `conftest.py` fixture, or `utils.py` helper before adding a new file.
+- Do not add a test that is skipped as a placeholder. A test that never runs covers nothing while reading as coverage that exists.
+- `--strict-markers` turns a misspelled mark into a collection error, but a mark you leave off is silent. Forgetting `model_compile` is how a whole-model compile ends up in the lane that runs on every PR.
+- The `model_compile`, `use_device`, and `maybe_use_device` marks exist in `tests/native/` only.
+- `tests/optimum/optimum_correctness/` holds `fire` CLI scripts, not pytest tests. Do not add `test_*.py` there.
+
+## Reporting
+
+- If you cannot finish, do not produce a plausible partial result. Stop and say what blocked you.
+- End every task by saying what you did not do: tests you could not run, hardware you do not have, assumptions you could not check.
+- Do not state a hypothesis as a fact.
+- Tests that break after your change are your regressions. Debug them. Do not stash or revert to check whether they also fail on `main`.
+
+## When a rule is in the way
+
+Some of the rules above cost something to follow. When you believe a case is a real exception — a comment no naming can replace, a workaround whose root fix is out of scope, a change that must touch both model paths — stop and ask before writing the code. Do not decide it alone, and do not work around it quietly.
+
+## Commits and PRs
+
+Follow the existing convention: `type(scope): summary`, for example `fix(mega-cache): key the bundle on the warm-up graph set`.
+
+Explain intent. The diff already shows what changed, so a message that narrates it adds nothing.
+
+## Skills
+
+Read and follow the matching skill before you start:
+
+- Adding or changing tests under `tests/native/`: `.claude/skills/writing-tests/SKILL.md`
+- Investigating a bug, a test failure, or unexpected behavior: `.claude/skills/debugging/SKILL.md`
+- Before claiming a change is done: `.claude/skills/finishing-a-change/SKILL.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

Coding agents here tend to write more than the task needs. The output looks reasonable, but it is verbose and over-engineered, and the same shapes come back in every PR:

- Abstractions and helpers built for a single call site
- Comments that restate the line below them, or explain the change to the reader
- A fallback or a silent recovery instead of fixing the cause
- Tests that pass whether the code is write or wrong, so they read as coverage without being coverage

Nothing in the repo says not to do this, so each agent guesses, and reviewers catch it by hand one time at a time. This writes the rules down once.

`AGENTS.md` holds the rules that apply to any change, and `CLAUDE.md` is a one line pointer to it:

- The model path split is the key part. `VLLM_RBLN_USE_VLLM_MODEL` divides the code in two, and only `__init__.py` and `platform.py` are allowed to branch on it.
- A short `Terms` section pins the words we already mix: model path, suite, lane.
- Scope, failure handling, comments, tests and reporting each get a short list. Every rule is written so a reviewer can point at it and say yes or no, and where a rule needs a limit it has a number rather than an adjective.

Three skills under `.claude/skills/` carry the steps that only matter at one moment, which keeps them out of the always loaded file:

- `writing-tests`: where a test goes in `tests/native/`, which mark it needs, and how to prove it fails before the fix
- `debugging`: the traps that make a reproduction lie, and the rules that stop a wrong cause from looking confirmed
- `finishing-a-change`: the check before calling a change done

What I expect from this:

- Smaller diffs, because the file says no helper for one call site and no files nobody asked for
- Fewer silent workarounds, because code either works or fails with a clear error
- Fewer empty tests, because a test has to fail before the fix and the agent has to show that it did
- Faster review;, because reviewers point at a rule instead of writing the same comment again
- Less repeated explaining, since new agents and new people read the same file

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [x] 📄 Documentation (`docs`)

---

### 🧪 How to Test

1. Hooks: `uvx pre-commit run --files AGENTS.md CLAUDE.md .claude/skills/*/SKILL.md`
2. Spot check the facts against `tests/native/conftest.py` for the marks and session options, and `vllm_rbln/patches/registry.py` for the patch rules

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

Neither model path changes. Docs only.

`tests/optimum/` rules are not settled. The marks and session options are native only. The test skill says so plainly, because an agent that has only seen the native rules would apply them where they gate nothing.

---
