### PR TITLE
feature(metrics): report DP prefill-padded decode as its own phase

### DIFF
--- a/tests/native/v1/worker/test_metrics_v2.py
+++ b/tests/native/v1/worker/test_metrics_v2.py
@@ -73,11 +73,11 @@ class TestMetrics:
 
 class TestSampleMerged:
     def test_latency_sums_and_model_phase_is_kept(self):
-        model = mm._Sample(latency=1.0, phase=True)
+        model = mm._Sample(latency=1.0, phase=mm._Phase.PREFILL)
         sampler = mm._Sample(latency=0.5, phase=None)
         merged = model.merged(sampler)
         assert merged.latency == 1.5
-        assert merged.phase is True  # keeps the model span's phase, not other's
+        assert merged.phase == mm._Phase.PREFILL  # keeps the model span's phase
 
     def test_add_is_none_only_when_both_none_else_treats_none_as_zero(self):
         a = mm._Sample(latency=1.0, host=0, device=None, ccl=5, prepare=None)
@@ -184,10 +184,10 @@ def _fake_clock(monkeypatch):
     return clock
 
 
-def _run_pass(ctx, is_prefill, with_sampler=True):
+def _run_pass(ctx, is_prefill, with_sampler=True, padded_decode=False):
     """Drive one execute_model pass the way the runner decorators do."""
     ctx.start_e2e()
-    with ctx.profile_model(is_prefill=is_prefill):
+    with ctx.profile_model(is_prefill=is_prefill, padded_decode=padded_decode):
         pass
     if with_sampler:
         with ctx.profile_sampler():
@@ -199,18 +199,20 @@ class TestPerformanceContextStateMachine:
     def test_model_then_sampler_merges_and_records(self, monkeypatch):
         ctx = _ctx(monkeypatch)
         ctx._submit(
-            mm._Sample(1.0, host=10, device=20, ccl=30, prepare=5, phase=True),
+            mm._Sample(
+                1.0, host=10, device=20, ccl=30, prepare=5, phase=mm._Phase.PREFILL
+            ),
             is_sampler=False,
         )
         # Model span alone stays pending -- nothing recorded yet.
-        assert ctx._metrics[True].call_count == 0
+        assert ctx._metrics[mm._Phase.PREFILL].call_count == 0
         assert ctx._pending is not None
 
         ctx._submit(
             mm._Sample(0.5, host=1, device=2, ccl=3, prepare=4, phase=None),
             is_sampler=True,
         )
-        m = ctx._metrics[True]
+        m = ctx._metrics[mm._Phase.PREFILL]
         assert m.latencies == [1.5]
         assert (m.host_times, m.device_times) == ([11], [22])
         assert (m.ccl_times, m.prepare_times) == ([33], [9])
@@ -219,34 +221,52 @@ class TestPerformanceContextStateMachine:
     def test_sampler_without_pending_is_ignored(self, monkeypatch):
         ctx = _ctx(monkeypatch)
         ctx._submit(mm._Sample(0.5, phase=None), is_sampler=True)
-        assert ctx._metrics[True].call_count == 0
-        assert ctx._metrics[False].call_count == 0
+        assert ctx._metrics[mm._Phase.PREFILL].call_count == 0
+        assert ctx._metrics[mm._Phase.DECODE].call_count == 0
 
     def test_flush_pending_records_model_only(self, monkeypatch):
         # A model step with no following sampler is recorded model-only on flush.
         ctx = _ctx(monkeypatch)
-        ctx._submit(mm._Sample(2.0, host=7, phase=False), is_sampler=False)
+        ctx._submit(mm._Sample(2.0, host=7, phase=mm._Phase.DECODE), is_sampler=False)
         ctx._flush_pending()
-        assert ctx._metrics[False].latencies == [2.0]
-        assert ctx._metrics[False].host_times == [7]
+        assert ctx._metrics[mm._Phase.DECODE].latencies == [2.0]
+        assert ctx._metrics[mm._Phase.DECODE].host_times == [7]
         assert ctx._pending is None
 
     def test_prefill_and_decode_go_to_separate_buckets(self, monkeypatch):
         ctx = _ctx(monkeypatch)
-        ctx._submit(mm._Sample(1.0, phase=True), is_sampler=False)
+        ctx._submit(mm._Sample(1.0, phase=mm._Phase.PREFILL), is_sampler=False)
         ctx._submit(mm._Sample(0.5, phase=None), is_sampler=True)
