### PR TITLE
fix(APC): keep multi-turn prefixes alive across eviction

### DIFF
--- a/tests/optimum/v1/core/test_prefix_caching.py
+++ b/tests/optimum/v1/core/test_prefix_caching.py
@@ -23,6 +23,8 @@ from vllm.utils.hashing import sha256
 from vllm.v1.core.kv_cache_utils import get_request_block_hasher, init_none_hash
 from vllm.v1.request import Request, RequestStatus
 
+from vllm_rbln.v1.core.prefix_cache_manager import RBLNPrefixKVCacheManager
+
 from .utils import create_model_runner_output, create_scheduler
 
 MAX_NUM_SEQ = 2
@@ -250,11 +252,11 @@ def test_cache_hit_child_block(limited_6blocks_scheduler):
     => [4, 5]
     4. Finish req0 and generate req3 with a different prompt,
        which spends 2 blocks when scheduled.
-    => [0, 1]
+    => [1, 0] (req0's blocks are evicted tail first)
     5. Finish req2 and generate req4 with the same prompt as req1,
        which spends 2 blocks when scheduled.
        Here, we check whether req4 correctly reuses req1's cached blocks.
-    => [4, 5] (reuse req1's cached blocks [2, 3])
+    => [5, 4] (reuse req1's cached blocks [2, 3])
     """
     init_none_hash(HASH_FN)
     # 1. Generate req0: 32 tokens -> 8 inner blocks
@@ -304,13 +306,13 @@ def test_cache_hit_child_block(limited_6blocks_scheduler):
     limited_6blocks_scheduler.update_from_output(output, model_runner_output)
     assert req3_id in output.block_table_dict
 
-    # Finish req2 and schedule req4 [4, 5]
+    # Finish req2 and schedule req4 [5, 4]
     # Reuse the req1's blocks [2, 3] for req4
     limited_6blocks_scheduler.finish_requests(req2_id, RequestStatus.FINISHED_ABORTED)
     output = limited_6blocks_scheduler.schedule()
     model_runner_output = create_model_runner_output(output)
     limited_6blocks_scheduler.update_from_output(output, model_runner_output)
-    answer = torch.tensor([4, 5, -1, -1], dtype=torch.int16)
+    answer = torch.tensor([5, 4, -1, -1], dtype=torch.int16)
     assert torch.allclose(output.block_table_dict[req4_id], answer)
     assert output.cached_block_table == [2, 3]
 
@@ -326,8 +328,8 @@ def test_allocated_blocks_excluded_from_cache_hit(limited_6blocks_scheduler):
         - It is for getting enough freed inner blocks.
     4. Finish req0 and req1, and generate req3 with the same prompt
         - Here, req3's prompt is the same as req0's prompt.
-        - req0 is allocated [0, 1]
-        - So the cached blocks become [2, 3], not [0, 1].
+        - req0's blocks are evicted tail first, so req3 is allocated [1, 0].
+        - So the cached blocks exclude req3's own blocks.
     """
     init_none_hash(HASH_FN)
     # 1. Generate req0: 32 tokens -> 8 inner blocks
@@ -370,19 +372,19 @@ def test_allocated_blocks_excluded_from_cache_hit(limited_6blocks_scheduler):
     assert output.cached_block_table == [2, 3]
     assert output.block_table_dict[req2_id].tolist() == [4, 5, -1, -1]
 
-    # Finish Schedule req0, req1 and schedule req3 [0, 1]
+    # Finish Schedule req0, req1 and schedule req3 [1, 0]
     # 1. To get enough freed inner blocks
     # this pytest finishes req0 and req1
-    # 2. req3 is allocated [0, 1] again
-    # 3. So the cached blocks become [2, 3]
-    # to exclude the allocated blocks [0, 1].
+    # 2. req3 is allocated req0's evicted blocks [1, 0] again
+    # 3. So the cached blocks become [4, 5]
+    # to exclude the allocated blocks [1, 0].
     limited_6blocks_scheduler.finish_requests(req0_id, RequestStatus.FINISHED_ABORTED)
     limited_6blocks_scheduler.finish_requests(req1_id, RequestStatus.FINISHED_ABORTED)
     output = limited_6blocks_scheduler.schedule()
     model_runner_output = create_model_runner_output(output)
     limited_6blocks_scheduler.update_from_output(output, model_runner_output)
     assert output.cached_block_table == [4, 5]
-    assert output.block_table_dict[req3_id].tolist() == [0, 1, -1, -1]
+    assert output.block_table_dict[req3_id].tolist() == [1, 0, -1, -1]
 
 
 def test_finish_request(scheduler):
@@ -448,3 +450,155 @@ def test_free_outer_blocks(scheduler):
     assert mapping_manager.get_mapping(0) is None
 
     assert len(mapping_manager._inner_to_outer) == 0
+
+
+def test_eviction_takes_conversation_tail_first():
+    """
+    Check that a finished request's outer blocks are evicted from the
+    tail of its prefix, not the front.
+
+    Matching stops at the first missing outer block, so evicting the
+    front block would invalidate the whole cached prefix while evicting
+    the tail only shortens the hit.
+    """
+    manager = RBLNPrefixKVCacheManager(
+        ob_size=OB_SIZE,
+        ib_size=IB_SIZE,
+        max_model_len=MAX_MODEL_LEN,
+        max_num_seqs=MAX_NUM_SEQ,
+        num_inner_blocks=16,
+    )  # 4 outer blocks
+    # req0 fills outer blocks [0, 1] and finishes.
+    manager.allocate_blocks("req0", 0, list(range(1, 9)))
+    manager.free_request("req0")
+    # req1 takes the remaining free outer blocks [2, 3].
+    manager.allocate_blocks("req1", 0, list(range(9, 17)))
+    # One more outer block forces eviction among req0's [0, 1].
+    assert manager.can_allocate(4, 0)
+    mapping_manager = manager._mapping_manager
+    assert mapping_manager.get_mapping(0) is not None
+    assert mapping_manager.get_mapping(1) is None
+
+
+def test_cache_hit_refreshes_eviction_order():
+    """
+    Check that a cache hit protects the matched outer blocks from
+    eviction: the least recently matched conversation is evicted first.
+    """
+    manager = RBLNPrefixKVCacheManager(
+        ob_size=OB_SIZE,
+        ib_size=IB_SIZE,
+        max_model_len=MAX_MODEL_LEN,
+        max_num_seqs=MAX_NUM_SEQ,
+        num_inner_blocks=24,
+    )  # 6 outer blocks
+    # Two finished conversations: req0 on [0, 1], req1 on [2, 3].
+    req0_inner_blocks = list(range(1, 9))
+    manager.allocate_blocks("req0", 0, req0_inner_blocks)
+    manager.free_request("req0")
+    manager.allocate_blocks("req1", 0, list(range(9, 17)))
+    manager.free_request("req1")
+    # req2 is running on [4] and hits req0's cached prefix.
+    manager.allocate_blocks("req2", 0, list(range(17, 21)))
+    cached_blocks, cached_lengths = manager.get_matched_outer_blocks(
+        "req2", req0_inner_blocks, len(req0_inner_blocks) * IB_SIZE
+    )
+    assert cached_blocks == [0, 1]
+    assert cached_lengths == [OB_SIZE, OB_SIZE]
+    # Evicting two blocks must take req1's [2, 3], not the just-hit [0, 1].
+    assert manager.can_allocate(12, 0)
+    mapping_manager = manager._mapping_manager
+    assert mapping_manager.get_mapping(0) is not None
+    assert mapping_manager.get_mapping(1) is not None
+    assert mapping_manager.get_mapping(2) is None
+    assert mapping_manager.get_mapping(3) is None
+
+
+def test_cache_hit_repositions_inner_blocks(scheduler):
+    """
+    Check that a cache hit moves the matched inner blocks to the tail
+    of the block pool's free queue without touching their ref_cnt.
+
+    The pool reuses free-queue blocks head-first and destroys their
+    hashes at reuse. A hit never touches the blocks (the copy-based
+    design must keep them freely reusable), so without repositioning
+    their queue position never refreshes and the hashes of a hot
+    conversation die on schedule, ending its outer-block hits.
+    """
+    init_none_hash(HASH_FN)
+    common_token_ids = [i for i in range(31)]
+    # req0's conversation: inner blocks [1..8], hashed [1..7].
+    req0 = create_request("req0", common_token_ids, IB_SIZE, HASH_FN)
+    scheduler.add_request(req0)
+    output = scheduler.schedule()
+    scheduler.update_from_output(output, create_model_runner_output(output))
+    scheduler.finish_requests("req0", RequestStatus.FINISHED_ABORTED)
+
+    # An unrelated conversation freed after req0: its hashed inner
+    # blocks sit behind req0's in the free queue.
+    other = create_request("other", [i + 100 for i in range(20)], IB_SIZE, HASH_FN)
+    scheduler.add_request(other)
+    output = scheduler.schedule()
+    scheduler.update_from_output(output, create_model_runner_output(output))
+    scheduler.finish_requests("other", RequestStatus.FINISHED_ABORTED)
+
+    # req1 repeats req0's prompt and hits its cached blocks.
+    req1 = create_request("req1", common_token_ids, IB_SIZE, HASH_FN)
+    scheduler.add_request(req1)
+    output = scheduler.schedule()
+    assert output.cached_block_table == [0, 1]
+    assert output.cached_length == [16, 12]
+
+    # The matched inner blocks [1..7] moved behind "other"'s blocks,
+    # tail of the prefix first, and stayed unreferenced.
+    block_pool = scheduler.kv_cache_manager.block_pool
+    free_ids = [
+        block.block_id for block in block_pool.free_block_queue.get_all_free_blocks()
+    ]
+    assert free_ids[-7:] == [7, 6, 5, 4, 3, 2, 1]
+    assert all(block_pool.blocks[block_id].ref_cnt == 0 for block_id in range(1, 8))
+
+
+def test_cache_hit_on_running_request_keeps_ref_cnt(scheduler):
+    """
+    Check the inner blocks' ref_cnt over the request lifecycle when the
+    prefix-cache hit source is still running.
+
+    ref_cnt on this path is a pure ownership flag: 1 while the
+    allocating request holds the block, 0 otherwise. A hit must not
+    add references (the hit copies the blocks instead of sharing them)
+    and must not reposition blocks a running request still owns, since
+    they are not in the free queue.
+    """
+    init_none_hash(HASH_FN)
+    common_token_ids = [i for i in range(31)]
+    # Allocation: req0 owns inner blocks [1..8].
+    req0 = create_request("req0", common_token_ids, IB_SIZE, HASH_FN)
+    scheduler.add_request(req0)
+    output = scheduler.schedule()
+    scheduler.update_from_output(output, create_model_runner_output(output))
+    block_pool = scheduler.kv_cache_manager.block_pool
+    assert all(block_pool.blocks[i].ref_cnt == 1 for i in range(1, 9))
+
+    # req1 hits req0's prefix while req0 is still running.
+    req1 = create_request("req1", common_token_ids, IB_SIZE, HASH_FN)
+    scheduler.add_request(req1)
+    output = scheduler.schedule()
+    assert output.cached_block_table == [0, 1]
+    assert output.cached_length == [16, 12]
+    # The hit adds no references: the matched blocks stay owned by req0
+    # alone and out of the free queue; req1 owns only its own blocks.
+    free_ids = {
+        block.block_id for block in block_pool.free_block_queue.get_all_free_blocks()
+    }
+    assert all(block_pool.blocks[i].ref_cnt == 1 for i in range(1, 9))
+    assert all(i not in free_ids for i in range(1, 9))
+    assert all(block_pool.blocks[i].ref_cnt == 1 for i in range(9, 17))
+
+    # Free: finishing req0 drops its ownership and requeues the blocks.
+    scheduler.finish_requests("req0", RequestStatus.FINISHED_ABORTED)
+    free_ids = {
+        block.block_id for block in block_pool.free_block_queue.get_all_free_blocks()
+    }
+    assert all(block_pool.blocks[i].ref_cnt == 0 for i in range(1, 9))
+    assert all(i in free_ids for i in range(1, 9))

--- a/vllm_rbln/v1/core/optimum_block_pool.py
+++ b/vllm_rbln/v1/core/optimum_block_pool.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Sequence
+
 from vllm.distributed.kv_events import KVCacheEvent
 from vllm.logger import init_logger
 from vllm.v1.core.block_pool import BlockHashToBlockMap, BlockPool
@@ -99,3 +101,31 @@ class RBLNBlockPool(BlockPool):
         self.kv_event_queue: list[KVCacheEvent] = []
 
         self.metrics_collector = metrics_collector
+
+    def refresh_cached_blocks(self, blocks: Sequence[KVCacheBlock]) -> None:
+        """Move free cached blocks to the tail of the free queue.
+
+        A cached block's hash lives only until the free queue reaches it:
+        `get_new_blocks` pops from the head and destroys the popped block's
+        hash entry. A prefix-cache hit copies the matched blocks instead of
+        referencing them, so nothing else refreshes their queue position;
+        moving them to the tail on every hit keeps a hot conversation's
+        hashes alive.
+
+        This must not raise ref_cnt. The hit does not actually reference
+        the blocks, so there is no later release to balance an increment,
+        and a block whose ref_cnt never returns to zero can never re-enter
+        the queue. Reordering the queue keeps the blocks freely reusable,
+        exactly as the copy-based design requires of its sources.
+
+        Iterated in reverse so the tail of the prefix sits nearer the head
+        and is reused before the front. Matching stops at the first missing
+        block, so the front must outlive the tail -- the same order the
+        outer copies are evicted in.
+        """
+        for block in reversed(blocks):
+            if block.ref_cnt > 0:
+                # Still referenced by a running request: not in the queue.
+                continue
+            self.free_block_queue.remove(block)
+            self.free_block_queue.append(block)

--- a/vllm_rbln/v1/core/optimum_kv_cache_manager.py
+++ b/vllm_rbln/v1/core/optimum_kv_cache_manager.py
@@ -341,11 +341,26 @@ class RBLNKVCacheManager(KVCacheManager):
         num_new_computed_tokens: int,
     ) -> tuple[list[int], list[int]]:
         cached_blocks = new_computed_blocks.get_block_ids()[0]
-        return self.prefix_cache_manager.get_matched_outer_blocks(
-            request.request_id,
-            cached_blocks,
-            num_new_computed_tokens,
+        cached_block_table, cached_length = (
+            self.prefix_cache_manager.get_matched_outer_blocks(
+                request.request_id,
+                cached_blocks,
+                num_new_computed_tokens,
+            )
         )
+        if cached_block_table:
+            # Keep the matched inner blocks' hashes alive as long as their
+            # outer copies. A hit bypasses allocate_slots' touch path
+            # (allocation passes empty computed blocks), so without
+            # repositioning, the hit blocks keep their free-queue position
+            # and get reused -- destroying their hashes -- while the outer
+            # copy is still resident, after which the outer block can never
+            # be matched again.
+            num_matched_blocks = sum(cached_length) // self.block_size
+            self.block_pool.refresh_cached_blocks(
+                new_computed_blocks.blocks[0][:num_matched_blocks]
+            )
+        return cached_block_table, cached_length
 
     def get_block_table(self, request_id: str) -> torch.Tensor:
         return self.prefix_cache_manager.get_blocks(request_id)

--- a/vllm_rbln/v1/core/prefix_cache_manager/optimum_eviction_policy.py
+++ b/vllm_rbln/v1/core/prefix_cache_manager/optimum_eviction_policy.py
@@ -20,71 +20,16 @@ from .optimum_block_mapping_manager import BlockMappingManager
 logger = init_logger(__name__)
 
 
-class SimpleEvictionPolicy:
-    """
-    Simple eviction policy to select blocks for eviction.
-    """
-
-    def register_block(self, block_id: int) -> None:
-        """Register a new block (called when block is first allocated)"""
-        pass
-
-    def unregister_block(self, block_id: int) -> None:
-        """Unregister a block (called when block is deallocated)"""
-        pass
-
-    def select_blocks_for_eviction(
-        self, mapping_manager: BlockMappingManager, count: int
-    ) -> list[int]:
-        """Select blocks for eviction."""
-        inactive_mappings = mapping_manager.get_inactive_mappings()
-        inactive_block_ids = [m.outer_block_id for m in inactive_mappings]
-        if len(inactive_block_ids) < count:
-            return []
-
-        return inactive_block_ids[:count]
-
-
-class FIFOEvictionPolicy(SimpleEvictionPolicy):
-    """
-    FIFO (First In First Out) eviction policy implementation.
-    """
-
-    def __init__(self):
-        self._allocation_order: OrderedDict[int, bool] = OrderedDict()
-
-    def register_block(self, block_id: int) -> None:
-        assert block_id not in self._allocation_order
-        self._allocation_order[block_id] = True
-
-    def unregister_block(self, block_id: int) -> None:
-        self._allocation_order.pop(block_id, None)
-
-    def select_blocks_for_eviction(
-        self, mapping_manager: BlockMappingManager, count: int
-    ) -> list[int]:
-        # NOTE If the cached block is evicted, we should also evict its mapping
-        # How about exclude the cached blocks from eviction?
-        # AS-IS: Eviction -> Cache check -> Allocation
-        # TO-DO: Cache check -> Eviction -> Allocation (more complicated)
-        inactive_mappings = mapping_manager.get_inactive_mappings()
-        inactive_block_ids = [m.outer_block_id for m in inactive_mappings]
-
-        evictable_blocks = [
-            block_id
-            for block_id in self._allocation_order
-            if block_id in inactive_block_ids
-        ]
-
-        if len(evictable_blocks) < count:
-            return []
-
-        return evictable_blocks[:count]
-
-
-class LRUEvictionPolicy(SimpleEvictionPolicy):
+class LRUEvictionPolicy:
     """
     LRU (Least Recently Used) eviction policy implementation.
+
+    Recency comes from `touch`. The prefix cache manager touches a
+    sequence's blocks in reverse order (front of the prefix last), so
+    within one sequence the tail is always evicted before the front.
+    Matching stops at the first missing block, so evicting the front
+    would invalidate the whole cached prefix while evicting the tail
+    only shortens the hit.
     """
 
     def __init__(self):
@@ -105,22 +50,16 @@ class LRUEvictionPolicy(SimpleEvictionPolicy):
     def select_blocks_for_eviction(
         self, mapping_manager: BlockMappingManager, count: int
     ) -> list[int]:
-        inactive_mappings = mapping_manager.get_inactive_mappings()
-        inactive_block_ids = [m.outer_block_id for m in inactive_mappings]
+        inactive_block_ids = {
+            mapping.outer_block_id
+            for mapping in mapping_manager.get_inactive_mappings()
+        }
 
-        untouched_blocks = [
-            block_id
-            for block_id in inactive_block_ids
-            if block_id not in self._access_order
-        ]
-
-        touched_blocks = [
+        evictable_blocks = [
             block_id
             for block_id in self._access_order
             if block_id in inactive_block_ids
         ]
-
-        evictable_blocks = untouched_blocks + touched_blocks
         if len(evictable_blocks) < count:
             return []
         return evictable_blocks[:count]

--- a/vllm_rbln/v1/core/prefix_cache_manager/optimum_prefix_cache_manager.py
+++ b/vllm_rbln/v1/core/prefix_cache_manager/optimum_prefix_cache_manager.py
@@ -23,7 +23,7 @@ import torch
 from vllm_rbln.logger import init_logger
 
 from .optimum_block_mapping_manager import BlockMappingManager, RBLNBlock
-from .optimum_eviction_policy import FIFOEvictionPolicy, LRUEvictionPolicy
+from .optimum_eviction_policy import LRUEvictionPolicy
 
 logger = init_logger(__name__)
 NO_MATCH_FOUND = -1
@@ -255,7 +255,7 @@ class RBLNPrefixKVCacheManager:
         self._mapping_manager = BlockMappingManager()
         self._cache_search_manager = CacheSearchManager(self._config)
         self._memory_pool_manager = MemoryPoolManager(max_model_len, ob_size)
-        self._eviction_policy = FIFOEvictionPolicy()
+        self._eviction_policy = LRUEvictionPolicy()
 
     def is_full_block_available(self) -> bool:
         blocks_per_seq = math.ceil(self._config.max_model_len / self._config.ob_size)
@@ -418,6 +418,12 @@ class RBLNPrefixKVCacheManager:
                 assert mapping is not None, "Mapping not found for block"
                 mapping.is_active = False
                 mapping.request_id = None
+        if not preemption:
+            # The blocks were registered in allocation order, which would
+            # evict the front of the prefix first. Touch in reverse so the
+            # tail is evicted before the front.
+            for block_id in reversed(outer_blocks):
+                self._eviction_policy.touch(block_id)
 
     def get_matched_outer_blocks(
         self, request_id: str, cached_blocks: list[int], num_new_computed_tokens: int
@@ -433,12 +439,10 @@ class RBLNPrefixKVCacheManager:
             "Cached outer blocks and allocated outer blocks should be disjoint"
         )
 
-        if result.has_cache_hit and isinstance(
-            self._eviction_policy, LRUEvictionPolicy
-        ):
-            # NOTE(eunji.lee):
-            # To increase the hit ratio,
-            # we need to touch the blocks in reverse order.
+        if result.has_cache_hit:
+            # Touch in reverse so the front of the prefix ends up the most
+            # recently used: matching stops at the first missing block, so
+            # the front must outlive the tail.
             for ob_id in reversed(result.cached_outer_blocks):
                 self._eviction_policy.touch(ob_id)
 


### PR DESCRIPTION
### 🚀 Summary of Changes

This PR fixes prefix-cache entries being invalidated too early during multi-turn conversations in the Optimum path.

#### Problem

Multi-turn conversations reuse the oldest prefix blocks first. However, the existing eviction behavior could remove those blocks prematurely at two levels:

1. **Outer blocks**
   - Outer blocks were evicted in FIFO order, starting from the front of the prefix.
   - Prefix matching stops at the first missing block.
   - As a result, evicting a single block from the front invalidated the entire cached prefix.

2. **Inner blocks**
   - A cache hit did not refresh the matched inner blocks' positions in the free queue.
   - The block pool could therefore reuse those blocks and remove their hashes while the corresponding outer blocks were still cached.
   - Once the hashes were removed, the outer blocks could no longer be matched.

#### Solution

This PR aligns the inner- and outer-block eviction order around recency:

- Use **LRU** as the outer-block eviction policy.
- Touch outer blocks in reverse prefix order when:
  - a cache hit occurs, or
  - a request is freed.
- Evict the tail of a prefix before its front, preserving the longest reusable prefix.
- Add `RBLNBlockPool.refresh_cached_blocks()` to move matched, unreferenced inner blocks to the tail of the free queue after a cache hit.
- Preserve the copy-based cache design by only reordering blocks without incrementing their `ref_cnt`.
- Leave blocks owned by running requests unchanged because they are not part of the free queue.

This change applies to the **Optimum path only**.

---

### 📌 Related Issues / Tickets

- Resolves #
- Related to #

---

### ✅ Type of Change

- [ ] 🚀 Release (`release`)
- [ ] ✨ Feature (`feature`)
- [ ] 🧠 Model support (`model`)
- [x] 🧬 Core engine changes (`core`)
- [x] 🛠 Bug fix (`fix`)
- [ ] ⚙️ Performance improvement (`perf`)
- [ ] 🔁 Refactor or code cleanup (`refactor`)
- [ ] 📄 Documentation (`docs`)
- [ ] ❓ Other (`other`)

---

### 🧪 How to Test

Run the prefix-caching tests:

```bash
pytest tests/optimum/v1/core/test_prefix_caching.py
```

Regression tests cover the following scenarios:

1. A finished conversation evicts outer blocks from the tail of its prefix first.
2. A cache hit refreshes the outer-block LRU order.
3. Matched inner blocks are moved to the tail of the free queue.
4. Refreshing cached inner blocks does not modify their `ref_cnt`.
5. Cache hits sourced from a running request preserve block ownership and free-queue state.
6. Existing cache-hit and allocated-block exclusion behavior remains valid under the new eviction order.

---

### 📋 Checklist

- [x] PR title follows the Conventional Commits format
- [ ] This PR is linked to an existing issue
- [x] The test method and expected behavior are described
- [x] Regression tests have been added
- [x] Documentation updates are not required

---

### 💬 Notes

Reviewers may want to focus on the following invariants:

- The front of a cached prefix must outlive its tail because matching stops at the first missing block.
- A cache hit must not increment the matched inner blocks' `ref_cnt`.
- Blocks owned by a running request must not be repositioned in the free queue.
- Inner-block hashes should remain valid for as long as their corresponding outer-cache entries can be matched.