### PR TITLE
fix(patches): let MultiConnector carry a sub-connector that is not PP-aware

### DIFF
--- a/tests/native/patches/test_multi_connector.py
+++ b/tests/native/patches/test_multi_connector.py
@@ -14,7 +14,12 @@
 
 from types import SimpleNamespace
 
-from vllm_rbln.patches.multi_connector import patched_update_state_after_alloc
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorBase_V1
+
+from vllm_rbln.patches.multi_connector import (
+    patched_set_xfer_handshake_metadata_pp_aware,
+    patched_update_state_after_alloc,
+)
 
 
 class _RecordingConnector:
@@ -63,3 +68,59 @@ def test_all_connectors_get_real_blocks_when_nobody_is_chosen():
 
     for connector in (first, second):
         assert connector.calls == [(blocks, 0)]
+
+
+class _PPAwareConnector:
+    """Stands in for RblnNixlConnector: implements the hook, so it gets it all."""
+
+    def __init__(self) -> None:
+        self.seen: list[dict] = []
+
+    def set_xfer_handshake_metadata_pp_aware(self, metadata):
+        self.seen.append(metadata)
+
+
+class _LegacyConnector:
+    """Stands in for RBLNLMCacheConnectorV1: inherits the base refusal.
+
+    Bound to the real base implementation rather than a stub, so the test
+    exercises the actual guard and the actual (pp, tp) -> tp flattening.
+    """
+
+    set_xfer_handshake_metadata_pp_aware = (
+        KVConnectorBase_V1.set_xfer_handshake_metadata_pp_aware
+    )
+
+    def __init__(self) -> None:
+        self.flattened: list[dict] = []
+
+    def set_xfer_handshake_metadata(self, metadata):
+        self.flattened.append(metadata)
+
+
+def _handshake_metadata(*ranks):
+    return {rank: f"meta{i}" for i, rank in enumerate(ranks)}
+
+
+def test_legacy_member_survives_pp4_prefill():
+    # The deployed failure: prefill at --pipeline-parallel-size 4 with
+    # MultiConnector[RblnNixlConnector, RBLNLMCacheConnectorV1]. Before the
+    # patch the legacy member raised and took the engine core down.
+    nixl, lmcache = _PPAwareConnector(), _LegacyConnector()
+    metadata = _handshake_metadata((0, 0), (1, 0), (2, 0), (3, 0))
+
+    patched_set_xfer_handshake_metadata_pp_aware(_multi(nixl, lmcache), metadata)
+
+    assert nixl.seen == [metadata]
+    # Flattened to {tp_rank: meta}, stage 0 only — what it saw before PP.
+    assert lmcache.flattened == [{0: "meta0"}]
+
+
+def test_single_stage_reaches_every_member_unchanged():
+    nixl, lmcache = _PPAwareConnector(), _LegacyConnector()
+    metadata = _handshake_metadata((0, 0), (0, 1))
+
+    patched_set_xfer_handshake_metadata_pp_aware(_multi(nixl, lmcache), metadata)
+
+    assert nixl.seen == [metadata]
+    assert lmcache.flattened == [{0: "meta0", 1: "meta1"}]

--- a/vllm_rbln/patches/multi_connector.py
+++ b/vllm_rbln/patches/multi_connector.py
@@ -11,33 +11,43 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Backport of vllm-project/vllm#46865 (``2285cfc``).
+"""Patches for ``MultiConnector``'s fan-out over its sub-connectors.
 
-``MultiConnector`` handed empty blocks to every sub-connector that did not win
-the lookup. An offload connector records those block ids for its store path, so
-blank blocks mean "cannot store". On a prefill instance with a cold cache nobody
-wins, so no child ever sees the real blocks and the cache never bootstraps.
+Both patches below fix the same shape of bug: ``MultiConnector`` hands every
+member the same thing, and a member that cannot use it takes the whole stack
+down with it (or silently stops working).
 
-TODO(vllm>=0.26.0): delete this module, its entry in ``patches/__init__.py`` and
-``tests/native/patches/test_multi_connector.py``.
+1. ``update_state_after_alloc`` — backport of vllm-project/vllm#46865
+   (``2285cfc``).
+2. ``set_xfer_handshake_metadata_pp_aware`` — no upstream fix filed yet; see the
+   comment on the patch itself.
 """
 
 from typing import TYPE_CHECKING
 
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorBase_V1
 from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import MultiConnector
 from vllm.version import __version_tuple__ as VLLM_VERSION
 
+from vllm_rbln.logger import init_logger
 from vllm_rbln.patches import register_patch
 
 if TYPE_CHECKING:
+    from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+        KVConnectorHandshakeMetadata,
+    )
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
     from vllm.v1.request import Request
 
