### PR TITLE
refactor(sampler): encode greedy requests as top_k=1 instead of one-hot logits

### DIFF
--- a/tests/optimum/v1/worker/test_optimum_input_batch.py
+++ b/tests/optimum/v1/worker/test_optimum_input_batch.py
@@ -1,0 +1,100 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""How the optimum path's padded sampling metadata reaches the RBLN sampling ops.
+
+`RBLNInputBatch` pads metadata to a bucket size instead of `num_reqs`, so
+`build_op_top_k_top_p` sees rows that belong to no request. Those rows must stay
+valid: the fused kernel uses `top_k` as an index, and a garbage value there
+faults instead of producing a discarded token.
+"""
+
+import torch
+from vllm.sampling_params import SamplingParams
+from vllm.v1.worker.gpu_input_batch import CachedRequestState
+
+from vllm_rbln.v1.sample.ops.top_k_top_p import (
+    GREEDY_TOP_K,
+    build_op_top_k_top_p,
+)
+from vllm_rbln.v1.worker.optimum_input_batch import RBLNInputBatch
+
+DEVICE = torch.device("cpu")
+VOCAB_SIZE = 8
+BUCKET_SIZE = 4
+TOP_K = 3
+
+
+def build_input_batch(requests: list[tuple[str, SamplingParams]]) -> RBLNInputBatch:
+    input_batch = RBLNInputBatch(
+        max_num_reqs=8,
+        max_model_len=64,
+        max_num_batched_tokens=64,
+        device=DEVICE,
+        vocab_size=VOCAB_SIZE,
+        block_sizes=[16],
+        kernel_block_sizes=[16],
+        max_num_blocks_per_req=[4],
+        use_rbln_sampler=True,
+    )
+    for req_id, params in requests:
+        input_batch.add_request(
+            CachedRequestState(
+                req_id=req_id,
+                prompt_token_ids=[1, 2, 3],
+                mm_features=None,
+                sampling_params=params,
+                pooling_params=None,
+                generator=None,
+                block_ids=([0, 1],),
+                num_computed_tokens=0,
+                output_token_ids=[],
+            )
+        )
+    input_batch.refresh_metadata_rbln(BUCKET_SIZE)
+    return input_batch
+
+
+def test_padded_rows_reach_the_op_with_both_filters_disabled():
+    # Two requests in a bucket of four: rows 2 and 3 belong to nobody. The
+    # top-k request is what makes vLLM materialize the tensors for the batch.
+    input_batch = build_input_batch(
+        [
+            ("greedy", SamplingParams(temperature=0.0)),
+            ("random_top_k", SamplingParams(temperature=1.0, top_k=TOP_K)),
+        ]
+    )
+    metadata = input_batch.sampling_metadata
+
+    # Metadata is padded to the bucket, not cut to `num_reqs`, because the
+    # sampler runs on logits padded the same way.
+    assert input_batch.num_reqs == 2
+    assert metadata.top_k.shape == (BUCKET_SIZE,)
+    assert metadata.temperature.shape == (BUCKET_SIZE,)
+    # No request uses top-p, so that one arrives as `None` and the fallback has
+    # to be built at the bucket length too -- which is why the batch size comes
+    # from the logits rather than from whichever tensor metadata happens to hold.
+    assert metadata.top_p is None
+
+    top_k, top_p = build_op_top_k_top_p(metadata, BUCKET_SIZE, VOCAB_SIZE, DEVICE)
+
+    # `top_k` covers the whole bucket, the padded rows included; the unused
+    # top-p is elided to `None`, which the compiler spells as a scalar 1.0.
+    assert top_k.shape == (BUCKET_SIZE,)
+    assert top_p is None
+
+    greedy = input_batch.req_id_to_index["greedy"]
+    random_top_k = input_batch.req_id_to_index["random_top_k"]
+    assert top_k[greedy].item() == GREEDY_TOP_K
+    assert top_k[random_top_k].item() == TOP_K

--- a/tests/torch_compile/unit/v1/sample/test_rbln_rejection_sampler.py
+++ b/tests/torch_compile/unit/v1/sample/test_rbln_rejection_sampler.py
@@ -1,0 +1,469 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+from vllm.sampling_params import SamplingParams
+from vllm.v1.sample.logits_processor import LogitsProcessors
+from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
+
+from vllm_rbln.v1.sample import rbln_rejection_sampler as module
+from vllm_rbln.v1.sample.ops.top_k_top_p import (
+    GREEDY_TOP_K,
+    GREEDY_TOP_P,
+    build_op_top_k_top_p,
+)
+from vllm_rbln.v1.sample.rbln_rejection_sampler import (
+    PLACEHOLDER_TOKEN_ID,
+    RBLNRejectionSamplerImpl,
+)
+
+DEVICE = torch.device("cpu")
+VOCAB_SIZE = 8
+NUM_SPEC_TOKENS = 2
+
+
+def make_sampling_metadata(
+    temperature: torch.Tensor | None,
+    all_greedy: bool,
+    all_random: bool,
+    top_k: torch.Tensor | None = None,
+    top_p: torch.Tensor | None = None,
+) -> SamplingMetadata:
+    """Build a SamplingMetadata carrying only the fields this impl reads.
+
+    Unlike the helper in test_torch_rejection_sampler, this one allows a mixed
+    batch (`all_greedy` and `all_random` both False).
+    """
+    return SamplingMetadata(
+        temperature=temperature,
+        all_greedy=all_greedy,
+        all_random=all_random,
+        top_p=top_p,
+        top_k=top_k,
+        generators={},
+        max_num_logprobs=None,
+        no_penalties=True,
+        prompt_token_ids=None,
+        frequency_penalties=torch.tensor([]),
+        presence_penalties=torch.tensor([]),
+        repetition_penalties=torch.tensor([]),
+        output_token_ids=[],
+        allowed_token_ids_mask=None,
+        bad_words_token_ids={},
+        logitsprocs=LogitsProcessors(),
+    )
+
+
+@pytest.fixture
+def impl(monkeypatch) -> RBLNRejectionSamplerImpl:
+    monkeypatch.setattr(module, "compile", lambda target, **kwargs: target)
+    return RBLNRejectionSamplerImpl(
+        compile_context=Mock(),
+        num_spec_tokens=NUM_SPEC_TOKENS,
+    )
+
+
+########################### build_op_top_k_top_p ###########################
+def test_all_greedy():
+    metadata = make_sampling_metadata(
+        temperature=None,
+        all_greedy=True,
+        all_random=False,
+    )
+
+    top_k, top_p = build_op_top_k_top_p(metadata, 3, VOCAB_SIZE, DEVICE)
+
+    assert torch.equal(top_k, torch.tensor([GREEDY_TOP_K] * 3, dtype=torch.int32))
+    # Greedy is keyed on `top_k == 1` alone; the unused top-p is elided.
+    assert top_p is None
+
+
+def test_all_random_pure_multinomial():
+    metadata = make_sampling_metadata(
+        temperature=torch.tensor([1.0, 2.0]),
+        all_greedy=False,
+        all_random=True,
+    )
+
+    top_k, top_p = build_op_top_k_top_p(metadata, 2, VOCAB_SIZE, DEVICE)
+
+    # Pure multinomial: the compiler fills both with scalar neutrals.
+    assert top_k is None
+    assert top_p is None
+
+
+def test_all_random_top_k_only():
+    metadata = make_sampling_metadata(
+        temperature=torch.tensor([1.0, 2.0]),
+        all_greedy=False,
+        all_random=True,
+        top_k=torch.tensor([3, VOCAB_SIZE], dtype=torch.int32),
+    )
+
+    top_k, top_p = build_op_top_k_top_p(metadata, 2, VOCAB_SIZE, DEVICE)
+
+    assert top_k is metadata.top_k
+    assert top_p is None
+
+
+def test_all_random_top_p_only():
+    metadata = make_sampling_metadata(
+        temperature=torch.tensor([1.0, 2.0]),
+        all_greedy=False,
+        all_random=True,
+        top_p=torch.tensor([0.9, 1.0], dtype=torch.float32),
+    )
+
+    top_k, top_p = build_op_top_k_top_p(metadata, 2, VOCAB_SIZE, DEVICE)
+
+    assert top_k is None
+    assert top_p is metadata.top_p
+
+
+def test_all_random_top_k_and_top_p():
+    metadata = make_sampling_metadata(
+        temperature=torch.tensor([1.0, 2.0]),
+        all_greedy=False,
+        all_random=True,
+        top_k=torch.tensor([3, VOCAB_SIZE], dtype=torch.int32),
+        top_p=torch.tensor([0.9, 1.0], dtype=torch.float32),
+    )
+
+    top_k, top_p = build_op_top_k_top_p(metadata, 2, VOCAB_SIZE, DEVICE)
+
+    assert top_k is metadata.top_k
+    assert top_p is metadata.top_p
+
+
+def test_mixed_pure_multinomial():
+    metadata = make_sampling_metadata(
+        temperature=torch.tensor([2.0, 0.0]),
+        all_greedy=False,
+        all_random=False,
+    )
+
+    top_k, top_p = build_op_top_k_top_p(metadata, 2, VOCAB_SIZE, DEVICE)
+
+    assert torch.equal(
+        top_k, torch.tensor([VOCAB_SIZE, GREEDY_TOP_K], dtype=torch.int32)
+    )
+    assert top_p is None
+
+
+def test_mixed_top_k_only():
+    metadata = make_sampling_metadata(
+        temperature=torch.tensor([0.0, 1.0]),
+        all_greedy=False,
+        all_random=False,
+        top_k=torch.tensor([VOCAB_SIZE, 3], dtype=torch.int32),
+    )
+
+    top_k, top_p = build_op_top_k_top_p(metadata, 2, VOCAB_SIZE, DEVICE)
+
+    assert torch.equal(top_k, torch.tensor([GREEDY_TOP_K, 3], dtype=torch.int32))
+    assert top_p is None
+
+
+def test_mixed_top_p_only():
+    """A greedy row is encoded as `top_k == 1`, so `top_k` cannot be elided
+    from a mixed batch even when no request uses top-k."""
+    metadata = make_sampling_metadata(
+        temperature=torch.tensor([0.0, 1.0]),
+        all_greedy=False,
+        all_random=False,
+        top_p=torch.tensor([1.0, 0.9], dtype=torch.float32),
+    )
+
+    top_k, top_p = build_op_top_k_top_p(metadata, 2, VOCAB_SIZE, DEVICE)
+
+    assert torch.equal(
+        top_k, torch.tensor([GREEDY_TOP_K, VOCAB_SIZE], dtype=torch.int32)
+    )
+    assert torch.equal(top_p, torch.tensor([GREEDY_TOP_P, 0.9], dtype=torch.float32))
+
+
+def test_mixed_top_k_and_top_p():
+    # Row 0 is greedy, and vLLM rewrites its params to the same values a random
+    # request without top-k/top-p carries -- which is why the op cannot tell the
+    # two apart from `sampling_metadata` alone.
+    metadata = make_sampling_metadata(
+        temperature=torch.tensor([0.0, 1.0, 2.0]),
+        all_greedy=False,
+        all_random=False,
+        top_k=torch.tensor([VOCAB_SIZE, 4, VOCAB_SIZE], dtype=torch.int32),
+        top_p=torch.tensor([1.0, 1.0, 0.9], dtype=torch.float32),
+    )
+
+    top_k, top_p = build_op_top_k_top_p(metadata, 3, VOCAB_SIZE, DEVICE)
+
+    assert torch.equal(
+        top_k, torch.tensor([GREEDY_TOP_K, 4, VOCAB_SIZE], dtype=torch.int32)
+    )
+    assert torch.equal(
+        top_p, torch.tensor([GREEDY_TOP_P, 1.0, 0.9], dtype=torch.float32)
+    )
+
+
+def build_input_batch(requests: list[tuple[str, SamplingParams]]) -> InputBatch:
+    """Feed real `SamplingParams` through an `InputBatch`, as the runner does.
+
+    Metadata built this way carries whatever vLLM's own bookkeeping puts there,
+    rather than the values a test picked.
+    """
+    input_batch = InputBatch(
+        max_num_reqs=8,
+        max_model_len=64,
+        max_num_batched_tokens=64,
+        device=DEVICE,
+        vocab_size=VOCAB_SIZE,
+        block_sizes=[16],
+        kernel_block_sizes=[16],
+        max_num_blocks_per_req=[4],
+    )
+    for req_id, params in requests:
+        input_batch.add_request(
+            CachedRequestState(
+                req_id=req_id,
+                prompt_token_ids=[1, 2, 3],
+                mm_features=None,
+                sampling_params=params,
+                pooling_params=None,
+                generator=None,
+                block_ids=([0, 1],),
+                num_computed_tokens=0,
+                output_token_ids=[],
+            )
+        )
+    input_batch.refresh_metadata()
+    return input_batch
+
+
+def test_greedy_request_of_a_mixed_batch_carries_neutral_top_k_top_p():
+    """The upstream contract the greedy detection rests on.
+
+    vLLM hands a greedy request the values that disable both filters --
+    `top_p=1.0` and `top_k=vocab_size` -- whatever the caller asked for, which is
+    exactly what a random request without filters carries. Temperature is the
+    only thing left that marks the row.
+    """
+    # The greedy request asks for both filters; the random ones are what make
+    # vLLM materialize the per-request tensors for the whole batch.
+    input_batch = build_input_batch(
+        [
+            ("greedy", SamplingParams(temperature=0.0, top_k=4, top_p=0.5)),
+            ("random_top_k", SamplingParams(temperature=1.0, top_k=4)),
+            ("random_top_p", SamplingParams(temperature=1.0, top_p=0.9)),
+        ]
+    )
+
+    metadata = input_batch.sampling_metadata
+    greedy = input_batch.req_id_to_index["greedy"]
+
+    assert not metadata.all_greedy
+    assert not metadata.all_random
+    assert metadata.top_k is not None
+    assert metadata.top_p is not None
+    assert metadata.top_k[greedy].item() == VOCAB_SIZE
+    assert metadata.top_p[greedy].item() == 1.0
+    assert metadata.temperature[greedy].item() == 0.0
+
+    # Which is why the row has to be re-encoded before it reaches the op.
+    top_k, top_p = build_op_top_k_top_p(
+        metadata, input_batch.num_reqs, VOCAB_SIZE, DEVICE
+    )
+    assert top_k[greedy].item() == GREEDY_TOP_K
+    assert top_p[greedy].item() == GREEDY_TOP_P
+
+
+# Every kind of row the op can receive, and the (k, p) pair it must arrive with.
+# `V` disables top-k and `1.0` disables top-p, so only the greedy row is rewritten.
+ROW_KINDS = [
+    ("greedy", SamplingParams(temperature=0.0), GREEDY_TOP_K, GREEDY_TOP_P),
+    ("pure_random", SamplingParams(temperature=1.0), VOCAB_SIZE, 1.0),
+    ("top_k_only", SamplingParams(temperature=1.0, top_k=3), 3, 1.0),
+    ("top_p_only", SamplingParams(temperature=1.0, top_p=0.9), VOCAB_SIZE, 0.9),
+    ("top_k_top_p", SamplingParams(temperature=1.0, top_k=2, top_p=0.8), 2, 0.8),
+]
+
+
+def test_every_row_kind_gets_its_own_top_k_top_p():
+    """All five kinds in one batch, since the op reads k/p per row."""
+    input_batch = build_input_batch(
+        [(name, params) for name, params, _, _ in ROW_KINDS]
+    )
+
+    top_k, top_p = build_op_top_k_top_p(
+        input_batch.sampling_metadata, input_batch.num_reqs, VOCAB_SIZE, DEVICE
+    )
+
+    for name, _, expected_k, expected_p in ROW_KINDS:
+        row = input_batch.req_id_to_index[name]
+        assert top_k[row].item() == expected_k, name
+        assert top_p[row].item() == pytest.approx(expected_p), name
+
+
+########################### apply_sampling_constraints ###########################
+def test_apply_sampling_constraints_leaves_all_greedy_logits_untouched(impl):
+    logits = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    metadata = make_sampling_metadata(
+        temperature=None,
+        all_greedy=True,
+        all_random=False,
+    )
+
+    out = impl.apply_sampling_constraints(
+        logits.clone(),
+        cu_num_draft_tokens=torch.tensor([1, 2]),
+        sampling_metadata=metadata,
+    )
+
+    # The op resolves these rows to their argmax, so no host-side rewrite is
+    # needed -- not even temperature scaling.
+    assert torch.equal(out, logits)
+
+
+def test_apply_sampling_constraints_scales_only_random_rows(impl):
+    logits = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    metadata = make_sampling_metadata(
+        temperature=torch.tensor([0.0, 2.0]),
+        all_greedy=False,
+        all_random=False,
+    )
+
+    out = impl.apply_sampling_constraints(
+        logits.clone(),
+        cu_num_draft_tokens=torch.tensor([1, 2]),
+        sampling_metadata=metadata,
+    )
+
+    # The greedy row is divided by 1 (scaling cannot move an argmax); the random
+    # row by its own temperature.
+    expected = torch.stack([logits[0], logits[1] / 2.0])
+    assert torch.equal(out, expected)
+
+
+########################### rejection_sample ###########################
+def make_target_probs(argmax_token_ids: list[int]) -> torch.Tensor:
+    """One row per draft position, peaked at the given token but far from
+    one-hot: the argmax holds 0.4 of the mass and the rest is spread evenly."""
+    num_tokens = len(argmax_token_ids)
+    probs = torch.full(
+        (num_tokens, VOCAB_SIZE),
+        0.6 / (VOCAB_SIZE - 1),
+        dtype=torch.float32,
+    )
+    for row, token_id in enumerate(argmax_token_ids):
+        probs[row, token_id] = 0.4
+    return probs
+
+
+def run_rejection_sample(
+    impl: RBLNRejectionSamplerImpl,
+    draft_token_ids: list[int],
+    target_argmax_token_ids: list[int],
+    bonus_token_ids: list[int],
+    metadata: SamplingMetadata,
+    num_draft_tokens: list[int] | None = None,
+) -> torch.Tensor:
+    """Run the impl on a batch of drafts packed in `draft_token_ids` order.
+
+    `num_draft_tokens` defaults to every request holding NUM_SPEC_TOKENS drafts.
+    """
+    if num_draft_tokens is None:
+        num_draft_tokens = [NUM_SPEC_TOKENS] * (len(draft_token_ids) // NUM_SPEC_TOKENS)
+    return impl.rejection_sample(
+        draft_token_ids=torch.tensor(draft_token_ids, dtype=torch.int32),
+        num_draft_tokens=num_draft_tokens,
+        max_spec_len=NUM_SPEC_TOKENS,
+        cu_num_draft_tokens=torch.cumsum(
+            torch.tensor(num_draft_tokens, dtype=torch.int32), dim=0
+        ),
+        draft_probs=None,
+        target_probs=make_target_probs(target_argmax_token_ids),
+        bonus_token_ids=torch.tensor(bonus_token_ids, dtype=torch.int64).unsqueeze(-1),
+        sampling_metadata=metadata,
+    )
+
+
+@pytest.mark.parametrize("trial", range(10))
+def test_greedy_rows_accept_exactly_the_target_argmax(impl, trial):
+    """A greedy row accepts iff its draft is the target argmax, and recovers the
+    argmax at the first mismatch.
+
+    `target_probs` puts only 0.4 on the argmax, so a row treated as random would
+    diverge from this expectation within a few trials.
+    """
+    metadata = make_sampling_metadata(
+        # Row 0 greedy, row 1 greedy, row 2 random.
+        temperature=torch.tensor([0.0, 0.0, 1.0]),
+        all_greedy=False,
+        all_random=False,
+        # The greedy rows carry the params vLLM assigns them, so only the
+        # temperature marks them as greedy.
+        top_k=torch.tensor([VOCAB_SIZE, VOCAB_SIZE, 1], dtype=torch.int32),
+        top_p=torch.tensor([1.0, 1.0, 1.0], dtype=torch.float32),
+    )
+
+    output = run_rejection_sample(
+        impl,
+        # Row 0 matches both argmaxes; row 1 mismatches at position 1; row 2
+        # (random, top_k=1) matches both argmaxes.
+        draft_token_ids=[3, 5, 2, 4, 6, 1],
+        target_argmax_token_ids=[3, 5, 2, 7, 6, 1],
+        bonus_token_ids=[10, 11, 12],
+        metadata=metadata,
+    )
+
+    expected = torch.tensor(
+        [
+            [3, 5, 10],  # all accepted -> bonus token
+            [2, 7, PLACEHOLDER_TOKEN_ID],  # accept one, then recover the argmax
+            [6, 1, 12],  # top_k=1 row behaves like the greedy rows
+        ],
+        dtype=torch.int32,
+    )
+    assert torch.equal(output, expected)
+
+
+def test_requests_with_fewer_drafts_than_the_padded_length(impl):
+    """A request may bring fewer drafts than `num_spec_tokens`, which the impl
+    pads to. Its bonus token then lands right after its own last draft."""
+    metadata = make_sampling_metadata(
+        temperature=None,
+        all_greedy=True,
+        all_random=False,
+    )
+
+    output = run_rejection_sample(
+        impl,
+        draft_token_ids=[3, 2, 4],
+        target_argmax_token_ids=[3, 2, 7],
+        bonus_token_ids=[10, 11],
+        metadata=metadata,
+        num_draft_tokens=[1, 2],
+    )
+
+    expected = torch.tensor(
+        [
+            # One draft, accepted -> bonus token at column 1, not at column 2.
+            [3, 10, PLACEHOLDER_TOKEN_ID],
+            [2, 7, PLACEHOLDER_TOKEN_ID],
+        ],
+        dtype=torch.int32,
+    )
+    assert torch.equal(output, expected)

--- a/tests/torch_compile/unit/v1/sample/test_rbln_sampler.py
+++ b/tests/torch_compile/unit/v1/sample/test_rbln_sampler.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest.mock import Mock
+
+import pytest
+import torch
+from vllm.v1.sample.logits_processor import LogitsProcessors
+from vllm.v1.sample.metadata import SamplingMetadata
+
+from vllm_rbln.v1.sample import rbln_sampler as module
+from vllm_rbln.v1.sample.rbln_sampler import RBLNSampler
+
+VOCAB_SIZE = 8
+
+
+def make_sampling_metadata(
+    temperature: torch.Tensor | None,
+    all_greedy: bool,
+    all_random: bool,
+) -> SamplingMetadata:
+    return SamplingMetadata(
+        temperature=temperature,
+        all_greedy=all_greedy,
+        all_random=all_random,
+        top_p=None,
+        top_k=None,
+        generators={},
+        max_num_logprobs=None,
+        no_penalties=True,
+        prompt_token_ids=None,
+        frequency_penalties=torch.tensor([]),
+        presence_penalties=torch.tensor([]),
+        repetition_penalties=torch.tensor([]),
+        output_token_ids=[],
+        allowed_token_ids_mask=None,
+        bad_words_token_ids={},
+        logitsprocs=LogitsProcessors(),
+    )
+
+
+@pytest.fixture
+def sampler(monkeypatch) -> RBLNSampler:
+    monkeypatch.setattr(module, "compile", lambda target, **kwargs: target)
+    return RBLNSampler(compile_context=Mock())
+
+
+@pytest.fixture
+def op_args(sampler) -> list[tuple[torch.Tensor, torch.Tensor]]:
+    """Record the (top_k, top_p) tensors the sampling op receives."""
+    recorded: list[tuple[torch.Tensor, torch.Tensor]] = []
+    original = sampler.topk_topp_sampler._compiled_rbln_topk_topp_sampler
+
+    def spy(logits, temperature, k, p):
+        recorded.append((k, p))
+        return original(logits, temperature, k, p)
+
+    sampler.topk_topp_sampler._compiled_rbln_topk_topp_sampler = spy
+    return recorded
+
+
+def near_tied_logits() -> torch.Tensor:
+    """Two rows whose top two logits are almost equal.
+
+    Under the previous encoding -- dividing a greedy row by 1e-3 to collapse its
+    softmax toward a one-hot -- a gap this small survives the scaling (0.0001 *
+    1000 = 0.1), leaving the argmax only ~52% likely. Narrowing the candidate
+    set instead makes the outcome exact.
+    """
+    logits = torch.full((2, VOCAB_SIZE), -100.0)
+    logits[0, 4] = 10.0
+    logits[0, 6] = 10.0001  # row 0 argmax
+    logits[1, 1] = 10.0001  # row 1 argmax
+    logits[1, 5] = 10.0
+    return logits
+
+
+def test_greedy_row_of_a_mixed_batch_samples_its_argmax(sampler):
+    metadata = make_sampling_metadata(
+        temperature=torch.tensor([0.0, 1.0]),
+        all_greedy=False,
+        all_random=False,
+    )
+
+    for _ in range(10):
+        sampled, _ = sampler.sample(near_tied_logits(), metadata)
+        assert sampled[0].item() == 6
+
+
+def test_all_greedy_batch_takes_the_argmax_op(sampler, op_args):
+    """The reference for the test above: `rbln::argmax` must answer the same."""
+    metadata = make_sampling_metadata(
+        temperature=None,
+        all_greedy=True,
+        all_random=False,
+    )
+
+    sampled, _ = sampler.sample(near_tied_logits(), metadata)
+
+    # An all-greedy batch skips the top-k/top-p op entirely.
+    assert op_args == []
+    assert sampled.tolist() == [6, 1]

--- a/vllm_rbln/v1/sample/ops/__init__.py
+++ b/vllm_rbln/v1/sample/ops/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/vllm_rbln/v1/sample/ops/top_k_top_p.py
+++ b/vllm_rbln/v1/sample/ops/top_k_top_p.py
@@ -1,0 +1,72 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import torch
+from vllm.v1.sample.metadata import SamplingMetadata
+
+GREEDY_TEMPERATURE = 0
+
+GREEDY_TOP_K = 1
+GREEDY_TOP_P = 1.0
+
+
+def build_op_top_k_top_p(
+    sampling_metadata: SamplingMetadata,
+    batch_size: int,
+    vocab_size: int,
+    device: torch.device,
+) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+    """
+    Build the per-request `top_k` / `top_p` inputs of an RBLN sampling op.
+
+    batch      | filters (random rows)    | top_k             | top_p
+    -----------+--------------------------+-------------------+----------------
+    all greedy | -                        | tensor of 1s      | None
+    all random | none (pure multinomial)  | None              | None
+               | top-k only               | metadata tensor   | None
+               | top-p only               | None              | metadata tensor
+               | top-k and top-p          | metadata tensor   | metadata tensor
+    mixed      | none (pure multinomial)  | 1 / vocab_size    | None
+               | top-k only               | 1 / metadata      | None
+               | top-p only               | 1 / vocab_size    | 1.0 / metadata
+               | top-k and top-p          | 1 / metadata      | 1.0 / metadata
+
+    In the mixed rows, `a / b` reads: `a` at greedy rows, `b` at random rows.
+    `top_k` is never `None` there, because a greedy row is encoded as
+    `top_k == 1`.
+    """
+    # Reached only from the rejection sampler: spec decode has no separate
+    # greedy op, while the normal sampler answers all_greedy with rbln::argmax.
+    if sampling_metadata.all_greedy:
+        return (
+            torch.full((batch_size,), GREEDY_TOP_K, dtype=torch.int32, device=device),
+            None,
+        )
+
+    top_k = sampling_metadata.top_k
+    top_p = sampling_metadata.top_p
+    assert top_k is None or top_k.shape == (batch_size,)
+    assert top_p is None or top_p.shape == (batch_size,)
+
+    if sampling_metadata.all_random:
+        return top_k, top_p
+
+    assert sampling_metadata.temperature is not None
+    is_greedy = sampling_metadata.temperature == GREEDY_TEMPERATURE
+    if top_k is None:
+        # vLLM stores `top_k=0` (unset) as `vocab_size`, which disables top-k.
+        top_k = torch.full((batch_size,), vocab_size, dtype=torch.int32, device=device)
+    top_k = torch.where(is_greedy, top_k.new_full((), GREEDY_TOP_K), top_k)
+    # `top_p` needs no rewrite: vLLM already pins a greedy row's top_p to
+    # GREEDY_TOP_P (1.0).
+    return top_k, top_p

--- a/vllm_rbln/v1/sample/rbln_rejection_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_rejection_sampler.py
@@ -27,6 +27,10 @@ from vllm_rbln import envs
 from vllm_rbln.compilation import compile, create_compile_context
 from vllm_rbln.logger import init_logger
 from vllm_rbln.platform import HAS_TORCH_RBLN, USE_DEVICE_TENSOR
+from vllm_rbln.v1.sample.ops.top_k_top_p import (
+    GREEDY_TEMPERATURE,
+    build_op_top_k_top_p,
+)
 
 if TYPE_CHECKING:
     from rebel import CompileContext
@@ -36,7 +40,6 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 PLACEHOLDER_TOKEN_ID = -1
-GREEDY_TEMPERATURE = 0
 
 
 # TODO(RBLN): Enable RBLNSampler for
@@ -434,8 +437,12 @@ class RBLNRejectionSamplerImpl(RejectionSamplerImpl):
             draft_per_batch[i, :n] = draft_token_ids[src_offset : src_offset + n]
             src_offset += n
 
-        # NOTE(RBLN): `sampling_metadata.top_k`/`top_p` already live on the input
-        # batch's device (== `device` here), so they feed the op as-is.
+        top_k, top_p = build_op_top_k_top_p(
+            sampling_metadata,
+            batch_size,
+            vocab_size,
+            device,
+        )
 
         # ------------------------------------------------------------------
         # 2) Call the NPU primitive.
@@ -448,8 +455,8 @@ class RBLNRejectionSamplerImpl(RejectionSamplerImpl):
             reshaped_draft_token_ids,
             reshaped_target_probs,
             cu_num_draft_tokens.to(device),
-            sampling_metadata.top_k,
-            sampling_metadata.top_p,
+            top_k,
+            top_p,
         )
 
         # ------------------------------------------------------------------
@@ -521,12 +528,12 @@ class RBLNRejectionSamplerImpl(RejectionSamplerImpl):
         cu_num_draft_tokens: torch.Tensor,  # [batch_size]
         sampling_metadata: SamplingMetadata,
     ) -> torch.Tensor:
-        """Process logits based on sampling metadata.
+        """Scale the target logits by each request's temperature.
 
-        This function applies temperature scaling to the rows of random-sampling
-        requests. Rows of greedy requests are collapsed onto their argmax, so
-        that the caller's softmax turns them into an exact one-hot target
-        distribution. top-k and top-p are left to the rejection sampling op.
+        Every draft-token row is divided by the temperature of the request that
+        owns it, greedy rows (temperature 0) by 1. Unlike upstream vLLM, top-k and
+        top-p are not applied here; `rbln::rejection_sample` takes them as
+        per-request inputs.
 
         Args:
             logits: Input logits tensor to be processed.
@@ -535,20 +542,18 @@ class RBLNRejectionSamplerImpl(RejectionSamplerImpl):
                 temperature and whether greedy sampling is used.
 
         Returns:
-            torch.Tensor: Processed logits -- the caller softmaxes the result to
-            build `target_probs`.
+            torch.Tensor: The scaled logits -- the caller softmaxes them to build
+            `target_probs`.
         """
         assert logits.ndim == 2
         assert cu_num_draft_tokens.ndim == 1
         if sampling_metadata.all_greedy:
