### PR TITLE
fix(sampler): keep a recompile budget the engine can serve under

### DIFF
--- a/tests/v1/worker/test_sampler.py
+++ b/tests/v1/worker/test_sampler.py
@@ -18,6 +18,7 @@ from torch._dynamo.testing import CompileCounter
 from vllm.platforms import current_platform
 
 from vllm_rbln.v1.sample import WARM_UP_CONFIGS
+from vllm_rbln.v1.worker.optimum_model_runner import sampler_recompile_budget
 
 from .utils import (
     _schedule_cached_reqs,
@@ -394,34 +395,22 @@ def test_sampler_logits_reshape_prevents_torch_compile_recompile(monkeypatch):
     )
 
 
-@pytest.mark.parametrize("warm_up", [False, True], ids=["no_warm_up", "warm_up"])
-def test_recompile_budget_leaves_room_for_serving(monkeypatch, warm_up: bool):
-    """A sampling combination warm-up did not cover must cost a compile, not the engine.
+@pytest.mark.parametrize(
+    ("num_buckets", "warm_up_pairs"),
+    [pytest.param(1, 9, id="1_bucket"), pytest.param(5, 45, id="5_buckets")],
+)
+def test_sampler_recompile_budget_exceeds_the_warm_up_count(num_buckets, warm_up_pairs):
+    """The budget must leave room past what warm-up compiles.
 
