### PR TITLE
other(ci): stop gating on CR13 and split the perf sweep by sampling

### DIFF
--- a/.buildkite/pipelines/vllm-rbln/pipeline-pr.yml
+++ b/.buildkite/pipelines/vllm-rbln/pipeline-pr.yml
@@ -72,6 +72,7 @@ steps:
 
   - label: ":pytest: [CR13] pytest"
     key: "vllm-rbln-pytest-cr13"
+    soft_fail: true
     if_changed: *if_changed
     agents:
       queue: udc

--- a/.buildkite/pipelines/vllm-rbln/scripts/perf/run_perf.py
+++ b/.buildkite/pipelines/vllm-rbln/scripts/perf/run_perf.py
@@ -154,7 +154,7 @@ def summarize(
     degraded = bool(skipped)
     lines = []
     for launch, row in rows:
-        cells = [launch]
+        cells = [launch, str(row.get("_benchmark_name", "--"))]
         for key, _, fmt in _METRICS:
             value = _num(row, key)
             cells.append(fmt(value) if value is not None else "--")
@@ -166,14 +166,14 @@ def summarize(
             degraded = True
         lines.append("| " + " | ".join(cells) + " |")
 
-    titles = ["launch", *(title for _, title, _ in _METRICS), "done"]
+    titles = ["launch", "bench", *(title for _, title, _ in _METRICS), "done"]
     body = [
         f"#### {target}" + (f" -- {chip}" if chip else ""),
         "",
         " · ".join(f"{k} {v}" for k, v in shared.items()),
         "",
         "| " + " | ".join(titles) + " |",
-        "|:--" + "|--:" * (len(titles) - 1) + "|",
+        "|:--|:--" + "|--:" * (len(titles) - 2) + "|",
         *lines,
     ]
     if skipped:

--- a/.buildkite/pipelines/vllm-rbln/scripts/perf/targets/minimax-m2.7.yaml
+++ b/.buildkite/pipelines/vllm-rbln/scripts/perf/targets/minimax-m2.7.yaml
@@ -14,6 +14,7 @@ serve:
   max_num_batched_tokens: 512
   max_num_seqs: 4
   enable_expert_parallel: true
+  enable_prefix_caching: false
 
 # One server start -- and one compile -- per entry.
 serve_params:
@@ -29,9 +30,16 @@ bench:
   num_warmups: 4
 
 bench_params:
-  c4-in50k-out1k:
+  c4-in50k-out1k-greedy:
     max_concurrency: 4
-    num_prompts: 40
+    num_prompts: 16
+    random_input_len: 51200
+    random_output_len: 1024
+    temperature: 0.0
+
+  c4-in50k-out1k-non-greedy:
+    max_concurrency: 4
+    num_prompts: 16
     random_input_len: 51200
     random_output_len: 1024
 

--- a/.buildkite/vllm-rbln-nightly.yml
+++ b/.buildkite/vllm-rbln-nightly.yml
@@ -133,7 +133,7 @@ steps:
         product: "RBLN-CR03"
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     secrets: *secrets
-    timeout_in_minutes: 120
+    timeout_in_minutes: 180
     artifact_paths:
       - "perf-results/**/*"
     command: *perf
@@ -149,7 +149,7 @@ steps:
         product: "RBLN-CR13"
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     secrets: *secrets
-    timeout_in_minutes: 120
+    timeout_in_minutes: 180
     artifact_paths:
       - "perf-results/**/*"
     command: *perf

--- a/.buildkite/vllm-rbln-nightly.yml
+++ b/.buildkite/vllm-rbln-nightly.yml
@@ -2,6 +2,9 @@ env:
   UV_CACHE_DIR: "/root/.cache/uv"
   UV_LINK_MODE: "symlink"
   UV_INDEX_STRATEGY: "unsafe-best-match"
+  # Only the cron schedule sets this, so a manual or re-run build exercises the
+  # lanes without publishing. Declared here so build.env sees the name either way.
+  NIGHTLY_DEPLOY: "${NIGHTLY_DEPLOY:-}"
 
 _secrets: &secrets
   UV_INDEX_RBLN_NEXUS_NIGHTLY_USERNAME: MGMT_NEXUS_USERNAME
@@ -188,6 +191,7 @@ steps:
   # so this runs on the default queue.
   - label: ":package: nightly publish"
     key: "nightly-publish"
+    if: 'build.env("NIGHTLY_DEPLOY") == "1"'
     depends_on:
       - "nightly-t0-ca25"
       - "nightly-t2-ca25"

--- a/tests/native/v1/spec_decode/test_spec_decode_e2e.py
+++ b/tests/native/v1/spec_decode/test_spec_decode_e2e.py
@@ -25,6 +25,7 @@ from tests.native.v1.spec_decode.utils import (
     MEDUSA_TARGET,
     TARGET_MODEL,
 )
+from tests.native.vllm_config import local_weights_path
 
 # A small, compilable target for the draft-free methods; ngram/suffix speculate
 # by matching repeats, so the prompt is deliberately repetitive.
@@ -102,6 +103,8 @@ def test_speculative_decoding_matches_reference(
     vllm_runner, method: str, whole_model: bool
 ) -> None:
     target, extra_kwargs, spec_config = SPEC_METHODS[method]
+    if draft := spec_config.get("model"):
+        spec_config = {**spec_config, "model": local_weights_path(draft)}
 
     with vllm_runner(target, **extra_kwargs) as ref_model:
         ref_outputs = ref_model.generate_greedy_logprobs(


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

Three CI option changes, no code paths touched.

- CR13 lane is no longer a gate.
- The perf target sweeps sampling, with prefix caching off.
- Gate the nightly publish step on `NIGHTLY_DEPLOY=1`.
- Additionally, resolve the drafts the spec-decode e2e table pins.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [x] ❓ Other (`other`): CI

---

### 🧪 How to Test

N/A

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
