### PR TITLE
other(ci): publish the nightly wheel to UDC Nexus

### DIFF
--- a/.buildkite/pipelines/vllm-rbln/scripts/publish-nightly-wheel.sh
+++ b/.buildkite/pipelines/vllm-rbln/scripts/publish-nightly-wheel.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Build the nightly wheel and publish it to the UDC Nexus vllm nightly index.
+#
+# Twin of fsw-integration's job-vllm-rbln-publish-wheel.yaml minus the artifact
+# hand-off: GitHub Actions built the wheel in one job and downloaded it in
+# another, while Buildkite builds and publishes in the same job.
+
+set -euo pipefail
+
+: "${UV_PUBLISH_URL:?not set -- fix the env block in .buildkite/vllm-rbln-nightly.yml}"
+: "${UV_PUBLISH_USERNAME:?not set -- fix the vault name in .buildkite/vllm-rbln-nightly.yml}"
+: "${UV_PUBLISH_PASSWORD:?not set -- fix the vault name in .buildkite/vllm-rbln-nightly.yml}"
+
+echo "--- :package: build wheel"
+# setuptools-scm derives the version from the nearest tag, so a checkout without
+# tags would publish 0.1.devN instead of the real nightly version.
+git fetch --tags --force --unshallow 2>/dev/null || git fetch --tags --force
+rm -rf dist
+uv build --wheel
+ls -lh dist/
+
+echo "--- :outbox_tray: publish to ${UV_PUBLISH_URL}"
+# --check-url is what makes a re-run on an unchanged commit a no-op instead of a
+# 409; it replaces the GHA job's check-nexus-wheel.sh probe. uv reads it from
+# UV_PUBLISH_CHECK_URL, and the index needs auth, so the credentials go inline --
+# there is no separate UV_PUBLISH_CHECK_* pair.
+scheme="${UV_PUBLISH_URL%%://*}"
+host_path="${UV_PUBLISH_URL#*://}"
+export UV_PUBLISH_CHECK_URL="${scheme}://${UV_PUBLISH_USERNAME}:${UV_PUBLISH_PASSWORD}@${host_path%/}/simple/"
+uv publish dist/*.whl

--- a/.buildkite/vllm-rbln-nightly.yml
+++ b/.buildkite/vllm-rbln-nightly.yml
@@ -114,32 +114,26 @@ steps:
       - *sync
       - "bash .buildkite/pipelines/vllm-rbln/scripts/lm-eval/run-lm-eval.sh"
 
-  # A skipped step satisfies depends_on, so this runs on ATOM alone until the
-  # CR03 steps above lose their skip.
-  # - label: ":package: nightly deploy"
-  #   key: "nightly-deploy"
-  #   depends_on:
-  #     - "nightly-t0-ca25"
-  #     - "nightly-t2-ca25"
-  #     - "nightly-t0-cr03"
-  #     - "nightly-t2-cr03"
-  #   agents:
-  #     queue: r18s
-  #   image: "${DEVTOOLS_DOCKER_IMAGE}"
-  #   secrets:
-  #     # PLACEHOLDER vault names -- confirm both before this step is enabled.
-  #     # TWINE_PASSWORD is PKG_ORG_GATE in GitHub Actions.
-  #     TWINE_PASSWORD: PKG_ORG_GATE
-  #     TWINE_REPOSITORY_URL: PKG_INTERNAL_PYPI_URL
-  #   timeout_in_minutes: 30
-  #   command:
-  #     - |
-  #       set -euo pipefail
-  #       # Without an explicit repository URL twine would target public PyPI, and
-  #       # the pod has no ~/.pypirc to fall back on. Fail instead of publishing
-  #       # anywhere unintended.
-  #       : "${TWINE_REPOSITORY_URL:?not set -- fix the vault name in pipeline.yml}"
-  #       : "${TWINE_PASSWORD:?not set -- fix the vault name in pipeline.yml}"
-  #       uv build --wheel
-  #       TWINE_USERNAME=__token__ TWINE_NON_INTERACTIVE=1 \
-  #         uv tool run twine upload --skip-existing dist/vllm_rbln*.whl
+  # The four gating lanes above; perf and lm-eval are measured, not gated, so
+  # they stay out of depends_on. No NPU needed -- the wheel is a pure CPU build,
+  # so this runs on the default queue.
+  - label: ":package: nightly publish"
+    key: "nightly-publish"
+    depends_on:
+      - "nightly-t0-ca25"
+      - "nightly-t2-ca25"
+      - "nightly-t0-cr03"
+      - "nightly-t2-cr03"
+    image: "${DEVTOOLS_DOCKER_IMAGE}"
+    secrets:
+      # rbln-nexus-nightly is a non-explicit index, so resolving the build
+      # backend already needs its credentials.
+      UV_INDEX_RBLN_NEXUS_NIGHTLY_USERNAME: MGMT_NEXUS_USERNAME
+      UV_INDEX_RBLN_NEXUS_NIGHTLY_PASSWORD: MGMT_NEXUS_PASSWORD
+      UV_PUBLISH_USERNAME: MGMT_NEXUS_USERNAME
+      UV_PUBLISH_PASSWORD: MGMT_NEXUS_PASSWORD
+    env:
+      UV_PUBLISH_URL: "https://nexus.mgmt.rbln.in/repository/pypi-vllm-nightly/"
+    timeout_in_minutes: 30
+    command:
+      - "bash .buildkite/pipelines/vllm-rbln/scripts/publish-nightly-wheel.sh"


### PR DESCRIPTION
### 🚀 Summary of Changes

The nightly pipeline runs every test lane but ships nothing: the deploy step landed commented out in #931 because its vault names were placeholders (`PKG_ORG_GATE`, `PKG_INTERNAL_PYPI_URL`). This replaces it with a working publish step.

- `nightly-publish` builds the wheel and uploads it to the UDC Nexus `pypi-vllm-nightly` repository, the same index the GitHub Actions job (`fsw-integration/job-vllm-rbln-publish-wheel.yaml`) published to.
- Credentials are `MGMT_NEXUS_USERNAME` / `MGMT_NEXUS_PASSWORD`, the vault entries the four test lanes already read `nexus.mgmt.rbln.in` with, so no new vault entry is needed. That account's upload permission was measured from inside CI rather than assumed — see Verification.
- The step depends on the four gating lanes (`nightly-t0-ca25`, `nightly-t2-ca25`, `nightly-t0-cr03`, `nightly-t2-cr03`). `perf` and `lm-eval` are measured, not gated, so they stay out of `depends_on`.
- No NPU is involved, so the step runs on the default queue instead of claiming a device.

Two things the GitHub Actions job needed and this does not:

- **No artifact round trip.** GHA built the wheel in one job and pulled the zip back down over `/actions/artifacts` in three separate publish jobs. Buildkite builds and publishes in the same job.
- **No `check-nexus-wheel.sh`.** `uv publish --check-url` already skips files that exist on the index, so a re-run on an unchanged commit is a no-op instead of a 409.

`git fetch --tags` runs before the build because setuptools-scm derives the version from the nearest tag; a checkout without tags would publish `0.1.devN` instead of the real nightly version.

Publishing to the internal (`pypi.rebellions.in`) and external (`pypi.rbln.ai`) indexes is deliberately left out. Neither has a confirmed upload account on Buildkite, and the external one is served by a network-separated runner in GHA, so it needs a queue decision first.

---

### 📌 Related Issues / Tickets

* Related to CLD-1724

---

### ✅ Type of Change

* [x] ❓ Other (`other`): CI — nightly package publishing

---

### 🧪 How to Test

1. Run the nightly pipeline on this branch. The published version should match the format already on the index, e.g. `vllm_rbln-0.10.3a5.dev27+g89de9b9ed-py3-none-any.whl`.
2. Re-run the same build. The publish step should report a skip rather than fail with a 409, because `--check-url` finds the file already there.
3. Confirm the wheel installs from the index:
   `uv pip install --index-url https://nexus.mgmt.rbln.in/repository/pypi-vllm-nightly/simple/ vllm-rbln==<published version>`

---

### 📸 Verification

#### The credentials can actually upload

This was the one real unknown, and it cannot be answered from a laptop: `MGMT_NEXUS_*` only exists inside a Buildkite job. A temporary probe step ran in build 140 of this PR and was removed from the branch afterwards, so it is not part of the diff.

```
POST https://nexus.mgmt.rbln.in/service/rest/v1/components?repository=pypi-vllm-nightly -> HTTP 400
[{"id":"*","message":"No assets found in upload"},{"id":"probe","message":"Unknown component field 'probe'"}]
✅ upload permission present
```

Why that 400 is the answer, and why the probe is safe:

| request | result |
| --- | --- |
| anonymous, multipart, no asset | `403` |
| `MGMT_NEXUS_*`, multipart, no asset | `400 No assets found in upload` |
| `MGMT_NEXUS_*` → `pypi-group-nightly` | `400 Uploading components to a 'group' type repository is unsupported` |

The components API authorizes before it validates the body, so reaching the "no asset" complaint means the account cleared authorization. No asset is attached, so nothing can be stored either way.

The PyPI legacy endpoint (`POST /repository/<repo>/` with `:action=file_upload`) is not usable for this: it answers `500` for the same request and distinguishes nothing. The first probe attempt used it and had to be replaced.

#### The target index

```
pypi-vllm-nightly | pypi | hosted        # uploadable type, not a group
GET /repository/pypi-vllm-nightly/simple/vllm-rbln/   -> 200 authenticated, 401 anonymous
```

Latest wheels already on the index are `vllm_rbln-0.10.3a5.dev27+g89de9b9ed-py3-none-any.whl`, which is exactly the format setuptools-scm produces from the repo's tags — the publish step needs no version rewriting.

#### The change itself

- `.buildkite/vllm-rbln-nightly.yml` parses, and the publish step is picked up as the seventh step alongside the six existing lanes.
- `bash -n` clean on `publish-nightly-wheel.sh`.
- The `--check-url` string the script assembles resolves to `https://<user>:<pass>@nexus.mgmt.rbln.in/repository/pypi-vllm-nightly/simple/`.
- `pre-commit run --files` clean on both changed files.

#### The wheel builds, and its version is the one the index expects

`uv build --wheel` on this branch:

```
Successfully built dist/vllm_rbln-0.11.2a10.dev17+geff00664d-py3-none-any.whl
```

`0.11.2a10.dev17+geff00664d` is setuptools-scm counting 17 commits past `v0.11.2a9`, which is the same shape as the wheels already sitting on the nightly index — so the publish step needs no version rewriting, and the `git fetch --tags` ahead of the build is what keeps it that way.

`uv lock --check` also passes, so nothing here disturbs the lockfile.

#### Not verified

The first end-to-end publish happens on the next nightly run; everything up to the upload itself is covered above.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

The GHA job also published to `pypi.rebellions.in` and `pypi.rbln.ai`. If either is still consumed downstream, say so and they can be added as separate steps once their upload accounts exist on Buildkite.