-        ctx._submit(mm._Sample(0.2, phase=False), is_sampler=False)
+        ctx._submit(mm._Sample(0.2, phase=mm._Phase.DECODE), is_sampler=False)
         ctx._submit(mm._Sample(0.1, phase=None), is_sampler=True)
-        assert ctx._metrics[True].latencies == [1.5]
-        assert ctx._metrics[False].latencies == pytest.approx([0.3])
+        assert ctx._metrics[mm._Phase.PREFILL].latencies == [1.5]
+        assert ctx._metrics[mm._Phase.DECODE].latencies == pytest.approx([0.3])
+
+    def test_padded_decode_gets_its_own_bucket(self, monkeypatch):
+        ctx = _ctx(monkeypatch)
+        _run_pass(ctx, is_prefill=False)
+        _run_pass(ctx, is_prefill=False, padded_decode=True)
+        assert ctx._metrics[mm._Phase.DECODE].call_count == 1
+        assert ctx._metrics[mm._Phase.PADDED_DECODE].call_count == 1
+        assert ctx._e2e[mm._Phase.DECODE].call_count == 1
+        assert ctx._e2e[mm._Phase.PADDED_DECODE].call_count == 1
+
+    def test_prefill_ignores_the_padded_flag(self, monkeypatch):
+        # num_tokens_padded is prefill-sized on a prefill step too; only decode
+        # steps split on it.
+        ctx = _ctx(monkeypatch)
+        _run_pass(ctx, is_prefill=True, padded_decode=True)
+        assert ctx._metrics[mm._Phase.PREFILL].call_count == 1
+        assert mm._Phase.PADDED_DECODE not in ctx._metrics
 
     def test_profile_model_flushes_prior_pending(self, monkeypatch):
         # Back-to-back model steps: the earlier pending one is flushed (recorded
         # model-only) when the next profile_model starts.
         ctx = _ctx(monkeypatch)
-        ctx._submit(mm._Sample(1.0, phase=True), is_sampler=False)
-        ctx.profile_model(is_prefill=False)  # span not entered; only flushes
-        assert ctx._metrics[True].call_count == 1
+        ctx._submit(mm._Sample(1.0, phase=mm._Phase.PREFILL), is_sampler=False)
+        # Span not entered; only flushes.
+        ctx.profile_model(is_prefill=False, padded_decode=False)
+        assert ctx._metrics[mm._Phase.PREFILL].call_count == 1
         assert ctx._pending is None
 
     def test_drain_backlog_flushes_runtimes_once(self, monkeypatch):
@@ -267,15 +287,15 @@ class TestE2EWindow:
         ctx = _ctx(monkeypatch)
         ctx.start_e2e()
         clock.now += 1.0  # input preparation, before the model span opens
-        with ctx.profile_model(is_prefill=True):
+        with ctx.profile_model(is_prefill=True, padded_decode=False):
             clock.now += 4.0
         clock.now += 1.0
         with ctx.profile_sampler():
             clock.now += 2.0
         clock.now += 1.0  # output copy, after the sampler span closed
         ctx.end_e2e()
-        assert ctx._metrics[True].latencies == [6.0]  # the two spans only
-        assert ctx._e2e[True].latencies == [9.0]  # the whole pass
+        assert ctx._metrics[mm._Phase.PREFILL].latencies == [6.0]  # the two spans only
+        assert ctx._e2e[mm._Phase.PREFILL].latencies == [9.0]  # the whole pass
         assert ctx._e2e_start is None
 
     def test_time_between_passes_is_excluded(self, monkeypatch):
@@ -283,21 +303,21 @@ class TestE2EWindow:
         ctx = _ctx(monkeypatch)
         for _ in range(2):
             ctx.start_e2e()
-            with ctx.profile_model(is_prefill=False):
+            with ctx.profile_model(is_prefill=False, padded_decode=False):
                 clock.now += 1.0
             ctx.end_e2e()
             clock.now += 10.0  # engine and idle time between passes
-        assert ctx._e2e[False].latencies == [1.0, 1.0]
+        assert ctx._e2e[mm._Phase.DECODE].latencies == [1.0, 1.0]
 
     def test_sampler_less_pass_is_still_timed(self, monkeypatch):
         # Intermediate chunked prefill / non-last PP rank.
         clock = _fake_clock(monkeypatch)
         ctx = _ctx(monkeypatch)
         ctx.start_e2e()
