### PR TITLE
docs(agent): adjust the agent rules after first use

### DIFF
--- a/.claude/skills/finishing-a-change/SKILL.md
+++ b/.claude/skills/finishing-a-change/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finishing-a-change
-description: Use before claiming a change is done, fixed, ready, or passing, and before writing a commit or PR — runs the checks, reviews the diff against the repository rules, and reports what was not done.
+description: Use before claiming a change is done, fixed, ready, or passing, and before you commit, open a PR, or run gh pr create — runs the checks, reviews the diff against the repository rules, fills in the PR template, and reports what was not done.
 ---
 
 # Finishing a change
@@ -39,6 +39,7 @@ Look for each of these:
 - **`else` branches for cases that cannot happen** — should be `assert` or `raise`
 - **Dead leftovers** — renamed `_var`, unused re-exports, `# removed` comments
 - **Anything not in English**
+- **Measured numbers** — throughput, latency, memory, or accuracy from an internal run. Take them out; this repository is public.
 
 Repository-specific checks:
 
@@ -64,4 +65,5 @@ An empty list is a claim. Only write it if it is true.
 - `type(scope): summary`, matching the existing history
 - Explain intent, not the diff
 - Say which model path or paths the change affects
-- English
+- English, and no measured numbers
+- Fill in `.github/PULL_REQUEST_TEMPLATE.md`. `gh pr create --body` does not apply it, so read the file and follow its sections rather than writing free-form prose.

--- a/.claude/skills/finishing-a-change/SKILL.md
+++ b/.claude/skills/finishing-a-change/SKILL.md
@@ -39,7 +39,7 @@ Look for each of these:
 - **`else` branches for cases that cannot happen** — should be `assert` or `raise`
 - **Dead leftovers** — renamed `_var`, unused re-exports, `# removed` comments
 - **Anything not in English**
-- **Measured numbers** — throughput, latency, memory, or accuracy from an internal run. Take them out; this repository is public.
+- **Absolute measurements** — throughput, latency, memory, or accuracy from an internal run. Take them out; this repository is public. A relative change is fine.
 
 Repository-specific checks:
 
@@ -66,5 +66,5 @@ An empty list is a claim. Only write it if it is true.
 - Summarise what changed in a line or two, then explain what the diff cannot show
 - Say which model path or paths the change affects
 - English
-- A perf change says the direction, not the number
+- A perf change may give a relative change, never an absolute measurement
 - Fill in `.github/PULL_REQUEST_TEMPLATE.md`. `gh pr create --body` does not apply it, so read the file and follow its sections rather than writing free-form prose.

--- a/.claude/skills/finishing-a-change/SKILL.md
+++ b/.claude/skills/finishing-a-change/SKILL.md
@@ -63,7 +63,8 @@ An empty list is a claim. Only write it if it is true.
 ## 5. Write the commit and PR
 
 - `type(scope): summary`, matching the existing history
-- Explain intent, not the diff
+- Summarise what changed in a line or two, then explain what the diff cannot show
 - Say which model path or paths the change affects
-- English, and no measured numbers
+- English
+- A perf change says the direction, not the number
 - Fill in `.github/PULL_REQUEST_TEMPLATE.md`. `gh pr create --body` does not apply it, so read the file and follow its sections rather than writing free-form prose.

--- a/.claude/skills/writing-tests/SKILL.md
+++ b/.claude/skills/writing-tests/SKILL.md
@@ -100,4 +100,3 @@ Watch it fail and read the failure — a test can fail for the wrong reason. If 
 - Duplicating the implementation's logic inside the test
 - Mocking what a real object or a temporary directory would do
 - A placeholder test that is skipped
-- A test diff larger than the code change it covers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,12 @@ Everything in the repository is written in English: code, comments, docstrings, 
 
 Conversation with the user is not a repository artifact. Reply in the language the user writes in.
 
+## What not to publish
+
+This repository is public. Keep measured numbers out of it: throughput, latency, memory footprint, and accuracy from internal runs do not belong in code, comments, tests, docs, commit messages, or PR descriptions. Benchmark scripts live here; their results do not. When a change needs a measurement to justify it, describe the direction and keep the figures to an internal channel.
+
+Upstream vLLM asks for eval results in the PR description. That convention does not apply here.
+
 ## Scope
 
 - Look for an existing utility or mechanism before writing a significant amount of new code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,7 @@ Some of the rules above cost something to follow. When you believe a case is a r
 
 Follow the existing convention: `type(scope): summary`, for example `fix(mega-cache): key the bundle on the warm-up graph set`.
 
