### PR TITLE
other(optimum): path-gate PR steps and refresh smoke suite

### DIFF
--- a/.buildkite/pipelines/optimum-pr/pipeline.yml
+++ b/.buildkite/pipelines/optimum-pr/pipeline.yml
@@ -19,6 +19,27 @@ _secrets: &secrets
   HF_TOKEN: HF_TOKEN
   HF_HOME: HF_HOME
 
+# Run a step only when the PR touches a path that can affect the optimum path.
+# Honored solely when the pipeline is uploaded with --git-diff-base (see
+# .buildkite/pr.yml); without that flag every step runs, as it did before.
+# The exclude list is deliberately conservative -- it drops only paths that are
+# native-path-only, since over-including merely wastes a run while
+# over-excluding would silently skip a suite that should have caught a break.
+_if_changed: &if_changed
+  include:
+    - ".buildkite/**"
+    - "tests/optimum/**"
+    - "vllm_rbln/**"
+    - "pyproject.toml"
+    - "uv.lock"
+  exclude:
+    - ".buildkite/pipelines/vllm-rbln/**"
+    - "tests/native/**"
+    - "vllm_rbln/patches/**"
+    - "vllm_rbln/compilation/**"
+    - "vllm_rbln/v1/worker/rbln_*.py"
+    - "vllm_rbln/v1/spec_decode/**"
+
 _sync: &sync "echo '--- :package: uv sync' && uv sync --locked --python 3.12 --extra test --extra dev --extra runtime && bash .buildkite/scripts/rebel-compiler-override.sh && echo '+++ :pytest: pytest'"
 
 steps:
@@ -26,6 +47,7 @@ steps:
   # CPU suites
   # ===========================================================================
   - label: ":pytest: tests/optimum/v1/core"
+    if_changed: *if_changed
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources: &cpu-only-resources
       cpu:
@@ -40,6 +62,7 @@ steps:
       - "uv run --no-sync pytest -x -vvs tests/optimum/v1/core --durations 0"
 
   - label: ":pytest: tests/optimum/v1/worker"
+    if_changed: *if_changed
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources: *cpu-only-resources
     secrets: *secrets
@@ -48,6 +71,7 @@ steps:
       - "uv run --no-sync pytest -x -vvs tests/optimum/v1/worker/test_rebel_optimum_model_runner.py --durations 0"
 
   - label: ":pytest: tests/optimum/optimum_compile/converter"
+    if_changed: *if_changed
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources: *cpu-only-resources
     secrets: *secrets
@@ -59,6 +83,7 @@ steps:
   # NPU suites
   # ===========================================================================
   - label: ":pytest: tests/optimum/entrypoints/openai"
+    if_changed: *if_changed
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources:
       npu:
@@ -70,6 +95,7 @@ steps:
       - "uv run --no-sync pytest -x -vvs tests/optimum/entrypoints/openai --durations 0 --timeout=600"
 
   - label: ":pytest: tests/optimum/entrypoints/llm"
+    if_changed: *if_changed
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources:
       npu:
@@ -81,6 +107,7 @@ steps:
       - "uv run --no-sync pytest -x -vvs tests/optimum/entrypoints/llm --durations 0"
 
   - label: ":pytest: tests/optimum/v1/models"
+    if_changed: *if_changed
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources:
       npu:
@@ -92,6 +119,7 @@ steps:
       - "uv run --no-sync pytest -x -vvs tests/optimum/v1/models --durations 0"
 
   - label: ":pytest: tests/optimum/v1/worker/test_sampler*.py"
+    if_changed: *if_changed
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources:
       npu:
@@ -108,6 +136,7 @@ steps:
   # Optimum smoke suites -> NPU using RSD
   # ===========================================================================
   - label: ":pytest: tests/optimum/optimum_compile/smoke rsd-1"
+    if_changed: *if_changed
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     env:
       # TODO single-threaded OpenMP works around a libgomp fork-safety deadlock in the