-        with ctx.profile_model(is_prefill=True):
+        with ctx.profile_model(is_prefill=True, padded_decode=False):
             clock.now += 3.0
         ctx.end_e2e()
-        assert ctx._e2e[True].latencies == [3.0]
+        assert ctx._e2e[mm._Phase.PREFILL].latencies == [3.0]
 
     def test_pass_without_a_model_span_is_dropped(self, monkeypatch):
         clock = _fake_clock(monkeypatch)
@@ -319,40 +339,40 @@ class TestE2EWindow:
         clock = _fake_clock(monkeypatch)
         ctx = _ctx(monkeypatch)
         ctx.start_e2e()
-        with ctx.profile_model(is_prefill=False):
+        with ctx.profile_model(is_prefill=False, padded_decode=False):
             clock.now += 1.0
         ctx.end_e2e()
         clock.now += 5.0
         ctx.end_e2e()
-        assert ctx._e2e[False].latencies == [1.0]
+        assert ctx._e2e[mm._Phase.DECODE].latencies == [1.0]
 
     def test_phase_does_not_carry_over_to_the_next_window(self, monkeypatch):
         clock = _fake_clock(monkeypatch)
         ctx = _ctx(monkeypatch)
         ctx.start_e2e()
-        with ctx.profile_model(is_prefill=False):
+        with ctx.profile_model(is_prefill=False, padded_decode=False):
             clock.now += 1.0
         ctx.end_e2e()
         ctx.start_e2e()
         clock.now += 5.0
         ctx.end_e2e()  # no model span: must not land in the decode bucket again
-        assert ctx._e2e[False].latencies == [1.0]
+        assert ctx._e2e[mm._Phase.DECODE].latencies == [1.0]
 
     def test_model_span_outside_a_window_is_not_attributed(self, monkeypatch):
         _fake_clock(monkeypatch)
         ctx = _ctx(monkeypatch)
-        ctx.profile_model(is_prefill=True)
-        assert ctx._e2e_is_prefill is None
+        ctx.profile_model(is_prefill=True, padded_decode=False)
+        assert ctx._e2e_phase is None
 
 
 class TestTimingSpanWiring:
     def test_model_and_sampler_spans_record_one_merged_step(self, monkeypatch):
         ctx = _ctx(monkeypatch)
         _run_pass(ctx, is_prefill=True)
-        m = ctx._metrics[True]
+        m = ctx._metrics[mm._Phase.PREFILL]
         assert m.call_count == 1
         assert m.host_times == []  # no reports captured -> no timing series
-        assert ctx._e2e[True].call_count == 1
+        assert ctx._e2e[mm._Phase.PREFILL].call_count == 1
         assert ctx._pending is None
 
 
@@ -372,6 +392,25 @@ class TestReporting:
             "DECODE E2E",
         ]
 
