### PR TITLE
other(ci): probe whether the two HF tokens share one account [DO NOT MERGE]

### DIFF
--- a/.buildkite/pr.yml
+++ b/.buildkite/pr.yml
@@ -1,14 +1,14 @@
+# THROWAWAY BRANCH -- not for merge.
+#
+# The test pipelines are stripped out on purpose. This branch only asks whether
+# FSW_HF_TOKEN and HF_TOKEN are the same Hugging Face account, and running the
+# optimum and vllm-rbln lanes to find that out would add load to the very quota
+# the probe is investigating.
+
 env:
   UV_CACHE_DIR: "/mnt/uv_cache"
   UV_LINK_MODE: "symlink"
   UV_INDEX_STRATEGY: "unsafe-best-match"
-
-# uv index creds for the pre-commit env (LHS = job env var, RHS = OB vault name).
-_uv_secrets: &uv_secrets
-  UV_INDEX_RBLN_NEXUS_NIGHTLY_USERNAME: MGMT_NEXUS_USERNAME
-  UV_INDEX_RBLN_NEXUS_NIGHTLY_PASSWORD: MGMT_NEXUS_PASSWORD
-  UV_INDEX_REBELLIONS_USERNAME: REBEL_SW_DEV_USERNAME
-  UV_INDEX_REBELLIONS_PASSWORD: REBEL_SW_DEV_PASSWORD
 
 steps:
   - label: ":closed_lock_with_key: team-member gate"
@@ -18,37 +18,12 @@ steps:
     command:
       - "bash .buildkite/scripts/gate-team-member.sh"
 
-  - label: ":mag: pre-commit"
-    notify:
-    - github_commit_status:
-        context: "[OB] pre-commit"
+  # LHS = job env var, RHS = OB vault name. The two vault entries here are the
+  # ones the vllm-rbln lanes and the optimum lanes each pass as HF_TOKEN.
+  - label: ":test_tube: HF token identity probe (temporary)"
     image: "${DEVTOOLS_DOCKER_IMAGE}"
-    secrets: *uv_secrets
+    secrets:
+      PROBE_FSW_HF_TOKEN: FSW_HF_TOKEN
+      PROBE_HF_TOKEN: HF_TOKEN
     command:
-      - "uv tool run pre-commit run --all-files --hook-stage manual --show-diff-on-failure"
-
-  # Both gates must pass before the heavy test pipelines are even uploaded.
-  - wait: ~
-
-  - group: ":gear: vllm-rbln optimum tests"
-    key: "optimum"
-    steps:
-      - label: ":sparkles: upload optimum-pr"
-        checkout:
-          sparse:
-            paths:
-              - .buildkite
-        command: "buildkite-agent pipeline upload .buildkite/pipelines/optimum-pr/pipeline.yml"
-
-  - group: ":snake: vllm-rbln tests"
-    key: "vllm-rbln"
-    steps:
-      - label: ":sparkles: upload vllm-rbln-pr"
-        checkout:
-          sparse:
-            paths:
-              - .buildkite
-        command: |
-          TARGET_BRANCH=$${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-dev}
-          git fetch origin $$TARGET_BRANCH
-          buildkite-agent pipeline upload .buildkite/pipelines/vllm-rbln/pipeline-pr.yml --git-diff-base origin/$$TARGET_BRANCH
+      - "bash .buildkite/scripts/probe-hf-token-identity.sh"