-# Fails loudly on the upgrade that makes this backport redundant.
+logger = init_logger(__name__)
+
+# Fails loudly on the upgrade that makes the vllm#46865 backport redundant.
 assert VLLM_VERSION < (0, 26), (
-    f"vLLM {VLLM_VERSION} already ships vllm#46865; delete this module, its "
-    "entry in vllm_rbln/patches/__init__.py and "
-    "tests/native/patches/test_multi_connector.py."
+    f"vLLM {VLLM_VERSION} already ships vllm#46865; delete "
+    "patched_update_state_after_alloc and the tests covering it in "
+    "tests/native/patches/test_multi_connector.py. The PP-aware handshake "
+    "patch below is independent — keep it until upstream stops requiring "
+    "every sub-connector to be PP-aware."
 )
 
 
@@ -63,4 +73,78 @@ def patched_update_state_after_alloc(
             request,
             blocks,
             num_external_tokens if i == chosen_connector else 0,
+        )
+
+
+# The base implementation refuses metadata it cannot interpret rather than
+# guessing, which is right for a lone connector. Identity comparison against it
+# is how we tell "implements the PP-aware hook" from "inherits the refusal".
+_BASE_PP_AWARE_HOOK = KVConnectorBase_V1.set_xfer_handshake_metadata_pp_aware
+
+
+def _implements_pp_aware_handshake(connector: KVConnectorBase_V1) -> bool:
+    return (
+        getattr(type(connector), "set_xfer_handshake_metadata_pp_aware", None)
+        is not _BASE_PP_AWARE_HOOK
+    )
+
+
+@register_patch(
+    target=(
+        "vllm.distributed.kv_transfer.kv_connector.v1."
+        "multi_connector.MultiConnector.set_xfer_handshake_metadata_pp_aware"
+    ),
+    reason=(
+        "Upstream forwards pp_rank > 0 handshake metadata to every sub-connector, "
+        "so one member that does not implement the PP-aware hook fails engine "
+        "startup for the whole stack — even when it performs no cross-instance "
+        "transfer at all."
+    ),
+)
+def patched_set_xfer_handshake_metadata_pp_aware(
+    self: MultiConnector,
+    metadata: "dict[tuple[int, int], KVConnectorHandshakeMetadata]",
+) -> None:
+    """Give each member the metadata it can actually read.
+
+    Upstream fans the full ``{(pp_rank, tp_rank): metadata}`` map out to every
+    member, and ``KVConnectorBase_V1``'s default hook raises on any key with
+    ``pp_rank > 0``:
+
+        ValueError: RBLNLMCacheConnectorV1 received pp_rank > 0 handshake
+                    metadata but does not support PP-disaggregated KV transfer.
+
+    That kills the engine core before it serves a request, and it kills it for
+    a member that does not transfer anything across instances. Our production
+    P/D shape is exactly that: ``RblnNixlConnector`` moves KV from prefill to
+    decode, while ``RBLNLMCacheConnectorV1`` is an offload/reuse tier local to
+    each pod. Running prefill with ``--pipeline-parallel-size 4`` therefore
+    fails at startup even though nothing about the transfer changed.
+
+    So the full map goes to members that implement the hook, and the
+    ``pp_rank == 0`` slice goes to the rest — which is what those members
+    received before PP existed. A member that does need every producer stage
+    must implement the hook to be handed it; being non-PP-aware is the claim
+    that it does not.
+    """
+    pp0 = {key: meta for key, meta in metadata.items() if key[0] == 0}
+    downgraded: list[str] = []
+
+    for c in self._connectors:
+        if _implements_pp_aware_handshake(c):
+            c.set_xfer_handshake_metadata_pp_aware(metadata)
+        else:
+            c.set_xfer_handshake_metadata_pp_aware(pp0)
+            downgraded.append(type(c).__name__)
+
+    if downgraded and len(pp0) != len(metadata):
+        logger.warning(
+            "MultiConnector: sub-connectors without the PP-aware KV handshake "
+            "were given the pp_rank=0 shards only (%d of %d): %s. That is "
+            "correct for a connector that does not transfer KV across "
+            "instances; one that does must implement "
+            "set_xfer_handshake_metadata_pp_aware.",
+            len(pp0),
+            len(metadata),
+            ", ".join(downgraded),
         )


### PR DESCRIPTION
> ## ⚠️ Correction — do not merge this as it stands
>
> This PR was written on a premise that is **false on the pinned `vllm==0.24.0+cpu`**: I
> assumed `RblnNixlConnector` inherits a PP-aware handshake from upstream `NixlConnector`.
> It does not — upstream added `set_xfer_handshake_metadata_pp_aware` to
> `nixl/connector.py` only **after** 0.24.0 (absent at tag `v0.24.0`, present on `main`).
>
> So on this stack **no** connector implements the hook, and this patch would hand
> `RblnNixlConnector` the `pp_rank == 0` slice alone — turning a loud startup `ValueError`
> into silent KV loss for stages 1..N-1, on exactly the deployment it targets. An
> end-to-end run with `kv_connector` = NIXL only (no LMCache) failed with the same error
> naming `RblnNixlConnector`.
>
> #901 already implements the hook properly for the RBLN NIXL connector — it folds
> `(pp_rank, tp_rank)` into the flat rank `_nixl_handshake` asks for, preserving every
> producer stage. That is the correct fix for the NIXL member, and it is not this one.
>
> What remains genuinely unsolved is the **LMCache member inside a `MultiConnector`**,
> which is pod-local and still refuses `pp_rank > 0`. I am reworking this PR around that
> narrower problem; the text below is kept for the record and is superseded above.