+    def test_padded_decode_is_a_separate_section(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(envs, "VLLM_RBLN_METRICS_DIR", str(tmp_path))
+        ctx = _ctx(monkeypatch)
+        # Out of report order on purpose: sections follow the fixed phase order.
+        _run_pass(ctx, is_prefill=False, padded_decode=True)
+        _run_pass(ctx, is_prefill=False)
+        _run_pass(ctx, is_prefill=True)
+        ctx.print_stats()
+
+        data = json.loads((tmp_path / "metrics.json").read_text())
+        assert list(data["sections"]) == [
+            "PREFILL + SAMPLE",
+            "DECODE + SAMPLE",
+            "PADDED DECODE + SAMPLE",
+            "PREFILL E2E",
+            "DECODE E2E",
+            "PADDED DECODE E2E",
+        ]
+
     def test_unseen_phase_is_omitted(self, monkeypatch, tmp_path):
         monkeypatch.setattr(envs, "VLLM_RBLN_METRICS_DIR", str(tmp_path))
         ctx = _ctx(monkeypatch)
@@ -385,10 +424,10 @@ class TestReporting:
         monkeypatch.setattr(envs, "VLLM_RBLN_METRICS_DIR", str(tmp_path))
         ctx = _ctx(monkeypatch)
         _run_pass(ctx, is_prefill=True, with_sampler=False)
-        assert ctx._metrics[True].call_count == 0  # waiting for a sampler
+        assert ctx._metrics[mm._Phase.PREFILL].call_count == 0  # waiting for a sampler
 
         ctx.print_stats()
-        assert ctx._metrics[True].call_count == 1
+        assert ctx._metrics[mm._Phase.PREFILL].call_count == 1
 
 
 class TestE2EDecorators:

--- a/vllm_rbln/v1/worker/metrics_v2.py
+++ b/vllm_rbln/v1/worker/metrics_v2.py
@@ -19,6 +19,7 @@ import time
 from collections import defaultdict
 from contextlib import nullcontext
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import TypeVar
 
 import numpy as np
@@ -28,6 +29,14 @@ from vllm_rbln.logger import init_logger
 
 logger = init_logger(__name__)
 T = TypeVar("T", int, float)
+
+
+class _Phase(Enum):
+    """Report phases, in report order; the value is the section label."""
+
+    PREFILL = "PREFILL"
+    DECODE = "DECODE"
+    PADDED_DECODE = "PADDED DECODE"
 
 
 @dataclass
@@ -98,7 +107,7 @@ class _Sample:
     device: int | None = None
     ccl: int | None = None
     prepare: int | None = None
-    phase: bool | None = None  # True=prefill, False=decode (set by the model span)
+    phase: _Phase | None = None  # None on a sampler span
 
     def merged(self, other: "_Sample") -> "_Sample":
         def _add(a: int | None, b: int | None) -> int | None:
@@ -126,7 +135,7 @@ class _TimingSpan:
     __slots__ = ("_ctx", "_phase", "_is_sampler", "_reports", "_start", "_capture_ctx")
 
     def __init__(
-        self, ctx: "_PerformanceContext", phase: bool | None, is_sampler: bool
+        self, ctx: "_PerformanceContext", phase: _Phase | None, is_sampler: bool
     ) -> None:
         self._ctx = ctx
         self._phase = phase
@@ -172,35 +181,39 @@ class _PerformanceContext:
     def __init__(self, name: str | None = None, runtimes: list | None = None) -> None:
         self.name = name
         self.rank_tag = _rank_tag()
-        self._metrics: dict[bool, Metrics] = defaultdict(Metrics)
+        self._metrics: dict[_Phase, Metrics] = defaultdict(Metrics)
         self._pending: _Sample | None = None
         self._e2e_start: float | None = None
-        self._e2e_is_prefill: bool | None = None
-        self._e2e: dict[bool, Metrics] = defaultdict(Metrics)
+        self._e2e_phase: _Phase | None = None
+        self._e2e: dict[_Phase, Metrics] = defaultdict(Metrics)
         self._runtimes = runtimes if runtimes is not None else []
         self._backlog_drained = False
 
     def start_e2e(self) -> None:
         self._e2e_start = time.perf_counter()
-        self._e2e_is_prefill = None
+        self._e2e_phase = None
 
     def end_e2e(self) -> None:
         end = time.perf_counter()
         start, self._e2e_start = self._e2e_start, None
         if start is None:
             return
-        if self._e2e_is_prefill is None:
+        if self._e2e_phase is None:
             return  # no forward pass ran: nothing to attribute
-        self._e2e[self._e2e_is_prefill].record(end - start)
+        self._e2e[self._e2e_phase].record(end - start)
 
-    def profile_model(self, is_prefill: bool) -> _TimingSpan:
+    def profile_model(self, is_prefill: bool, padded_decode: bool) -> _TimingSpan:
         self._drain_report_backlog()
         # A prior model step with no sampler (intermediate chunked prefill,
         # non-last PP rank) leaves a pending report; record it model-only here.
         self._flush_pending()
+        if is_prefill:
+            phase = _Phase.PREFILL
+        else:
+            phase = _Phase.PADDED_DECODE if padded_decode else _Phase.DECODE
         if self._e2e_start is not None:
-            self._e2e_is_prefill = is_prefill
-        return _TimingSpan(self, phase=is_prefill, is_sampler=False)
+            self._e2e_phase = phase
+        return _TimingSpan(self, phase=phase, is_sampler=False)
 
     def profile_sampler(self) -> _TimingSpan:
         return _TimingSpan(self, phase=None, is_sampler=True)
@@ -220,9 +233,8 @@ class _PerformanceContext:
             self._pending = None
 
     def _record(self, s: _Sample) -> None:
-        self._metrics[bool(s.phase)].record(
-            s.latency, s.host, s.device, s.ccl, s.prepare
-        )
+        assert s.phase is not None, "sampler-only sample reached _record"
+        self._metrics[s.phase].record(s.latency, s.host, s.device, s.ccl, s.prepare)
 
     def _drain_report_backlog(self) -> None:
         """Discard warmup reports left in the runtime FIFO before measuring."""
@@ -237,10 +249,10 @@ class _PerformanceContext:
     def print_stats(self) -> None:
         self._flush_pending()  # record the final step if it had no sampler
         sections: dict[str, Metrics] = {}
-        for phase, m in sorted(self._metrics.items(), key=lambda x: not x[0]):
-            sections["PREFILL + SAMPLE" if phase else "DECODE + SAMPLE"] = m
-        for phase, m in sorted(self._e2e.items(), key=lambda x: not x[0]):
-            sections["PREFILL E2E" if phase else "DECODE E2E"] = m
+        for suffix, table in (("+ SAMPLE", self._metrics), ("E2E", self._e2e)):
+            for phase in _Phase:
+                if phase in table:
+                    sections[f"{phase.value} {suffix}"] = table[phase]
         name = f"{self.name} | {self.rank_tag}" if self.rank_tag else self.name
         _report_metrics(name, sections)
         _write_metrics_json(self.name, self.rank_tag, sections)

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1428,7 +1428,12 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 scheduler_output,
                 defer_finalize=defer_kv_connector_finalize,
             ) as kv_connector_output,
