### PR TITLE
fix(scheduler): reject a max_model_len the KV pool can never serve

### DIFF
--- a/tests/native/v1/core/test_pd_disaggregation.py
+++ b/tests/native/v1/core/test_pd_disaggregation.py
@@ -28,7 +28,8 @@ from vllm_rbln.v1.core.utils import step_is_prefill
 
 BLOCK_SIZE = 16
 PROMPT_LEN = 2 * BLOCK_SIZE
-MAX_LEN = BLOCK_SIZE * 100
+# 99, not 100: one block of the pool is BlockPool's reserved null block.
+MAX_LEN = BLOCK_SIZE * 99
 
 
 def _scheduler(matched_tokens: int, *, is_async: bool = True, **kwargs):

--- a/tests/native/v1/core/test_rbln_scheduler.py
+++ b/tests/native/v1/core/test_rbln_scheduler.py
@@ -240,8 +240,9 @@ class TestScheduleBasic:
         assert len(sched.waiting) == 2
 
     def test_chunked_prefill_across_steps(self):
-        # A prompt longer than max_num_batched_tokens is chunked across steps.
-        sched = create_rbln_scheduler(max_num_batched_tokens=256)
+        # A prompt longer than max_num_batched_tokens is chunked across steps;
+        # max_model_len only has to clear the prompt itself.
+        sched = create_rbln_scheduler(max_num_batched_tokens=256, max_model_len=1024)
         req = create_requests(1, num_tokens=500)[0]
         sched.add_request(req)
         out = sched.schedule()
@@ -329,14 +330,62 @@ class TestScheduleDecodeBatchLimit:
         assert not sched.requests
 
 
+class TestCapacityInvariant:
+    # One block of the pool is BlockPool's reserved null block, so a
+    # max_model_len above (num_blocks - 1) * block_size admits prompts that can
+    # never be allocated: they retry every step forever and block the queue
+    # behind them. The scheduler rejects such a config at construction.
+    BLOCK_SIZE = 8192
+    NUM_BLOCKS = 13
+    USABLE = (NUM_BLOCKS - 1) * BLOCK_SIZE
+
+    def _scheduler(self, max_model_len: int):
+        return create_rbln_scheduler(
+            block_size=self.BLOCK_SIZE,
+            num_blocks=self.NUM_BLOCKS,
+            max_model_len=max_model_len,
+            max_num_batched_tokens=512,
+        )
+
+    def test_max_model_len_beyond_usable_pool_is_rejected(self):
+        # max_model_len sized to the whole pool, which is one block too many.
+        with pytest.raises(ValueError, match="usable KV cache capacity"):
+            self._scheduler(self.NUM_BLOCKS * self.BLOCK_SIZE)
+
+    def test_max_model_len_at_usable_capacity_is_accepted(self):
+        sched = self._scheduler(self.USABLE)
+        assert sched.max_model_len == self.USABLE
+
+    def test_prompt_at_usable_capacity_still_schedules(self):
+        # The guard must not be off by one the other way: the longest admissible
+        # prompt (max_model_len - 1, since admission rejects the rest) has to
+        # keep running, one max_num_batched_tokens chunk per step.
+        sched = self._scheduler(self.USABLE)
+        req = create_requests(
+            1, num_tokens=self.USABLE - 1, block_size=self.BLOCK_SIZE
+        )[0]
+        sched.add_request(req)
+        out = sched.schedule()
+        assert out.num_scheduled_tokens[req.request_id] == 512
+
+
 class TestSchedulePrefillAllocation:
     def test_prefill_not_scheduled_when_full_prompt_cannot_fit(self):
-        # KV is reserved for the whole prompt: 500 tokens need 32 blocks and only
-        # ~19 are usable, so nothing is scheduled even though one chunk would fit.
+        # KV is reserved for the whole prompt, so a prefill waits until all of
+        # it fits: with 8 of the 19 usable blocks held by a running decode, a
+        # 200-token prompt (13 blocks) is not scheduled even though its first
+        # 128-token chunk would fit.
         sched = create_rbln_scheduler(
-            max_num_batched_tokens=128, block_size=16, num_blocks=20
+            max_num_batched_tokens=128,
+            block_size=16,
+            num_blocks=20,
+            max_model_len=19 * 16,  # the usable pool
         )