@@ -125,6 +154,7 @@ steps:
       - "uv run --no-sync pytest -x -vvs tests/optimum/optimum_compile/smoke/test_rsd1.py --durations 0"
 
   - label: ":pytest: tests/optimum/optimum_compile/smoke rsd-4"
+    if_changed: *if_changed
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources:
       npu:
@@ -136,6 +166,7 @@ steps:
       - "uv run --no-sync pytest -x -vvs tests/optimum/optimum_compile/smoke/test_rsd4.py --durations 0"
 
   - label: ":pytest: tests/optimum/optimum_compile/smoke rsd-8"
+    if_changed: *if_changed
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources:
       npu:

--- a/.buildkite/pr.yml
+++ b/.buildkite/pr.yml
@@ -38,7 +38,10 @@ steps:
           sparse:
             paths:
               - .buildkite
-        command: "buildkite-agent pipeline upload .buildkite/pipelines/optimum-pr/pipeline.yml"
+        command: |
+          TARGET_BRANCH=$${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-dev}
+          git fetch origin $$TARGET_BRANCH
+          buildkite-agent pipeline upload .buildkite/pipelines/optimum-pr/pipeline.yml --git-diff-base origin/$$TARGET_BRANCH
 
   - group: ":snake: vllm-rbln tests"
     key: "vllm-rbln"

--- a/tests/optimum/optimum_compile/smoke/test_base.py
+++ b/tests/optimum/optimum_compile/smoke/test_base.py
@@ -188,8 +188,12 @@ class MultimodalSmoke:
             if self.USE_CHAT_TEMPLATE:
                 from transformers import AutoProcessor
 
+                # setUpClass's LLM(...) already pulled this model -- processor
+                # included -- into the HF cache, so resolve from disk. Re-fetching
+                # re-issues an etag HEAD per file against the hub for nothing, and
+                # that redundant round is a real contributor to CI rate-limit hits.
                 processor = AutoProcessor.from_pretrained(
-                    self.MODEL_ID, **self.PROCESSOR_KWARGS
+                    self.MODEL_ID, local_files_only=True, **self.PROCESSOR_KWARGS
                 )
                 messages = [
                     {

--- a/tests/optimum/optimum_compile/smoke/test_rsd1.py
+++ b/tests/optimum/optimum_compile/smoke/test_rsd1.py
@@ -54,22 +54,3 @@ class TestBgeM3(PoolingSmoke.Test):
         "max_model_len": 1024,
         "max_num_seqs": 4,
     }
-
-
-# TODO: Uncomment this when we have a model to test.
-# class TestQwen35VL(MultimodalSmoke.Test):
-#     # Linear attention
-#     MODEL_ID = "Qwen/Qwen3.5-0.8B"
-#     HF_OVERRIDES = {
-#         "text_config.num_hidden_layers": 4,
-#         "vision_config.depth": 1,
-#     }
-#     NUM_DEVICES = 1
-#     LLM_KWARGS = {
-#         "block_size": 4096,
-#         "max_model_len": 8192,
-#         "max_num_seqs": 1,
-#         "additional_config": {"rbln_config": {"visual": {"max_seq_len": [512]}}},
-#     }
-#     # Cap the image so its vision-token count fits the visual max_seq_len (512).
-#     MM_PROCESSOR_KWARGS = {"min_pixels": 64 * 16 * 16, "max_pixels": 64 * 16 * 16}

--- a/tests/optimum/optimum_compile/smoke/test_rsd8.py
+++ b/tests/optimum/optimum_compile/smoke/test_rsd8.py
@@ -36,3 +36,21 @@ class TestQwen25VL(MultimodalSmoke.Test):
     }
     # Shrink the image so its vision-token count fits the visual max_seq_len.
     MM_PROCESSOR_KWARGS = {"min_pixels": 64 * 14 * 14, "max_pixels": 64 * 14 * 14}