--- a/.buildkite/scripts/probe-hf-token-identity.sh
+++ b/.buildkite/scripts/probe-hf-token-identity.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# THROWAWAY -- this whole branch exists to answer one question and is not meant
+# to merge.
+#
+# Do FSW_HF_TOKEN and HF_TOKEN belong to the same Hugging Face account?
+#
+# It matters because the rate limit that killed build 142 (429, "you hit the
+# quota of 2500 api requests per 5 minutes period") is charged per account, not
+# per job. The vllm-rbln lanes authenticate with FSW_HF_TOKEN and the optimum
+# lanes with HF_TOKEN; if both resolve to the same user or org, every lane in
+# every concurrent build shares one bucket and capping concurrency is the only
+# lever. If they resolve to different accounts, the two lane families are
+# already isolated and the vllm-rbln side alone is over budget.
+#
+# whoami-v2 is a read-only endpoint. Nothing here prints a token.
+
+set -euo pipefail
+
+: "${PROBE_FSW_HF_TOKEN:?not set -- fix the vault name in .buildkite/pr.yml}"
+: "${PROBE_HF_TOKEN:?not set -- fix the vault name in .buildkite/pr.yml}"
+
+command -v curl >/dev/null 2>&1 || { apt-get update && apt-get install -y curl; }
+
+identify() {
+  local label="$1" token="$2"
+  local headers body
+  headers=$(mktemp)
+  body=$(mktemp)
+
+  local code
+  code=$(curl -s -D "${headers}" -o "${body}" -w '%{http_code}' \
+    -H "Authorization: Bearer ${token}" \
+    "https://huggingface.co/api/whoami-v2")
+
+  echo "--- ${label}: HTTP ${code}"
+  if [ "${code}" != "200" ]; then
+    echo "    could not identify this token; body follows"
+    head -c 300 "${body}"; echo
+    return
+  fi
+
+  python3 - "${body}" "${label}" <<'PY'
+import json, sys
+
+with open(sys.argv[1]) as fh:
+    me = json.load(fh)
+
+orgs = [o.get("name") for o in me.get("orgs", [])]
+print(f"    name : {me.get('name')}")
+print(f"    type : {me.get('type')}")
+print(f"    orgs : {orgs or '(none)'}")
+PY
+
+  # The quota is a moving window, so these only line up if the two tokens are
+  # charged to the same bucket -- a weaker signal than the identity above, but
+  # free, and it reads the actual counter rather than an account name.
+  grep -i '^x-ratelimit' "${headers}" | sed 's/^/    /' || echo "    (no x-ratelimit headers)"
+}
+
+identify "FSW_HF_TOKEN" "${PROBE_FSW_HF_TOKEN}"
+identify "HF_TOKEN" "${PROBE_HF_TOKEN}"
+
+echo
+echo "Same name/orgs on both  -> one shared quota bucket; only concurrency control helps."
+echo "Different name/orgs     -> the lane families are isolated; vllm-rbln alone is over budget."


### PR DESCRIPTION
> **Not for merge.** This branch exists to read one HTTP response from CI. Close it once the answer is recorded.

### 🚀 Summary of Changes

Build 142 of #942 died on a Hugging Face 429:

```
429 Too Many Requests: you have reached your 'api' rate limit.
Retry after 74 seconds (0/2500 requests remaining in current 300s window).
```

That quota is charged **per account**, not per job or per lane. The vllm-rbln lanes pass `FSW_HF_TOKEN` as `HF_TOKEN`; the optimum lanes pass the vault entry literally named `HF_TOKEN`. Only the vllm-rbln lanes hit the limit — but that is not evidence the accounts differ, because the optimum lanes make far fewer API calls and would stay under the limit either way.

This adds one step that calls `whoami-v2` with each token and prints the resolved name, type, and orgs. It never prints a token, and `whoami-v2` is read-only.

The answer changes which fix is worth building:

- **Same account** → one shared bucket across every concurrent build. Capping concurrency is the only lever; per-lane changes just move the failure around.
- **Different accounts** → the two lane families are already isolated, and the vllm-rbln side alone is over budget. Then reducing its API calls (`HF_HUB_OFFLINE`) is the targeted fix.

The optimum and vllm-rbln pipelines are stripped out of `pr.yml` on this branch. Running them to answer this question would add load to the quota being measured.

---

### 📌 Related Issues / Tickets

* Related to CLD-1724, blocks the retry story for #942

---

### ✅ Type of Change

* [x] ❓ Other (`other`): CI diagnostics, temporary

---

### 🧪 How to Test

Read the `:test_tube: HF token identity probe (temporary)` step in this PR's build. Expected shape:

```
--- FSW_HF_TOKEN: HTTP 200
    name : <account>
    type : <user|org>
    orgs : [...]
--- HF_TOKEN: HTTP 200
    name : <account>
    ...
```

---

### 💬 Notes

Two further findings from vLLM v0.24.0 `vllm/transformers_utils/repo_utils.py`, both relevant to whatever fix follows:

- `list_repo_files` catches `OfflineModeIsEnabled` and returns `[]`, so `HF_HUB_OFFLINE=1` removes the 429 path entirely — but `[]` then reads as "this repo has no such file" to `any_pattern_in_repo_files`, which silently flips feature detection instead of failing loudly.
- `with_retry(..., max_retries=2, retry_delay=2)` ignores the server's `Retry-After: 74s` and burns both attempts within ~6 seconds. That is upstream code; we cannot fix it here.
