### PR TITLE
other(ci): raise UV_LOCK_TIMEOUT to 1200 for the shared uv cache

### DIFF
--- a/.buildkite/pipelines/optimum-pr/pipeline.yml
+++ b/.buildkite/pipelines/optimum-pr/pipeline.yml
@@ -7,6 +7,7 @@ notify:
 env:
   UV_CACHE_DIR: "/mnt/uv_cache"
   UV_LINK_MODE: "symlink"
+  UV_LOCK_TIMEOUT: "1200"
   UV_INDEX_STRATEGY: "unsafe-best-match"
   NUM_INPUT_PROMPT: "1"
   VLLM_LOGGING_LEVEL: "DEBUG"

--- a/.buildkite/pipelines/vllm-rbln/pipeline-pr.yml
+++ b/.buildkite/pipelines/vllm-rbln/pipeline-pr.yml
@@ -5,6 +5,7 @@ notify:
 env:
   UV_CACHE_DIR: "/root/.cache/uv"
   UV_LINK_MODE: "symlink"
+  UV_LOCK_TIMEOUT: "1200"
   UV_INDEX_STRATEGY: "unsafe-best-match"
 
 _if_changed: &if_changed

--- a/.buildkite/pr.yml
+++ b/.buildkite/pr.yml
@@ -1,6 +1,7 @@
 env:
   UV_CACHE_DIR: "/mnt/uv_cache"
   UV_LINK_MODE: "symlink"
+  UV_LOCK_TIMEOUT: "1200"
   UV_INDEX_STRATEGY: "unsafe-best-match"
 
 # uv index creds for the pre-commit env (LHS = job env var, RHS = OB vault name).

--- a/.buildkite/vllm-rbln-nightly.yml
+++ b/.buildkite/vllm-rbln-nightly.yml
@@ -1,6 +1,7 @@
 env:
   UV_CACHE_DIR: "/root/.cache/uv"
   UV_LINK_MODE: "symlink"
+  UV_LOCK_TIMEOUT: "1200"
   UV_INDEX_STRATEGY: "unsafe-best-match"
 
 _secrets: &secrets


### PR DESCRIPTION
## What

Raise `UV_LOCK_TIMEOUT` to 1200s for the shared uv cache, so concurrent CI lanes don't
fail while waiting on the distribution-cache lock.

## Why

Lanes share `/mnt/uv_cache` and contend on the editable-build lock for the local package
(`vllm-rbln @ file:///workspace/build/buildkite`). uv's default 300s lock wait times out
under that contention:

```
Failed to acquire lock on the distribution cache
Timeout (300s) when waiting for lock on `/mnt/uv_cache/sdists-v9/editable/…`,
is another uv process running? You can set `UV_LOCK_TIMEOUT` to increase the timeout.
```

(vllm-rbln-pr-ci build #329.) Matches `rebel_compiler`'s shared-cache setting
(`.buildkite/pipelines/vllm-dynamo-ci/scripts/install-deps.sh` uses `UV_LOCK_TIMEOUT=1200`).

## Change

`UV_LOCK_TIMEOUT: "1200"` added next to the existing `UV_*` knobs in the four pipeline env
blocks: `pr.yml`, `optimum-pr/pipeline.yml`, `vllm-rbln/pipeline-pr.yml`, `vllm-rbln-nightly.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
