### PR TITLE
other(ci): run the PR lanes against the HF cache instead of the API

### DIFF
--- a/.buildkite/pipelines/vllm-rbln/pipeline-pr.yml
+++ b/.buildkite/pipelines/vllm-rbln/pipeline-pr.yml
@@ -6,6 +6,16 @@ env:
   UV_CACHE_DIR: "/root/.cache/uv"
   UV_LINK_MODE: "symlink"
   UV_INDEX_STRATEGY: "unsafe-best-match"
+  # vLLM lists a model's repo files at every engine init, and that call goes to
+  # the Hub API even when HF_HOME already holds the model. The budget is 2500
+  # calls per 5 minutes per account, charged to the one account these lanes
+  # authenticate as, so five concurrent builds drained it and killed a run with
+  # a 429. Offline mode serves the cache and makes the call count zero.
+  #
+  # The nightly lanes stay online, so they are what warms the cache for a newly
+  # added model. Re-run a build with HF_HUB_OFFLINE=0 when a PR needs a model
+  # the cache has not seen yet.
+  HF_HUB_OFFLINE: "${HF_HUB_OFFLINE:-1}"
 
 _if_changed: &if_changed
   include:

--- a/.buildkite/pipelines/vllm-rbln/scripts/run-t1-compile.sh
+++ b/.buildkite/pipelines/vllm-rbln/scripts/run-t1-compile.sh
@@ -3,7 +3,10 @@
 
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
-require_env HF_TOKEN
+# HF_HOME matters more under HF_HUB_OFFLINE: an unset one silently becomes a
+# cold ~/.cache/huggingface, which offline mode turns into a confusing
+# LocalEntryNotFoundError deep inside a test instead of a slow first download.
+require_env HF_TOKEN HF_HOME
 
 args=(
   tests/native


### PR DESCRIPTION
### 🚀 Summary of Changes

Build 142 of #942 died on a Hugging Face rate limit, and so will any run unlucky enough to land in a busy window:

```
429 Too Many Requests: you have reached your 'api' rate limit.
Retry after 74 seconds (0/2500 requests remaining in current 300s window).
Url: https://huggingface.co/api/models/meta-llama/Llama-3.2-1B-Instruct/tree/main?recursive=true
```

The call is vLLM listing a model's repo files, which it does at every engine init. huggingface_hub sends that to the Hub API even when `HF_HOME` already holds the model, so the call count scales with (models × lanes × concurrent builds), not with downloads. The budget is 2500 API calls per 5 minutes **per account**, and every vllm-rbln lane authenticates as the same one.

This sets `HF_HUB_OFFLINE=1` on the PR lanes. It removes the calls rather than reducing them — vLLM's `list_repo_files` catches `OfflineModeIsEnabled` and returns an empty list, and every other lookup resolves out of the shared cache.

The nightly lanes stay online, so they remain what warms the cache when a model is added. A PR that needs a model the cache has not seen can re-run its build with `HF_HUB_OFFLINE=0` — the value is written as `"${HF_HUB_OFFLINE:-1}"`, the same override idiom `rebel_compiler`'s pipelines use.

`HF_HOME` joins the `require_env` check in `run-t1-compile.sh`, because offline mode makes it load-bearing. Unset, it silently falls back to a cold `~/.cache/huggingface`; online that costs a download, offline it surfaces as a `LocalEntryNotFoundError` deep inside a test.

---

### 📌 Related Issues / Tickets

* Related to CLD-1724
* Unblocks #942, whose CI failure prompted this

---

### ✅ Type of Change

* [x] ❓ Other (`other`): CI reliability

---

### 🧪 How to Test

**This PR's own CI run is the experiment.** Both lanes must pass with the same test set as a recent online run — a green run is the evidence that the shared cache covers every model the lanes touch.

1. `:pytest: [CA25] pytest` and `:pytest: [CR03] pytest` should pass in roughly their usual ~24 minutes. Compare the collected/passed counts against a recent `dev`-based run (build 138 is a good baseline).
2. No `429` and no `huggingface.co/api/` traffic should appear in either log.
3. To confirm the escape hatch, re-run this build with `HF_HUB_OFFLINE=0` and check the lanes still pass.

---

### 💬 Notes

**What to watch for in review.** Offline mode is not purely subtractive. `list_repo_files` returning `[]` is indistinguishable, to its callers, from "this repo contains no such file":

```python
def any_pattern_in_repo_files(...):
    return len(list_filtered_repo_files(...)) > 0
```

So a feature probe that would answer True online can quietly answer False offline, and vLLM may then take a different loader path instead of failing. A green run makes that unlikely for the models these lanes touch, but it does not rule it out for a model added later — which is part of why nightly stays online.

Two things this does **not** fix:

- `with_retry(func, msg, max_retries=2, retry_delay=2)` in `vllm/transformers_utils/repo_utils.py` ignores the server's `Retry-After: 74s` and burns both attempts within ~6 seconds. Upstream; not fixable here.
- The lanes have no `retry:` block and `run-t1-compile.sh` passes `-x`, so any single transient failure still discards a ~24-minute lane. Worth deciding separately.

Separately, and not addressed here: the two CI token families resolve to different Hugging Face accounts — the vllm-rbln lanes to a `Rebellions` user in the `rbln` org, the optimum lanes to a personal account with no org. The optimum side's dependency on an individual's token is a bus factor worth its own ticket.