-            self.performance_ctx.profile_model(self.is_prefill),
+            self.performance_ctx.profile_model(
+                self.is_prefill,
+                # num_tokens_padded is the MoE pad shape, so matching the prefill
+                # dim means this decode ran the prefill-sized graph.
+                padded_decode=num_tokens_padded == self.max_num_tokens,
+            ),
         ):
             model_output = self.model_executable(
                 **staged_model_inputs.as_kwargs(),


### PR DESCRIPTION
### 🚀 Summary of Changes

`metrics_v2` keyed every step on a single `is_prefill` bool, so a decode step that
actually ran the prefill-sized graph was averaged into `DECODE`. #811 deliberately left
the legacy `padded_decode` split out because its criterion was known to be imprecise;
this is the promised follow-up. Affects the **vLLM-native path** only.

* **Why the legacy criterion was wrong** — it read
  `num_padded_tokens is not None and num_padded_tokens != batch_bucket_size`, comparing a
  **token count against a batch count**. Under spec decode `num_padded_tokens` scales with
  the per-request query length, so every spec-decode step came out padded. With
  `VLLM_RBLN_SPECIALIZE_MOE_DECODE=0` and DP > 1 it was true for every decode step.

* **The criterion is now tokens against tokens** —
  `padded_decode = num_tokens_padded == self.max_num_tokens`, evaluated at the model span.
  `num_tokens_padded` is what `RBLNDPMetadata.make` turns into `max_pads_across_dp`, whose
  `shape[0]` the MoE runner reads as the pad dimension, so two decode steps agreeing on it
  agree on the compiled shape. Matching `max_num_tokens` therefore means this step ran the
  prefill-sized graph. `dp_size == 1` leaves `num_tokens_padded` at `None` and never
  matches, and a longer per-request query length grows the padding without reaching the
  prefill dimension, so spec decode does not trip it. The comparison is an argument to
  `profile_model`, so it is evaluated whether or not `VLLM_RBLN_METRICS` is set — one int
  compare per pass, against a value already in hand.

* **It is a property of the shape, not of why the shape was chosen** — that matters for a
  narrowed padding that happens to land on `max_num_tokens`
  (`num_reqs_padded * max_tokens_per_req` can reach it). That step really is running the
  prefill-sized graph, and reading the shape reports it as such where a flag set in the
  narrowing branch would hard-code it back into `DECODE`. Likewise, with the specialized
  path disabled there is no narrowed decode graph at all, so every DP decode step is
  reported as padded — the accurate picture of that configuration.

* **A `_Phase` enum replaces the bool** — `_Sample.phase` is now `_Phase.PREFILL` /
  `DECODE` / `PADDED_DECODE`, and each member's value is its section label. Definition
  order is report order, so `print_stats` iterates the enum rather than sorting on a bool,
  and the label lives with the key instead of in a parallel dict. Phases with no recorded
  step are still omitted. `_record` now asserts the phase is set rather than coercing a
  missing one into `DECODE`, since silently defaulting is the mis-bucketing this PR exists
  to remove.

The report gains `PADDED DECODE + SAMPLE` and `PADDED DECODE E2E`, ordered after their
`DECODE` counterparts. On a DP4 gpt-oss-120b run the padded-decode latency separates
cleanly from plain decode and sits much closer to prefill, while its host overhead
(`E2E` minus `MODEL + SAMPLE`) stays decode-like — the graph shape grows to prefill size
but the host still prepares a decode-sized batch. Counts stay in parity between the two
levels for every phase.

The section set is purely additive — no existing label is renamed or removed:

```
PREFILL + SAMPLE          PREFILL + SAMPLE
DECODE + SAMPLE           DECODE + SAMPLE
                    ->    PADDED DECODE + SAMPLE     <- new
PREFILL E2E               PREFILL E2E
DECODE E2E                DECODE E2E
                          PADDED DECODE E2E          <- new
```

**Ordering against #920.** That PR touches the same three files and reworks
`_PerformanceContext` in a conflicting direction: it moves the report capture to one
per-pass window, drops the `+ SAMPLE` section family entirely, and keeps the `bool` phase
key while renaming `_e2e` to `_pass_metrics`. Whichever lands second needs a real rebase,
not a textual merge — and if #920 goes first, the split here applies only to the
pass-level sections, leaving `PADDED DECODE E2E` with no `+ SAMPLE` counterpart. Happy to
rebase onto it either way; flagging so the order is a decision rather than an accident.

Dummy batches stay out of the report, deliberately: `execute_dummy_batch` goes through
`_dummy_run`, which has no model span, so an idle DP rank's dummy decode is device time
the report does not count. It is a pure collective participant, not work the served
requests caused.

---

### 📌 Related Issues / Tickets

* Resolves #
* Related to #811 (where the legacy criterion was dropped and this follow-up was agreed)
* Related to #909 (metrics_v2 report capture and aggregation), #920 (conflicting rework of
  the same spans), #774 (the per-bucket decode split this deliberately does not do)