-            return logits_for_one_hot_probs(logits)
+            return logits
 
         num_tokens = logits.shape[0]
-        # NOTE(eunji.lee):
-        # Upstream vLLM treats any temperature below _SAMPLING_EPS as greedy,
-        # sets it to 0, and then overrides it to 1 right before the sampling op.
-        # We do the same here: greedy rows are overwritten below, so the value
-        # their logits are divided by does not matter as long as it is not 0.
+        # NOTE(eunji.lee): A greedy row's temperature is 0, which the division
+        # below cannot handle. Substituting 1 is harmless: `rbln::rejection_sample`
+        # samples those rows under top_k=1, so only their argmax can come out.
         temperature = expand_batch_to_tokens(
             sampling_metadata.temperature,
             cu_num_draft_tokens,
@@ -559,28 +564,8 @@ class RBLNRejectionSamplerImpl(RejectionSamplerImpl):
         # NOTE(woosuk): Update `logits` in place to avoid allocating a new tensor.
         logits.div_(temperature.unsqueeze(-1))
 
-        # NOTE(eunji.lee): The NPU `rbln::rejection_sample` primitive has no
-        # greedy kernel -- every row goes through random rejection sampling. A
-        # greedy row therefore has to carry a one-hot target distribution, which
-        # makes accept-iff-draft-is-argmax the only possible outcome.
-        greedy_rows = expand_batch_to_tokens(
-            sampling_metadata.temperature == GREEDY_TEMPERATURE,
-            cu_num_draft_tokens,
-            num_tokens,
-        ).nonzero(as_tuple=True)[0]
-        if greedy_rows.numel() > 0:
-            greedy_rows = greedy_rows.to(logits.device)
-            logits[greedy_rows] = logits_for_one_hot_probs(logits[greedy_rows])
-
         # NOTE(eunji.lee): top_k & top_p are applied together during rejection sampling.
         return logits
-
-
-def logits_for_one_hot_probs(logits: torch.Tensor) -> torch.Tensor:
-    """Return -inf except 0.0 at the argmax, so that softmax gives an exact
-    one-hot."""
-    _, max_idx = logits.max(dim=-1, keepdim=True)
-    return torch.full_like(logits, float("-inf")).scatter_(-1, max_idx, 0.0)
 
 
 def rbln_rejection_sample(

--- a/vllm_rbln/v1/sample/rbln_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_sampler.py
@@ -18,6 +18,7 @@ import rebel
 import torch
 import torch.nn as nn
 from vllm.config.model import LogprobsMode
+from vllm.sampling_params import _SAMPLING_EPS
 from vllm.v1.outputs import LogprobsTensors, SamplerOutput
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.logprobs import batched_count_greater_than
@@ -27,12 +28,7 @@ import vllm_rbln.envs as envs
 from vllm_rbln.compilation import compile, create_compile_context
 from vllm_rbln.logger import init_logger
 from vllm_rbln.platform import HAS_TORCH_RBLN, USE_DEVICE_TENSOR
-
-# NOTE:
-# Greedy requests use a small temperature (1e-3) so softmax collapses to a near
-# one-hot at argmax. Upstream's _SAMPLING_EPS (1e-5) is too small here —
-# it pushes logits past softmax's safe exp range and overflows.
-_SAMPLING_EPS = 1e-3
+from vllm_rbln.v1.sample.ops.top_k_top_p import build_op_top_k_top_p
 
 logger = init_logger(__name__)
 
@@ -184,30 +180,27 @@ class RBLNSampler(VLLMSampler):
 
         logprobs_mode = logprobs_mode_override or self.logprobs_mode
         assert not (sampling_metadata.all_greedy and sampling_metadata.all_random)
-        if not sampling_metadata.all_greedy:
-            greedy_sampled = None
-        else:
-            # It runs only all_greedy is True
-            greedy_sampled = self.greedy_sample(logits)
-            if sampling_metadata.all_greedy:
-                processed_logprobs = None
-                if (
-                    sampling_metadata.max_num_logprobs is not None
-                    or sampling_metadata.logprob_token_ids
-                ):
-                    if logprobs_mode == "processed_logits":
-                        processed_logprobs = logits
-                    elif logprobs_mode == "processed_logprobs":
-                        processed_logprobs = self.compute_logprobs(logits)
-                return greedy_sampled, processed_logprobs
+        if sampling_metadata.all_greedy:
+            # Upstream vLLM keeps this result to merge with the random one via
+            # `torch.where`. vLLM RBLN has no merge step: a mixed batch sends its
+            # greedy rows through the random-sampling path with top_k=1, so the op
+            # can only draw their argmax.
+            processed_logprobs = None
+            if (
+                sampling_metadata.max_num_logprobs is not None
+                or sampling_metadata.logprob_token_ids
+            ):
+                if logprobs_mode == "processed_logits":
+                    processed_logprobs = logits
+                elif logprobs_mode == "processed_logprobs":
+                    processed_logprobs = self.compute_logprobs(logits)
+            return self.greedy_sample(logits), processed_logprobs
 
         assert sampling_metadata.temperature is not None
 
         temperature = sampling_metadata.temperature
         if not sampling_metadata.all_random:
-            temperature = torch.where(
-                temperature < _SAMPLING_EPS, _SAMPLING_EPS, temperature
-            )
+            temperature = torch.where(temperature < _SAMPLING_EPS, 1.0, temperature)
 
         argmax_invariant = sampling_metadata.logitsprocs.argmax_invariant
         # if argmax_invariant processors are active, apply temperature scaling
@@ -225,22 +218,21 @@ class RBLNSampler(VLLMSampler):
         for processor in argmax_invariant:
             logits = processor.apply(logits)
 
+        k, p = build_op_top_k_top_p(
+            sampling_metadata,
+            logits.shape[0],
+            logits.shape[-1],
+            logits.device,
+        )
         # Apply temperature and top_k and/or top_p.
         random_sampled, processed_logprobs = self.topk_topp_sampler(
             logits,
             sampling_metadata.generators,
             temperature,
-            sampling_metadata.top_k,
-            sampling_metadata.top_p,
+            k,
+            p,
         )
 
-        assert greedy_sampled is None, (
-            "Upstream vLLM runs greedy and random sampling "
-            "separately and merges the results, "
-            "but vLLM RBLN processes greedy and random requests together: "
-            "greedy requests are routed through the random-sampling path "
-            "with a very small temperature value."
-        )
         return random_sampled, processed_logprobs
 
     def forward(


### PR DESCRIPTION
# Description

Backport of #915 to `release-v0.11.2`, originally by @rebel-eunji.

Cherry-picked manually from `3b4b9e5` (the squashed commit on `dev`). Applies without conflicts;
the diff is identical to #915 — 7 files, 815 insertions, 72 deletions.

The automatic backport did not run: the `backport release-v0.11.2` label was removed at 08:26,
six minutes before the pull request was merged at 08:32, and the workflow gate reads the label set
carried in the merge event payload. See the skipped run
https://github.com/RBLN-SW/vllm-rbln/actions/runs/32706816153.

Review context lives on #915.
