### PR TITLE
fix(loader): skip checkpoint weights beyond a config-truncated layer count

### DIFF
--- a/vllm_rbln/patches/models_utils.py
+++ b/vllm_rbln/patches/models_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 from collections.abc import Iterable
 
 import torch
@@ -25,6 +26,25 @@ from vllm.model_executor.models.utils import (
 )
 
 from vllm_rbln.patches import register_patch
+
+_LAYER_IDX = re.compile(r"(?:^|\.)layers\.(\d+)\.")
+
+
+def _skip_truncated_layers(
+    weights: Iterable[tuple[str, torch.Tensor]], num_hidden_layers: int
+) -> Iterable[tuple[str, torch.Tensor]]:
+    """Drop checkpoint weights of layers a config-truncated model does not build.
+
+    Restores the [RBLN] skip that lived in the forked load_weights removed by
+    #947: a model truncated via hf_overrides (num_hidden_layers=N) still reads
+    the full checkpoint, and stock load_weights KeyErrors on `layers.N+`.
+    A model truncated via VLLM_RBLN_NUM_HIDDEN_LAYERS keeps the full config,
+    so this filter is a no-op on that path."""
+    for name, weight in weights:
+        m = _LAYER_IDX.search(name)
+        if m and int(m.group(1)) >= num_hidden_layers:
+            continue
+        yield name, weight
 
 
 # NOTE(RBLN): Introduced in https://github.com/RBLN-SW/vllm-rbln/pull/81
@@ -46,6 +66,12 @@ def patched_load_module(
 ) -> Iterable[str]:
     if isinstance(module, PPMissingLayer):
         return
+
+    if module is self.module and not base_prefix:
+        config = getattr(module, "config", None)
+        num_hidden_layers = getattr(config, "num_hidden_layers", 0)
+        if num_hidden_layers and not getattr(config, "_rbln_load_last_n_layers", False):
+            weights = _skip_truncated_layers(weights, num_hidden_layers)
 
     # Avoid infinite recursion since this function is typically
     # called inside load_weights of the module itself


### PR DESCRIPTION
### 🚀 Summary of Changes

#947 removed the forked `load_weights` overrides, and with them the only guard that made **config-truncated models** (hf_overrides `num_hidden_layers=N`) loadable from a full checkpoint:

```python
# removed in #947 (weight_loader.py)
# [RBLN] Skips loading of layers greater than `num_hidden_layers`.
if name.startswith("layers"):
    layer_idx = int(name.split(".")[1])
    if layer_idx >= self.config.num_hidden_layers:
        continue
```

Since then every layer-truncated run through vllm-executor fails at weight loading — e.g. compiler-pr-ci ATOM vLLM Dynamo CI, [build #9171](https://obedients.k8s.rebellions.in/orgs/main/pipelines/compiler-pr-ci/builds/9171?job=8b68b699-05ea-4b97-a4a5-3bf11bad0a38):

```
qwen2_moe.py:528 → param = params_dict[name]
KeyError: 'layers.3.input_layernorm.weight'   (--num-hidden-layers 3)
```

vllm-rbln's own CI stayed green because `tests/native` truncates via `VLLM_RBLN_NUM_HIDDEN_LAYERS` (#914, PPMissingLayer path), which has its own skip machinery — only the executor's config-mutation path lost coverage.

### Fix

Restore the skip as a generic filter in `patched_load_module` (top-level call only): drop `layers.M` weights with `M >= config.num_hidden_layers`.

- config-mutation path (executor `--num-hidden-layers`): broken behaviour restored, equivalent to the pre-#947 fork
- `VLLM_RBLN_NUM_HIDDEN_LAYERS` path (#914): config stays full → filter is a **no-op**, no interference
- untruncated runs: checkpoint never exceeds the config count → no-op
- `_rbln_load_last_n_layers` (minimax_m2 custom): filter is bypassed — that flag has no consumer in-tree today, left untouched rather than silently dropping the tail layers it wants

Longer term the executor should migrate to `VLLM_RBLN_NUM_HIDDEN_LAYERS` (rebellions-sw/vllm-executor PR follows); once that lands this filter is a no-op everywhere and can be dropped.

### Verification

- Unit: filter keeps `layers.0-2`/non-layer weights, drops `layers.3+` and `model.layers.5+` (the exact failing name `layers.3.input_layernorm.weight` included); full-config pass-through is byte-identical
- `ruff check` / `ruff format --check` clean

cc @rebel-cjlee (#947/#914)