---

### ✅ Type of Change

* [ ] 🚀 Release (`release`)
* [x] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. `uv run --no-sync pytest tests/native/v1/worker/test_metrics_v2.py`
2. Run with `VLLM_RBLN_METRICS=1` on DP > 1 and a workload where ranks cross phase
   boundaries — more requests per rank than `max_num_seqs`, so a rank admits a new
   request while its peers are still decoding. `PERFORMANCE STATISTICS` gains the two
   `PADDED DECODE` sections, and their call counts match between `+ SAMPLE` and `E2E`.
   `VLLM_RBLN_METRICS_DIR` writes the same thing as per-rank JSON.
3. Edge cases: `dp_size == 1`, and a fully symmetric DP workload — equal-length prompts,
   one request per rank — produce no `PADDED DECODE` section at all, because no step
   qualifies.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

`profile_model(is_prefill, padded_decode)` takes the flag as a required argument. A DP
prefill step does have `num_tokens_padded == max_num_tokens`, so `(True, True)` is the
normal call there and `is_prefill` deliberately wins; the pair is two independent facts
the runner knows, not a widened enum. #888 migrates the optimum runner onto `metrics_v2`
and will have to decide what to pass.

Two coverage gaps, both stated rather than papered over. The call-site expression itself
is not unit-tested — it lives inside `execute_model` and needs the full runner. And
`tests/native/` has no DP coverage of `_determine_batch_padding` at all: the tests that
had it were deleted with `tests/torch_compile/unit/v1/worker/` in #931. Restoring that is
worth its own change; adding it here would test pre-existing logic that this PR no longer
touches.

Batch-bucket padding — this rank's batch being smaller than the bucket it ran — is a
separate axis and is not covered here. A padded/not-padded bool is the wrong shape for it:
with several buckets in play it does not say which graph ran. The per-bucket decode split
from #774 is the right form, and is left as a follow-up.

One thing to know when reproducing through `vllm-rbln-executor`: its DP run worker for
`rbln-run` has no live `print_stats` flush and relies on the shutdown-time dump, unlike
the `measure` worker which flushes through `collective_rpc` while the engine is alive.
If a rank's statistics block is missing entirely, that is the dump path, not this change.