-        req = create_requests(1, num_tokens=500, block_size=16)[0]
+        running = create_requests(
+            1, num_tokens=128, block_size=16, max_tokens=30, req_ids=["running"]
+        )[0]
+        advance_to_decode(sched, running)
+        req = create_requests(1, num_tokens=200, block_size=16, req_ids=["waiting"])[0]
         sched.add_request(req)
         out = sched.schedule()
         assert req.request_id not in out.num_scheduled_tokens
@@ -344,7 +393,7 @@ class TestSchedulePrefillAllocation:
         sched2 = create_rbln_scheduler(
             max_num_batched_tokens=128, block_size=16, num_blocks=10000
         )
-        req2 = create_requests(1, num_tokens=500, block_size=16)[0]
+        req2 = create_requests(1, num_tokens=200, block_size=16)[0]
         sched2.add_request(req2)
         out2 = sched2.schedule()
         assert out2.num_scheduled_tokens[req2.request_id] == 128

--- a/tests/native/v1/core/test_sub_block_prefix_caching.py
+++ b/tests/native/v1/core/test_sub_block_prefix_caching.py
@@ -88,7 +88,8 @@ class TestScheduleSubBlockCopyOps:
 class TestSubBlockVersusKVConnector:
     # Whoever covers more wins, sub-block on ties since a local copy beats an
     # RDMA fetch. None of that code runs without a connector, hence the mock.