+
+
+class TestQwen35VL(MultimodalSmoke.Test):
+    # Linear attention
+    MODEL_ID = "Qwen/Qwen3.5-0.8B"
+    HF_OVERRIDES = {
+        "text_config.num_hidden_layers": 4,
+        "vision_config.depth": 1,
+    }
+    NUM_DEVICES = 8
+    LLM_KWARGS = {
+        "block_size": 4096,
+        "max_model_len": 8192,
+        "max_num_seqs": 1,
+        "additional_config": {"rbln_config": {"visual": {"max_seq_len": [512]}}},
+    }
+    # Cap the image so its vision-token count fits the visual max_seq_len (512).
+    MM_PROCESSOR_KWARGS = {"min_pixels": 64 * 16 * 16, "max_pixels": 64 * 16 * 16}


### PR DESCRIPTION
### 🚀 Summary of Changes

Reduces the HF-hub load that the **optimum-rbln** PR pipeline puts on every push, in two parts. No native-path code is touched.

**1. Path-gate the optimum PR steps.** The pipeline uploaded every step on every PR, so a change touching only native-path code still spun up all the optimum NPU model-loading suites. Each step now carries `if_changed`, and `.buildkite/pr.yml` uploads the pipeline with `--git-diff-base origin/$TARGET_BRANCH` (mirroring the existing vllm-rbln uploader) so `if_changed` is honored. A step runs only when the PR touches a path that can affect the optimum path.

The `include` stays broad (`vllm_rbln/**`); the narrowing lives in a deliberately conservative `exclude` of native-path-only paths (`patches/**`, `compilation/**`, `v1/worker/rbln_*.py`, `v1/spec_decode/**`, `tests/native/**`, the vllm-rbln pipeline dir). This is the safe direction: over-including only wastes a run, whereas a restrictive `include` would silently skip the suite on a shared-code change — e.g. a regression in `platform.py` or `envs.py`, which both paths use.

**2. Smoke suite.**
- `MultimodalSmoke` now reads the chat-template processor with `local_files_only=True`. `setUpClass`'s `LLM(...)` has already pulled the model (processor included) into the HF cache, so the second load need not re-issue an etag HEAD per file against the hub — a redundant round that contributes to HF rate-limit hits in CI.
- Qwen3.5-VL moves from a commented-out placeholder in `test_rsd1.py` to a live `TestQwen35VL` in `test_rsd8.py` (`NUM_DEVICES=8`).

**Model path affected:** optimum-rbln only.

---

### 📌 Related Issues / Tickets

<!-- Needs a linked development issue before merge. -->

* Related to #

---

### ✅ Type of Change

* [x] ❓ Other (`other`): CI path-gating + optimum smoke suite update

---

### 🧪 How to Test

1. On this PR, the `upload optimum-pr` step uploads the pipeline with `--git-diff-base origin/dev`. Verify the optimum steps **run** here (the PR touches `tests/optimum/**` and `.buildkite/**`).
2. Open a PR that touches only a native-path file (e.g. `vllm_rbln/patches/**` or `tests/native/**`) and verify the optimum steps are **skipped**.
3. The `smoke rsd-8` step now runs `TestQwen35VL` (compile + generate on 8 devices) and must produce at least one token.

Verified locally: `pre-commit` (ruff / mypy / license) passes on all changed files; the pipeline YAML parses and every step resolves the `if_changed` anchor. The NPU smoke suites themselves were **not** run locally — they require an RBLN NPU.

---

### 📸 Screenshots / Logs (if applicable)

N/A

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

- A prefetch → `HF_HUB_OFFLINE=1` variant of the smoke steps was prototyped and dropped: its payoff hinges on whether the CI `HF_HOME` cache is persistent across builds (unknown), and each smoke class loads its model roughly once, so the reduction was marginal. The always-valid piece (`local_files_only`) is what remains.
- The `exclude` list is intentionally conservative; it can be tightened once the gating behavior is observed on a few PRs.
- Needs a linked development issue before merge (checklist item above is unchecked).
