### PR TITLE
perf(worker): skip full dynamo guard evaluation after warm-up

### DIFF
--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -259,6 +259,8 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             else None
         )
         self.runtime_holder: list = []
+        # Set once warm-up has compiled every model shape (see warmup_model).
+        self._skip_guard_eval = False
 
         # Sampler
         if envs.VLLM_RBLN_SAMPLER:
@@ -1474,6 +1476,12 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 scheduler_output,
                 defer_finalize=defer_kv_connector_finalize,
             ) as kv_connector_output,
+            # Scoped to the model call: demand-driven compiled helpers (e.g.
+            # logprobs gathering in the sampler) legitimately compile after
+            # warm-up and must keep full guard evaluation.
+            torch.compiler.set_stance(skip_guard_eval_unsafe=True)
+            if self._skip_guard_eval
+            else nullcontext(),
         ):
             model_output = self.model_executable(
                 **staged_model_inputs.as_kwargs(),
@@ -3124,6 +3132,12 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 self.drafter.dummy_run()
 
         mega_cache.save(self.model_config.model, sig)
+
+        # Warm-up compiled every shape the model executable dispatches, so
+        # keep only the guards that pick between cache entries; an un-warmed
+        # shape now raises instead of silently recompiling.
+        self._skip_guard_eval = True
+        logger.info("Dynamo guard evaluation reduced to diff guards.")
 
     def _process_kv_cache_copy_ops(
         self,


### PR DESCRIPTION
### 🚀 Summary of Changes

On the vLLM-native path, every compiled model call re-evaluates the full Dynamo guard set — one TENSOR_MATCH per graph input, every step. But bucketing warm-up has already compiled every shape the model executable will ever dispatch, so this work only re-checks answers that cannot change.

After warm-up, the model call in `execute_model` runs under `torch.compiler.set_stance(skip_guard_eval_unsafe=True)`. Only the guards that pick between Dynamo cache entries still run, which cuts per-call dispatch overhead to roughly a quarter in steady-state decode.

The stance is scoped to the model call instead of being set globally. Warm-up covers the model's shape space, but not every compiled function in the process: demand-driven helpers such as the sampler's logprobs gathering legitimately compile new shapes after warm-up (only requests that ask for logprobs reach them), and a global stance turns that first compile into a hard failure. Scoping keeps full guard evaluation for everything except the warmed model call.

Why this is safe without a toggle:
- The stance is engaged only after `warmup_model()` actually ran (the worker skips warm-up for `enforce_eager`, compile-off, and warm-up-off), so it is never active without full shape coverage.
- If an un-warmed shape ever reaches the model call, Dynamo raises a RuntimeError instead of silently recompiling — it fails loud, not wrong.

**This is part 1 of a 3-part input-setup optimization series:**
1. this PR — skip full guard evaluation for the warmed model call (vllm-rbln)
2. runtime Python input identity cache (rebel_compiler#13005)
3. runtime C++ vmem input-prep optimization (rebel_compiler)

Parts 2 and 3 land in rebel_compiler, so they cannot be stacked on this PR; they will be stacked on each other there. Each part is independent — this PR needs nothing from the later ones.

---

### 📌 Related Issues / Tickets

* Related to # (input-setup optimization series, 1/3)

---

### ✅ Type of Change

* [x] ⚙️ Performance improvement (`perf`)

---

### 🧪 How to Test

1. Run any vLLM-native serving workload with warm-up enabled.
2. Verify the log line `Dynamo guard evaluation reduced to diff guards.` appears once after warm-up.
3. Verify outputs are unchanged and per-step host time drops (the "TorchDynamo Cache Lookup" span in a torch profile shrinks to about a quarter).
4. Run a request with `logprobs` set: the sampler's logprobs path compiles on first use and must keep working (this is the case a global stance breaks, caught by the `t1-compile` CI lane).
5. Edge case: a model shape outside the warmed bucket set raises RuntimeError instead of silently recompiling.

---

### 💬 Notes

`skip_guard_eval_unsafe` is the same mechanism upstream vLLM relies on in deploy mode. Upstream goes further and drops all guards at compile time via `guard_filter_fn`; we keep the entry-selecting guards because our bucketing puts multiple entries behind one compiled callable.