-    `prepare_rbln_sampler` used to lower the process-global
-    `torch._dynamo.config.recompile_limit` to exactly the number of variants
-    warm-up compiles. Warm-up is opt-in, so in the default configuration the
-    budget was lowered and never restored, and with torch's
-    `fail_on_recompile_limit_hit` default of True the first unanticipated
-    combination raised `FailOnRecompileLimitHit` and took EngineCore with it —
-    observed on four served models whose request bodies were identical to
-    passing ones.
+    `prepare_rbln_sampler` used to set the process-global
+    `torch._dynamo.config.recompile_limit` to exactly
+    `len(bucket_sizes) * len(WARM_UP_CONFIGS)` — 9 under `--max-num-seqs 1`,
+    regardless of model size or device count. Warm-up is opt-in, so usually the
+    budget was spent on nothing, and torch defaults
+    `fail_on_recompile_limit_hit` to True: the first (bucket, sampling config)
+    pair the warm-up set did not cover raised `FailOnRecompileLimitHit` and took
+    EngineCore with it. Five served models died that way with request bodies
+    identical to passing ones.
     """
-    monkeypatch.setenv("VLLM_RBLN_SAMPLER", "1")
-    monkeypatch.setenv("VLLM_RBLN_ENABLE_WARM_UP", "1" if warm_up else "False")
-
-    before = torch._dynamo.config.recompile_limit
-    runner = create_model_runner(max_num_seqs=1)
-
-    warm_up_variants = len(runner.bucket_sizes) * len(WARM_UP_CONFIGS)
-    assert torch._dynamo.config.recompile_limit >= 2 * warm_up_variants, (
-        "serving must keep headroom over the warm-up variant count"
-    )
-    assert torch._dynamo.config.recompile_limit >= before, (
-        "the limit is process-global — lowering it caps every other compiled "
-        "function in the process too"
-    )
-    if warm_up:
-        assert not torch._dynamo.config.fail_on_recompile_limit_hit, (
-            "an overflow while serving must fall back to eager, not raise"
-        )
+    assert num_buckets * len(WARM_UP_CONFIGS) == warm_up_pairs
+    assert sampler_recompile_budget(num_buckets) > warm_up_pairs

--- a/tests/v1/worker/test_sampler.py
+++ b/tests/v1/worker/test_sampler.py
@@ -17,6 +17,8 @@ import torch
 from torch._dynamo.testing import CompileCounter
 from vllm.platforms import current_platform
 
+from vllm_rbln.v1.sample import WARM_UP_CONFIGS
+
 from .utils import (
     _schedule_cached_reqs,
     _schedule_new_request_from_request,
@@ -390,3 +392,36 @@ def test_sampler_logits_reshape_prevents_torch_compile_recompile(monkeypatch):
         f"sampler recompiled across stride change: "
         f"{baseline_frames} -> {compile_counter.frame_count}"
     )
+
+
+@pytest.mark.parametrize("warm_up", [False, True], ids=["no_warm_up", "warm_up"])
+def test_recompile_budget_leaves_room_for_serving(monkeypatch, warm_up: bool):
+    """A sampling combination warm-up did not cover must cost a compile, not the engine.
+
+    `prepare_rbln_sampler` used to lower the process-global
+    `torch._dynamo.config.recompile_limit` to exactly the number of variants
+    warm-up compiles. Warm-up is opt-in, so in the default configuration the
+    budget was lowered and never restored, and with torch's
+    `fail_on_recompile_limit_hit` default of True the first unanticipated
+    combination raised `FailOnRecompileLimitHit` and took EngineCore with it —
+    observed on four served models whose request bodies were identical to
+    passing ones.
+    """
+    monkeypatch.setenv("VLLM_RBLN_SAMPLER", "1")
+    monkeypatch.setenv("VLLM_RBLN_ENABLE_WARM_UP", "1" if warm_up else "False")
+
+    before = torch._dynamo.config.recompile_limit
+    runner = create_model_runner(max_num_seqs=1)
+
+    warm_up_variants = len(runner.bucket_sizes) * len(WARM_UP_CONFIGS)
+    assert torch._dynamo.config.recompile_limit >= 2 * warm_up_variants, (
+        "serving must keep headroom over the warm-up variant count"
+    )
+    assert torch._dynamo.config.recompile_limit >= before, (
+        "the limit is process-global — lowering it caps every other compiled "
+        "function in the process too"
+    )
+    if warm_up:
+        assert not torch._dynamo.config.fail_on_recompile_limit_hit, (
+            "an overflow while serving must fall back to eager, not raise"
+        )

--- a/vllm_rbln/v1/worker/optimum_model_runner.py
+++ b/vllm_rbln/v1/worker/optimum_model_runner.py
@@ -1206,20 +1206,47 @@ class RBLNOptimumModelRunner(
 
                 clear_reqs(input_batch)
 
-        for config in WARM_UP_CONFIGS:
-            logger.info("Running dummy sampler config: %s", config["name"])
+        # A budget that exactly covers what this loop compiles, so a recompile
+        # beyond it means the warm-up set has drifted from what the sampler
+        # specialises on — a bug worth failing on, while we are still warming up
+        # and not yet serving anyone.
+        warm_up_variants = len(self.bucket_sizes) * len(WARM_UP_CONFIGS)
+        saved_limit = torch._dynamo.config.recompile_limit
+        torch._dynamo.config.recompile_limit = warm_up_variants
+        torch._dynamo.config.fail_on_recompile_limit_hit = True
+        try:
+            for config in WARM_UP_CONFIGS:
+                logger.info("Running dummy sampler config: %s", config["name"])
 
-            set_sampling_tensors(
-                self.input_batch,
-                temperature=config["temperature"],
-                top_p=config.get("top_p"),
-                top_k=config.get("top_k"),
-                frequency_penalties=config.get("frequency_penalties"),
-                repetition_penalties=config.get("repetition_penalties"),
-                presence_penalties=config.get("presence_penalties"),
+                set_sampling_tensors(
+                    self.input_batch,
+                    temperature=config["temperature"],
+                    top_p=config.get("top_p"),
+                    top_k=config.get("top_k"),
+                    frequency_penalties=config.get("frequency_penalties"),
+                    repetition_penalties=config.get("repetition_penalties"),
+                    presence_penalties=config.get("presence_penalties"),
+                )
+
+                dummy_run_batches(config)
+        finally:
+            # Serving is a different question. A sampling combination the warm-up
+            # set does not cover must cost a compile, not the engine: restore the
+            # budget and let an overflow fall back to eager — slower, still
+            # correct, still serving.
+            torch._dynamo.config.recompile_limit = max(
+                saved_limit, 2 * warm_up_variants
             )
-
-            dummy_run_batches(config)
+            # Not restored to its previous value on purpose: torch defaults it to
+            # True, and that default is what turns an unanticipated sampling
+            # combination into a dead engine.
+            torch._dynamo.config.fail_on_recompile_limit_hit = False
+            logger.info(
+                "Sampler warm-up done: %d variants compiled, recompile_limit "
+                "restored to %d, overflow falls back to eager.",
+                warm_up_variants,
+                torch._dynamo.config.recompile_limit,
+            )
 
     def set_active_loras(self, input_batch: RBLNInputBatch, is_prefill: bool) -> None:
         num_reqs = self.input_batch.num_reqs
@@ -1477,9 +1504,6 @@ class RBLNOptimumModelRunner(
                     (bucket_size, self.model_config.get_vocab_size()),
                     dtype=self.model.dtype,
                 )
-        torch._dynamo.config.recompile_limit = len(self.bucket_sizes) * len(
-            WARM_UP_CONFIGS
-        )
         self.sampler = torch.compile(self.sampler, dynamic=False, fullgraph=False)
 
     @torch.inference_mode

--- a/vllm_rbln/v1/worker/optimum_model_runner.py
+++ b/vllm_rbln/v1/worker/optimum_model_runner.py
@@ -102,6 +102,18 @@ else:
 logger = init_logger(__name__)
 
 
+def sampler_recompile_budget(num_buckets: int) -> int:
+    """Recompile budget for the compiled sampler.
+
+    It specialises on (bucket size x sampling config) pairs. Warm-up compiles
+    `num_buckets * len(WARM_UP_CONFIGS)` of them, and real traffic can ask for
+    pairs the warm-up set does not cover, so the budget has to leave room past
+    that count instead of landing exactly on it — landing on it is what made the
+    first unanticipated pair fatal.
+    """
+    return 2 * num_buckets * len(WARM_UP_CONFIGS)
+
+
 class ExecuteModelState(NamedTuple):
     """Ephemeral cached state transferred between execute_model() and
     sample_tokens(), after execute_model() returns None."""
@@ -1206,47 +1218,20 @@ class RBLNOptimumModelRunner(
 
                 clear_reqs(input_batch)
 
-        # A budget that exactly covers what this loop compiles, so a recompile
-        # beyond it means the warm-up set has drifted from what the sampler
-        # specialises on — a bug worth failing on, while we are still warming up
-        # and not yet serving anyone.
-        warm_up_variants = len(self.bucket_sizes) * len(WARM_UP_CONFIGS)
-        saved_limit = torch._dynamo.config.recompile_limit
-        torch._dynamo.config.recompile_limit = warm_up_variants
-        torch._dynamo.config.fail_on_recompile_limit_hit = True
-        try:
-            for config in WARM_UP_CONFIGS:
-                logger.info("Running dummy sampler config: %s", config["name"])
+        for config in WARM_UP_CONFIGS:
+            logger.info("Running dummy sampler config: %s", config["name"])
 
-                set_sampling_tensors(
-                    self.input_batch,
-                    temperature=config["temperature"],
-                    top_p=config.get("top_p"),
-                    top_k=config.get("top_k"),
-                    frequency_penalties=config.get("frequency_penalties"),
-                    repetition_penalties=config.get("repetition_penalties"),
-                    presence_penalties=config.get("presence_penalties"),
-                )
+            set_sampling_tensors(
+                self.input_batch,
+                temperature=config["temperature"],
+                top_p=config.get("top_p"),
+                top_k=config.get("top_k"),
+                frequency_penalties=config.get("frequency_penalties"),
+                repetition_penalties=config.get("repetition_penalties"),
+                presence_penalties=config.get("presence_penalties"),
+            )
 
-                dummy_run_batches(config)
-        finally:
-            # Serving is a different question. A sampling combination the warm-up
-            # set does not cover must cost a compile, not the engine: restore the
-            # budget and let an overflow fall back to eager — slower, still
-            # correct, still serving.
-            torch._dynamo.config.recompile_limit = max(
-                saved_limit, 2 * warm_up_variants
-            )
-            # Not restored to its previous value on purpose: torch defaults it to
-            # True, and that default is what turns an unanticipated sampling
-            # combination into a dead engine.
-            torch._dynamo.config.fail_on_recompile_limit_hit = False
-            logger.info(
-                "Sampler warm-up done: %d variants compiled, recompile_limit "
-                "restored to %d, overflow falls back to eager.",
-                warm_up_variants,
-                torch._dynamo.config.recompile_limit,
-            )
+            dummy_run_batches(config)
 
     def set_active_loras(self, input_batch: RBLNInputBatch, is_prefill: bool) -> None:
         num_reqs = self.input_batch.num_reqs
@@ -1504,6 +1489,17 @@ class RBLNOptimumModelRunner(
                     (bucket_size, self.model_config.get_vocab_size()),
                     dtype=self.model.dtype,
                 )
+        # Only ever raise this: it is process-global, so setting it to the
+        # warm-up count capped every compiled function in the process — and with
+        # warm-up being opt-in, it was usually not even spent on warm-up.
+        torch._dynamo.config.recompile_limit = max(
+            torch._dynamo.config.recompile_limit,
+            sampler_recompile_budget(len(self.bucket_sizes)),
+        )
+        # A pair we did not anticipate must cost a compile, not the engine. torch
+        # defaults this to True, which turns the overflow into a dead EngineCore
+        # mid-serve instead of a slower eager fallback.
+        torch._dynamo.config.fail_on_recompile_limit_hit = False
         self.sampler = torch.compile(self.sampler, dynamic=False, fullgraph=False)
 
     @torch.inference_mode


### PR DESCRIPTION
## Symptom

Four served models die at the first request with

```
torch._dynamo.exc.FailOnRecompileLimitHit: Hard failure due to fail_on_recompile_limit_hit
torch._dynamo hit config.recompile_limit (9)
```

`qwen2-7b`, `salamandra-7b`, `midm-2.0-base`, `qwen2.5-vl-7b`. Their peers pass with **byte-identical request bodies** (`{"max_tokens": 32}`, no other sampling parameter) and the same serve-shape flags, so the request is not what distinguishes them.

## Cause

`prepare_rbln_sampler` lowers the **process-global** dynamo budget to exactly the number of variants warm-up compiles:

```python
torch._dynamo.config.recompile_limit = len(self.bucket_sizes) * len(WARM_UP_CONFIGS)
```

With `--max-num-seqs 1`, `bucket_sizes == [1]` and `len(WARM_UP_CONFIGS) == 9`, so the limit is 9 — and `dummy_sampler_run` compiles exactly 9. Zero headroom, by construction.

Two things make that fatal rather than merely tight:

1. **Warm-up is opt-in.** `optimum_worker.py` returns early unless `VLLM_RBLN_ENABLE_WARM_UP` is set, so in the default configuration the budget is lowered and *never restored* — nothing has been pre-compiled, and the 10th variant real traffic needs is the one that dies.
2. **torch defaults `fail_on_recompile_limit_hit` to True** (verified on the torch in this stack), so passing the budget raises instead of falling back to eager. A performance ceiling becomes an engine kill.

And because the knob is global, the warm-up value also caps every other compiled function in the process.

## Fix

Scope the tight budget to the warm-up loop, which is the only place the expected count is known:

- **During warm-up** — limit = `warm_up_variants`, `fail_on_recompile_limit_hit = True`. A recompile beyond it means the warm-up set has drifted from what the sampler specialises on. That is a bug, and failing on it while nobody is being served is the right response.
- **After warm-up** — restore `max(previous_limit, 2 * warm_up_variants)` and set `fail_on_recompile_limit_hit = False`. A sampling combination the warm-up set does not cover should cost a compile and run eager: slower, still correct, still serving.

`prepare_rbln_sampler` no longer touches the global knob, so the no-warm-up path keeps torch's default 64 instead of inheriting 9.

## Test

`tests/v1/worker/test_sampler.py::test_recompile_budget_leaves_room_for_serving`, parametrized over warm-up on and off. It asserts serving headroom over the warm-up count, that the global limit is never left lower than it started, and that overflow is non-fatal.

On the current code it fails with

```
AssertionError: serving must keep headroom over the warm-up variant count
assert 9 >= (2 * 9)
```

— the same 9 as the reported error. With the fix both cases pass. `ruff check` and `ruff format` are clean.

## Provenance

Found while running all 53 documented vLLM recipes from `rbln_sdk_doc` on 16x RBLN-CA22 (KMD 3.2.2), verbatim as a reader would copy them, on `vllm 0.22.0+cpu` + `vllm-rbln 0.11.1`. The code path is identical in `0.11.2a9`, so this is not version-specific.