---

## Summary

`MultiConnector` fans the PP-aware handshake metadata out to **every** member, and
`KVConnectorBase_V1`'s default hook **raises** on any key with `pp_rank > 0`. So a single
member that does not implement the hook fails engine-core startup for the whole stack —
**even when that member transfers nothing across instances.**

That is the shape of a `MultiConnector[RblnNixlConnector, RBLNLMCacheConnectorV1]`
deployment: NIXL moves KV from prefill to decode, while the LMCache connector is a
process-local offload/reuse tier that takes no part in the transfer. Run prefill with
`--pipeline-parallel-size 4` and the engine core dies before serving a request:

```
File "vllm/v1/engine/core.py", line 190, in __init__
    kv_connector.set_xfer_handshake_metadata_pp_aware(content)
File "vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py", line 478
    c.set_xfer_handshake_metadata_pp_aware(metadata)
File "vllm/distributed/kv_transfer/kv_connector/v1/base.py", line 668
    raise ValueError(
ValueError: RBLNLMCacheConnectorV1 received pp_rank > 0 handshake metadata
            but does not support PP-disaggregated KV transfer.
```

Reproduced on a 4-way pipeline-parallel prefill instance: all four ranks came up,
compiled, and registered `RblnNixlConnectorWorker (D2D)` — then died at the handshake
above, before any request was served.

## Why now

The hook is new upstream, and this repo crossed the version that introduces it:

| this repo | pinned vllm | `set_xfer_handshake_metadata_pp_aware` |
|---|---|---|
| `0fd32c89` | `0.22.0+cpu` | does not exist — nobody is asked whether they are PP-aware |
| `dev` today | `0.24.0+cpu` | called on every member, unconditionally |

So a prefill-PP deployment that worked on the 0.22.0 line stops booting on 0.24.0, with
nothing about the transfer path having changed.

Same code path as #924 (`fix(nixl): key KV handshake metadata by (pp_rank, tp_rank)`):
that fixed the shape of the keys, this fixes who gets handed them.

## The fix

Patch `MultiConnector.set_xfer_handshake_metadata_pp_aware` in `vllm_rbln/patches/`, next
to the `update_state_after_alloc` backport already living there (same class, same
fan-out-to-every-member bug shape):

* members that **implement** the hook get the full `{(pp_rank, tp_rank): metadata}` map;
* the rest get the `pp_rank == 0` slice — which is what they received before PP existed,
  and which the base hook then flattens to `{tp_rank: metadata}` exactly as before.

Not-PP-aware is read as the connector's own claim that it does not need every producer
stage. A connector that does need them must implement the hook to be handed them; the
downgrade is logged once with the connector names, so it is never silent.

Fixing it here rather than in `RBLNLMCacheConnectorV1` is deliberate:

1. it holds for **any** non-PP-aware member, not just the LMCache one;
2. a `kv_transfer_config` may name a sub-connector by
   `kv_connector_module_path`, which bypasses this repo's factory registration entirely —
   a subclass in `rbln_lmcache_connector.py` would not be in the object graph at all;
3. `lmcache_rbln` owns neither the fan-out nor the PP contract; `MultiConnector` does.

## How to test

```bash
pytest tests/native/patches/test_multi_connector.py
```

Two new tests. `_LegacyConnector` binds **the real** `KVConnectorBase_V1` hook rather than
a stub, so the guard and the `(pp, tp) -> tp` flattening under test are the production
ones:

* `test_legacy_member_survives_pp4_prefill` — the reported failure. NIXL sees all four
  stages; the legacy member sees `{0: meta}`; nothing raises. On `dev` this fails with the
  exact `ValueError` above.
* `test_single_stage_reaches_every_member_unchanged` — the pp1 path every non-PP
  deployment uses today is byte-for-byte what it was.

End-to-end verification on a prefill-PP4 + decode-DP4 deployment is queued and I will
report the result here. **Draft until that lands.**

## Notes

* The module docstring and the `assert VLLM_VERSION < (0, 26)` message are amended: they
  told a future reader to delete the *whole module* once 0.26 ships vllm#46865, which
  would now take this patch with it. The message names the function and its tests instead.
  This patch has no upstream counterpart yet — happy to open one against vLLM if you would
  rather the leniency lived there.
* The pp0 slice is a real narrowing: a non-PP-aware connector that silently *did* need the
  other stages would now get partial data instead of a crash. I could not find one — the
  base's own docstring says the default "assumes pp_rank is always 0" — but it is the one
  judgement call in the patch and worth a second opinion.

