### PR TITLE
fix(kv): backport LMCache mp MultiConnector lose-path

### DIFF
--- a/tests/native/patches/test_lmcache_mp_connector.py
+++ b/tests/native/patches/test_lmcache_mp_connector.py
@@ -1,0 +1,107 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ``lmcache`` is an optional runtime dependency of vllm-rbln, so the patch
+# target module cannot be imported for real here. Stub it in sys.modules
+# before importing the patch so `patched_update_state_after_alloc`'s internal
+# `from vllm...lmcache_mp_connector import ...` resolves to the stub.
+import enum
+import sys
+import types
+from types import SimpleNamespace
+from typing import Any
+
+_TARGET_MODULE = "vllm.distributed.kv_transfer.kv_connector.v1.lmcache_mp_connector"
+
+
+class _RequestState(enum.Enum):
+    PREFETCHING = "prefetching"
+    WAITING_FOR_LOAD = "waiting_for_load"
+    READY = "ready"
+
+
+_stub: Any = types.ModuleType(_TARGET_MODULE)
+_stub.LMCacheMPRequestState = _RequestState
+_stub.reformat_block_ids = lambda block_ids: block_ids[0]
+_stub.logger = SimpleNamespace(debug=lambda *args, **kwargs: None)
+sys.modules[_TARGET_MODULE] = _stub
+
+from vllm_rbln.patches.lmcache_mp_connector import (  # noqa: E402
+    patched_update_state_after_alloc,
+)
+
+
+class _Tracker:
+    def __init__(self, num_lmcache_hit_blocks: int, num_vllm_hit_blocks: int) -> None:
+        self.allocated_block_ids: list[int] = []
+        self.num_lmcache_hit_blocks = num_lmcache_hit_blocks
+        self.num_vllm_hit_blocks = num_vllm_hit_blocks
+        self.state = _RequestState.PREFETCHING
+        self.all_token_ids = list(range(64))
+
+    def append_block_ids(self, block_ids: list[int]) -> None:
+        self.allocated_block_ids.extend(block_ids)
+
+    def needs_retrieve(self) -> bool:
+        return self.num_lmcache_hit_blocks > self.num_vllm_hit_blocks
+
+
+class _SchedulerAdapter:
+    def __init__(self) -> None:
+        self.cleaned_up: list[str] = []
+        self.freed: list[dict[str, object]] = []
+
+    def cleanup_lookup_result(self, request_id: str) -> None:
+        self.cleaned_up.append(request_id)
+
+    def free_lookup_locks(self, token_ids, start, end, request_id) -> None:
+        self.freed.append({"start": start, "end": end, "request_id": request_id})
+
+
+def _connector(tracker: _Tracker) -> SimpleNamespace:
+    return SimpleNamespace(
+        _get_request_tracker=lambda request_id: tracker,
+        scheduler_adapter=_SchedulerAdapter(),
+        vllm_block_size=16,
+    )
+
+
+def test_non_chosen_connector_transitions_to_ready_and_frees_all_locks():
+    tracker = _Tracker(num_lmcache_hit_blocks=4, num_vllm_hit_blocks=1)
+    connector = _connector(tracker)
+    blocks = SimpleNamespace(get_block_ids=lambda: ([1, 2, 3, 4],))
+
+    patched_update_state_after_alloc(
+        connector, SimpleNamespace(request_id="req-0"), blocks, 0
+    )
+
+    assert tracker.state == _RequestState.READY
+    assert connector.scheduler_adapter.freed == [
+        {"start": 0, "end": 4 * 16, "request_id": "req-0"}
+    ]
+
+
+def test_chosen_connector_waits_for_load_and_frees_only_vllm_hit_locks():
+    tracker = _Tracker(num_lmcache_hit_blocks=4, num_vllm_hit_blocks=1)
+    connector = _connector(tracker)
+    blocks = SimpleNamespace(get_block_ids=lambda: ([1, 2, 3, 4],))
+
+    patched_update_state_after_alloc(
+        connector, SimpleNamespace(request_id="req-1"), blocks, 100
+    )
+
+    assert tracker.state == _RequestState.WAITING_FOR_LOAD
+    assert connector.scheduler_adapter.freed == [
+        {"start": 0, "end": 1 * 16, "request_id": "req-1"}
+    ]