-Explain intent. The diff already shows what changed, so a message that narrates it adds nothing.
+Explain intent. Summarise what changed in a line or two, then spend the space on what the diff cannot show — the reason behind an unusual approach, a constraint that forced the shape, a tradeoff that was weighed. Do not walk through the diff file by file; that is the part a reader can already see.
 
 ## Skills
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,14 @@ The codebase already has a word for each of these. Use it, and do not reach for 
 
 **`@register_patch` overwrites an upstream symbol and is the last resort.** Use it only when no extension point exists, and make `reason` say what upstream cannot express — not what the replacement does. When you are unsure whether an extension point exists, ask instead of defaulting to a patch.
 
+These are the cases that legitimately reach a patch:
+
+- Upstream's shape cannot express an RBLN constraint, such as a KV cache that has to enter the compiled graph as an input, or a kernel RBLN does not provide.
+- An upstream module needs adapting to an RBLN interface, and replacing one method beats reimplementing the model.
+- An upstream bug, or a fix that is not released yet. Cite the upstream issue and give the version that removes the need, such as `TODO(vllm>=0.26.0): delete`. A temporary patch with no removal condition becomes a permanent one.
+
+The registry rules:
+
 - Never `setattr` an upstream symbol directly. Every replacement goes through the registry, which verifies that it took.
 - A new module under `patches/` must be added to the import list in `patches/__init__.py`. A decorator in a module nobody imports registers nothing.
 - Duplicate keys and duplicate targets raise. Two patches may share a target only when their `condition` predicates are mutually exclusive.
@@ -106,7 +114,6 @@ Code either succeeds or fails with a clear error.
 
 - A test must fail without the change it covers. Verify that; do not assume it.
 - Cover what the change touched. Do not test pre-existing logic, third-party functions, or statically defined values.
-- If the test diff dwarfs the code change, cut scope.
 - Extend an existing file, `conftest.py` fixture, or `utils.py` helper before adding a new file.
 - Do not add a test that is skipped as a placeholder. A test that never runs covers nothing while reading as coverage that exists.
 - `--strict-markers` turns a misspelled mark into a collection error, but a mark you leave off is silent. Forgetting `model_compile` is how a whole-model compile ends up in the lane that runs on every PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,9 @@ Conversation with the user is not a repository artifact. Reply in the language t
 
 ## What not to publish
 
-This repository is public. Keep measured numbers out of it: throughput, latency, memory footprint, and accuracy from internal runs do not belong in code, comments, tests, docs, commit messages, or PR descriptions. Benchmark scripts live here; their results do not. When a change needs a measurement to justify it, describe the direction and keep the figures to an internal channel.
+This repository is public. Absolute measurements stay out of it: throughput, latency, memory footprint, and accuracy from an internal run do not belong in code, comments, tests, docs, commit messages, or PR descriptions. Benchmark scripts live here; their results do not.
+
+A relative change is fine. Say that something got a third faster, not what the two numbers were, and keep the raw figures to an internal channel.
 
 Upstream vLLM asks for eval results in the PR description. That convention does not apply here.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,7 @@ Explain intent. Summarise what changed in a line or two, then spend the space on
 
 ## Skills
 
-Read and follow the matching skill before you start:
+Read and follow the matching skill at the point it applies:
 
 - Adding or changing tests under `tests/native/`: `.claude/skills/writing-tests/SKILL.md`
 - Investigating a bug, a test failure, or unexpected behavior: `.claude/skills/debugging/SKILL.md`


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

Follow-up to #936. Some adjustments from using the rules and from what the review surfaced.

- Patching now says when a patch is right, not only when it is wrong.
- Dropped the rule that the test diff should stay smaller than the code change.
- Added `What not to publish`. The repository is public, so throughput, latency, memory and accuracy form internal runs stay out of code, commits and PR descriptions.
- PR descriptions have to use the template.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #936 

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [x] 📄 Documentation (`docs`)

---

### 🧪 How to Test

N/A

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

@rebel-jonghewk one open question. The rule as written says a perf change gives the direction only, with no numbers. I left it that way rather than deciding on my own, but would a relative figure like "30% faster" be fine? Direction alone may be too weak to justify a perf change in review, though the internal channel is there for the details, so it works either way. Let me know and I will update the rule.

---