-    MAX_LEN = BLOCK_SIZE * 100
+    # 99, not 100: one block of the pool is BlockPool's reserved null block.
+    MAX_LEN = BLOCK_SIZE * 99
 
     def _scheduler(self, matched_tokens: int):
         return create_rbln_scheduler(

--- a/tests/native/v1/core/utils.py
+++ b/tests/native/v1/core/utils.py
@@ -151,11 +151,21 @@ def create_rbln_scheduler(
 ) -> RBLNScheduler:
     """Build an RBLNScheduler on CPU (ported from upstream tests/v1/core/utils):
     opt-125m config only, num_gpu_blocks set manually, no KV connector."""
-    model_config = ModelConfig(
-        model=local_model_path(model), trust_remote_code=True, dtype="float16", seed=42
-    )
     if max_model_len is None:
-        max_model_len = max_num_batched_tokens
+        # One block of the pool is BlockPool's reserved null block, and the
+        # scheduler rejects a max_model_len above the remaining capacity.
+        max_model_len = min(max_num_batched_tokens, (num_blocks - 1) * block_size)
+    model_config = ModelConfig(
+        model=local_model_path(model),
+        trust_remote_code=True,
+        dtype="float16",
+        seed=42,
+        # The scheduler reads max_model_len from model_config, so setting it on
+        # SchedulerConfig alone would leave every test on opt-125m's native
+        # 2048; the hf override lifts that native limit out of the way.
+        max_model_len=max_model_len,
+        hf_overrides={"max_position_embeddings": max_model_len},
+    )
     scheduler_config = SchedulerConfig(
         max_num_seqs=max_num_seqs,
         max_num_batched_tokens=max_num_batched_tokens,

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -69,6 +69,8 @@ class RBLNScheduler(Scheduler):
     ) -> None:
         super().__init__(*args, **kwargs)
 
+        self._validate_kv_cache_capacity()
+
         # Replace the upstream KVCacheManager with RBLNKVCacheManager
         # when sub-block prefix caching is enabled.
         # Sub-block size equals the prefill chunk size (max_num_batched_tokens)
@@ -127,6 +129,35 @@ class RBLNScheduler(Scheduler):
         # ceil(demand / pp) to spread decodes across microbatches. pp == 1 makes
         # the soft cap a no-op. See v1/core/utils.py.
         self._pp_size = self.vllm_config.parallel_config.pipeline_parallel_size
+
+    def _validate_kv_cache_capacity(self) -> None:
+        """Reject a max_model_len the KV cache pool can never serve.
+
+        BlockPool permanently reserves one null block, so only
+        (num_blocks - 1) blocks are allocatable. Admission checks a prompt
+        against max_model_len alone while a new prefill reserves the whole
+        sequence up front, so a prompt above the usable capacity is admitted
+        and then fails allocation on every step: it waits forever without
+        erroring and head-of-line-blocks the requests behind it. Upstream's
+        startup check sizes the pool against cdiv(max_model_len, block_size)
+        blocks, one more than are usable, so it does not cover this.
+
+        The bound assumes a single KV cache group at the scheduler's block
+        size. A hybrid layout draws from the same pool for every group and so
+        needs at least this much, which keeps the check conservative: it can
+        miss a violation, never invent one.
+        """
+        num_blocks = self.kv_cache_config.num_blocks
+        usable_tokens = (num_blocks - 1) * self.block_size
+        if self.max_model_len > usable_tokens:
+            raise ValueError(
+                f"max_model_len ({self.max_model_len}) exceeds the usable KV "
+                f"cache capacity ({usable_tokens} tokens = ({num_blocks} blocks "
+                f"- 1 reserved null block) x {self.block_size} tokens per "
+                "block). Prompts above the usable capacity would wait forever. "
+                "Raise the KV cache block count (e.g. --num-gpu-blocks-override) "
+                "or lower --max-model-len."
+            )
 
     def _decode_demand(self) -> int:
         """Total decode demand for this step's soft (ceil(demand/pp)) cap.


### PR DESCRIPTION
### 🚀 Summary of Changes

The usable KV cache pool is `(num_blocks - 1) * block_size` tokens, because `BlockPool`
permanently reserves one block as its null block. Nothing checked `max_model_len` against
that, so a prompt in the gap was admitted and then failed allocation on every scheduling
attempt — waiting forever without erroring and head-of-line-blocking the engine. #957 has
the full analysis and reproduction.

`RBLNScheduler` now validates the invariant at construction and refuses the configuration:

```
max_model_len (106496) exceeds the usable KV cache capacity (98304 tokens =
(13 blocks - 1 reserved null block) x 8192 tokens per block). Prompts above the usable
capacity would wait forever. Raise the KV cache block count (e.g.
--num-gpu-blocks-override) or lower --max-model-len.
```

Two test-side fixes come with it, both exposed by the invariant:

- `create_rbln_scheduler` passed `max_model_len` to `SchedulerConfig` only, which the
  scheduler does not read, so every test in `tests/native/v1/core` silently ran at
  opt-125m's native 2048 whatever it asked for. It now reaches `ModelConfig`, and the
  default stays within the usable pool.
- 15 existing test configurations violated the invariant, 11 of them by setting
  `max_model_len` to exactly `num_blocks * block_size` — the same shape as the
  configurations in #957. Two further tests relied on the clamp: one needed a
  `max_model_len` above its prompt, and the full-prompt-must-fit test now creates pool
  pressure with a running decode instead of an oversized prompt, since a prompt longer
  than the pool can no longer be admitted at all.

Affected modules: Scheduler (`vllm_rbln/v1/core/rbln_scheduler.py`), native core tests.

---

### 📌 Related Issues / Tickets

* Resolves #957

---

### ✅ Type of Change

* [x] 🛠 Bug fix (`fix`)

---

### 🧪 How to Test

1. `pytest tests/native/v1/core` — 195 passed, 2 skipped (192 passed before, plus the
   three new cases).
2. `pytest tests/native` — 87 failed, 1234 passed, 2 errors. The failing set is identical
   to the `dev` baseline; all of it predates this branch and lives in
   `tests/native/v1/worker`.
3. Remove the `_validate_kv_cache_capacity()` call and re-run
   `pytest tests/native/v1/core/test_rbln_scheduler.py::TestCapacityInvariant` —
   `test_max_model_len_beyond_usable_pool_is_rejected` fails, the other two pass.
4. Boundary check: `TestCapacityInvariant` also asserts that `max_model_len` equal to the
   usable capacity is accepted and that the longest admissible prompt still schedules, so
   the guard cannot go off by one in the other direction.

Verified against vllm 0.24.0+cpu on `dev` @1b138645.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (no user-facing docs cover KV block sizing)

---

### 💬 Notes

Two points worth a reviewer's attention:

- `create_rbln_scheduler` now defaults `max_model_len` to
  `min(max_num_batched_tokens, (num_blocks - 1) * block_size)` so the harness builds a
  valid configuration by default. The alternative is to leave the default alone and set
  `max_model_len` explicitly in the six tests that would otherwise fail; that keeps each
  test's intent visible in its own body at the cost of a larger diff. Say which you
  prefer and I will switch.
- The invariant assumes a single KV cache group at the scheduler's block size. A hybrid
  layout draws from the same pool for every group and so needs at least this much, which
  keeps the check conservative: it can miss a violation, never invent one. The docstring
  says so.