--- a/vllm_rbln/patches/__init__.py
+++ b/vllm_rbln/patches/__init__.py
@@ -33,6 +33,7 @@ from . import (
     fp8_moe_method,
     gpt_oss,
     gpt_oss_mxfp4_config,
+    lmcache_mp_connector,
     metrics,
     minimax_m2,
     mla,

--- a/vllm_rbln/patches/lmcache_mp_connector.py
+++ b/vllm_rbln/patches/lmcache_mp_connector.py
@@ -1,0 +1,99 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Backport of vllm-project/vllm#47505 (open, unmerged as of writing).
+
+A non-chosen ``MultiConnector`` sub-connector calls ``update_state_after_alloc``
+with ``num_external_tokens=0``, but ``LMCacheMPConnectorUpstream`` decides
+whether to load purely from ``needs_retrieve()``, which only looks at block
+counts. It wrongly waits to load and leaks lookup locks (nothing outside
+``end_session`` releases them). This backport adds
+``and num_external_tokens > 0`` to that condition, matching upstream's fix.
+
+TODO(vllm-pr-47505): delete this module and its entry in
+``patches/__init__.py`` once vllm#47505 merges and the vllm-rbln pin picks it
+up.
+"""
+
+from typing import TYPE_CHECKING
+
+from vllm_rbln.patches import register_patch
+
+if TYPE_CHECKING:
+    from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_mp_connector import (
+        LMCacheMPConnectorUpstream,
+    )
+    from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+    from vllm.v1.request import Request
+
+
+@register_patch(
+    target=(
+        "vllm.distributed.kv_transfer.kv_connector.v1.lmcache_mp_connector."
+        "LMCacheMPConnectorUpstream.update_state_after_alloc"
+    ),
+    reason=(
+        "Backport vllm#47505 (open, unmerged): a non-chosen MultiConnector "
+        "sub-connector sees num_external_tokens=0 but needs_retrieve() ignores "
+        "that, so it wrongly waits to load and leaks lookup locks."
+    ),
+)
+def patched_update_state_after_alloc(
+    self: "LMCacheMPConnectorUpstream",
+    request: "Request",
+    blocks: "KVCacheBlocks",
+    num_external_tokens: int,
+) -> None:
+    from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_mp_connector import (
+        LMCacheMPRequestState,
+        logger,
+        reformat_block_ids,
+    )
+
+    tracker = self._get_request_tracker(request.request_id)
+    block_ids = reformat_block_ids(blocks.get_block_ids())
+
+    existing_count = len(tracker.allocated_block_ids)
+    new_block_ids = block_ids[existing_count:]
+    if new_block_ids:
+        tracker.append_block_ids(new_block_ids)
+
+    # Exact patch vs upstream — the rest of this method is a copy.
+    # upstream:  condition = tracker.needs_retrieve()
+    condition = tracker.needs_retrieve() and num_external_tokens > 0
+    if tracker.state == LMCacheMPRequestState.PREFETCHING:
+        tracker.state = (
+            LMCacheMPRequestState.WAITING_FOR_LOAD
+            if condition
+            else LMCacheMPRequestState.READY
+        )
+        self.scheduler_adapter.cleanup_lookup_result(request.request_id)
+
+        if tracker.num_lmcache_hit_blocks > 0:
+            if not condition:
+                free_end = tracker.num_lmcache_hit_blocks * self.vllm_block_size
+            else:
+                free_end = tracker.num_vllm_hit_blocks * self.vllm_block_size
+
+            if free_end > 0:
+                self.scheduler_adapter.free_lookup_locks(
+                    token_ids=list(tracker.all_token_ids),
+                    start=0,
+                    end=free_end,
+                    request_id=request.request_id,
+                )
+                logger.debug(
+                    "Free locks of tokens %d-%d since it is cached by vLLM.",
+                    0,
+                    free_end,
+                )

--- a/vllm_rbln/patches/lmcache_mp_connector.py
+++ b/vllm_rbln/patches/lmcache_mp_connector.py
@@ -25,6 +25,7 @@ TODO(vllm-pr-47505): delete this module and its entry in
 up.
 """
 
+import importlib.util
 from typing import TYPE_CHECKING
 
 from vllm_rbln.patches import register_patch
@@ -37,6 +38,18 @@ if TYPE_CHECKING:
     from vllm.v1.request import Request
 
 
+def _lmcache_available() -> bool:
+    """True when the optional ``lmcache`` package is installed.
+
+    The vLLM-vendored target module exists in the pin, but importing it
+    does ``from lmcache.utils import ...`` at module scope, so without
+    ``lmcache`` the import raises ``ModuleNotFoundError`` and the registry
+    then AttributeErrors on the parent package. Native CI does not install
+    ``lmcache``.
+    """
+    return importlib.util.find_spec("lmcache") is not None
+
+
 @register_patch(
     target=(
         "vllm.distributed.kv_transfer.kv_connector.v1.lmcache_mp_connector."
@@ -47,6 +60,7 @@ if TYPE_CHECKING:
         "sub-connector sees num_external_tokens=0 but needs_retrieve() ignores "
         "that, so it wrongly waits to load and leaks lookup locks."
     ),
+    condition=_lmcache_available,
 )
 def patched_update_state_after_alloc(
     self: "LMCacheMPConnectorUpstream",


### PR DESCRIPTION
### 🚀 Summary of Changes

Backport [vllm-project/vllm#47505](https://github.com/vllm-project/vllm/pull/47505) onto `LMCacheMPConnectorUpstream.update_state_after_alloc`.

A non-chosen `MultiConnector` sub-connector is called with `num_external_tokens=0`, but upstream decides whether to load from `needs_retrieve()` alone (block counts). It then enters `WAITING_FOR_LOAD` and leaks lookup locks — nothing outside `end_session` releases them.

The only behavioural change vs upstream is this assignment:

```python
# Exact patch vs upstream — the rest of this method is a copy.
# upstream:  condition = tracker.needs_retrieve()
condition = tracker.needs_retrieve() and num_external_tokens > 0
```

Native path only (`vllm_rbln/patches/`). Delete the module once vllm#47505 merges and the vllm-rbln pin picks it up (`TODO(vllm-pr-47505)`).

---

### 📌 Related Issues / Tickets

* Related to [vllm-project/vllm#47505](https://github.com/vllm-project/vllm/pull/47505)

---

### ✅ Type of Change

* [x] 🛠 Bug fix (`fix`)

---

### 🧪 How to Test

1. Run `uv run --no-sync pytest tests/native/patches/test_lmcache_mp_connector.py --noconftest -q`
2. Expected: 2 passed. A losing connector (`num_external_tokens=0`) goes `READY` and frees all lookup locks; a chosen connector (`num_external_tokens>0`) stays `WAITING_FOR_LOAD` and frees only the vLLM-hit range.
3. Edge: `--noconftest` is required in a venv whose vLLM does not vendor `lmcache_mp_connector`. The full native suite's `pytest_configure` applies every patch and will `AttributeError` on that missing module.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

- No in-tree vllm-rbln issue yet; this tracks the upstream PR.
- `register_patch` has no `condition`. Images / venvs without the vendored connector will fail at `apply_registered_patches()`.
- AI assistance was used.


Made with [Cursor](https://cursor.com)