### PR TITLE
refactor(ci): build the optimum suites' environment once per build

### DIFF
--- a/.buildkite/pipelines/optimum-pr/pipeline.yml
+++ b/.buildkite/pipelines/optimum-pr/pipeline.yml
@@ -21,11 +21,12 @@ _secrets: &secrets
 
 # Every job hashes to the same editable entry in the shared NFS cache and uv holds that
 # lock for the whole build, so the project install skips the cache (astral-sh/uv#15380).
-# uv rejects --no-cache under this pipeline's symlink link mode, hence the copy override.
+# Both overrides are load-bearing: uv rejects --no-cache under this pipeline's symlink
+# link mode, and uv pip otherwise targets the image's VIRTUAL_ENV over the project .venv.
 _sync: &sync |
   echo '--- :package: uv sync'
   uv sync --locked --python 3.12 --extra test --extra dev --extra runtime --no-install-project
-  UV_LINK_MODE=copy uv pip install -e . --no-deps --no-cache
+  UV_LINK_MODE=copy uv pip install --python .venv/bin/python -e . --no-deps --no-cache
   bash .buildkite/scripts/rebel-compiler-override.sh
   echo '+++ :pytest: pytest'
 

--- a/.buildkite/pipelines/optimum-pr/pipeline.yml
+++ b/.buildkite/pipelines/optimum-pr/pipeline.yml
@@ -8,6 +8,8 @@ env:
   UV_CACHE_DIR: "/mnt/uv_cache"
   UV_LINK_MODE: "symlink"
   UV_INDEX_STRATEGY: "unsafe-best-match"
+  UV_PROJECT_ENVIRONMENT: "/mnt/cache/venv"
+  VIRTUAL_ENV: "/mnt/cache/venv"
   NUM_INPUT_PROMPT: "1"
   VLLM_LOGGING_LEVEL: "DEBUG"
 
@@ -19,18 +21,18 @@ _secrets: &secrets
   HF_TOKEN: HF_TOKEN
   HF_HOME: HF_HOME
 
-# Every job hashes to the same editable entry in the shared NFS cache and uv holds that
-# lock for the whole build, so the project install skips the cache (astral-sh/uv#15380).
-# Both overrides are load-bearing: uv rejects --no-cache under this pipeline's symlink
-# link mode, and uv pip otherwise targets the image's VIRTUAL_ENV over the project .venv.
-_sync: &sync |
-  echo '--- :package: uv sync'
-  uv sync --locked --python 3.12 --extra test --extra dev --extra runtime --no-install-project
-  UV_LINK_MODE=copy uv pip install --python .venv/bin/python -e . --no-deps --no-cache
-  bash .buildkite/scripts/rebel-compiler-override.sh
-  echo '+++ :pytest: pytest'
+_needs_venv: &needs_venv ["venv"]
 
 steps:
+  - label: ":package: shared venv"
+    key: "venv"
+    image: "${DEVTOOLS_DOCKER_IMAGE}"
+    secrets: *secrets
+    command:
+      - |
+        uv sync --locked --python 3.12 --extra test --extra dev --extra runtime --no-editable --compile-bytecode
+        bash .buildkite/scripts/rebel-compiler-override.sh
+
   # ===========================================================================
   # CPU suites
   # ===========================================================================
@@ -44,24 +46,24 @@ steps:
         requests: "32Gi"
         limits: "32Gi"
     secrets: *secrets
+    depends_on: *needs_venv
     command:
-      - *sync
       - "uv run --no-sync pytest -x -vvs tests/optimum/v1/core --durations 0"
 
   - label: ":pytest: tests/optimum/v1/worker"
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources: *cpu-only-resources
     secrets: *secrets
+    depends_on: *needs_venv
     command:
-      - *sync
       - "uv run --no-sync pytest -x -vvs tests/optimum/v1/worker/test_rebel_optimum_model_runner.py --durations 0"
 
   - label: ":pytest: tests/optimum/optimum_compile/converter"
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources: *cpu-only-resources
     secrets: *secrets
+    depends_on: *needs_venv
     command:
-      - *sync
       - "uv run --no-sync pytest -x -vvs tests/optimum/optimum_compile/converter --durations 0"
 
   # ===========================================================================
@@ -74,8 +76,8 @@ steps:
         count: 1
         product: ["RBLN-CA22", "RBLN-CA25"]
     secrets: *secrets
+    depends_on: *needs_venv
     command:
-      - *sync
       - "uv run --no-sync pytest -x -vvs tests/optimum/entrypoints/openai --durations 0 --timeout=600"
 
   - label: ":pytest: tests/optimum/entrypoints/llm"
@@ -85,8 +87,8 @@ steps:
         count: 1
         product: ["RBLN-CA22", "RBLN-CA25"]
     secrets: *secrets
+    depends_on: *needs_venv
     command:
-      - *sync
       - "uv run --no-sync pytest -x -vvs tests/optimum/entrypoints/llm --durations 0"
 
   - label: ":pytest: tests/optimum/v1/models"
@@ -96,8 +98,8 @@ steps:
         count: 1
         product: ["RBLN-CA22", "RBLN-CA25"]
     secrets: *secrets
+    depends_on: *needs_venv
     command:
-      - *sync
       - "uv run --no-sync pytest -x -vvs tests/optimum/v1/models --durations 0"
 
   - label: ":pytest: tests/optimum/v1/worker/test_sampler*.py"
@@ -107,8 +109,8 @@ steps:
         count: 8
         product: ["RBLN-CA22", "RBLN-CA25"]
     secrets: *secrets
+    depends_on: *needs_venv
     command:
-      - *sync
       - 'uv run --no-sync pytest -x -vvs -n 8 -k "warm_up_true" tests/optimum/v1/worker/test_sampler.py --durations 0'
       - 'uv run --no-sync pytest -x -vvs -n 8 -k "warm_up_false" tests/optimum/v1/worker/test_sampler.py --durations 0'
       - 'uv run --no-sync pytest -x -vvs -n 8 -k "not warm_up_true and not warm_up_false" tests/optimum/v1/worker/test_sampler.py tests/optimum/v1/worker/test_sampler_bucket.py --durations 0'
@@ -129,8 +131,8 @@ steps:
         count: 1
         product: ["RBLN-CA22", "RBLN-CA25"]
     secrets: *secrets
+    depends_on: *needs_venv
     command:
-      - *sync
       - "uv run --no-sync pytest -x -vvs tests/optimum/optimum_compile/smoke/test_rsd1.py --durations 0"
 
   - label: ":pytest: tests/optimum/optimum_compile/smoke rsd-4"
@@ -140,8 +142,8 @@ steps:
         count: 4
         product: ["RBLN-CA22", "RBLN-CA25"]
     secrets: *secrets
+    depends_on: *needs_venv
     command:
-      - *sync
       - "uv run --no-sync pytest -x -vvs tests/optimum/optimum_compile/smoke/test_rsd4.py --durations 0"
 
   - label: ":pytest: tests/optimum/optimum_compile/smoke rsd-8"
@@ -151,6 +153,6 @@ steps:
         count: 8
         product: ["RBLN-CA22", "RBLN-CA25"]
     secrets: *secrets
+    depends_on: *needs_venv
     command:
-      - *sync
       - "uv run --no-sync pytest -x -vvs tests/optimum/optimum_compile/smoke/test_rsd8.py --durations 0"

--- a/.buildkite/pipelines/optimum-pr/pipeline.yml
+++ b/.buildkite/pipelines/optimum-pr/pipeline.yml
@@ -19,7 +19,14 @@ _secrets: &secrets
   HF_TOKEN: HF_TOKEN
   HF_HOME: HF_HOME
 
-_sync: &sync "echo '--- :package: uv sync' && uv sync --locked --python 3.12 --extra test --extra dev --extra runtime && bash .buildkite/scripts/rebel-compiler-override.sh && echo '+++ :pytest: pytest'"
+# Every job hashes to the same editable entry in the shared NFS cache and uv holds that
+# lock for the whole build, so the project install skips the cache (astral-sh/uv#15380).
+_sync: &sync |
+  echo '--- :package: uv sync'
+  uv sync --locked --python 3.12 --extra test --extra dev --extra runtime --no-install-project
+  uv pip install -e . --no-deps --no-cache
+  bash .buildkite/scripts/rebel-compiler-override.sh
+  echo '+++ :pytest: pytest'
 
 steps:
   # ===========================================================================

--- a/.buildkite/pipelines/optimum-pr/pipeline.yml
+++ b/.buildkite/pipelines/optimum-pr/pipeline.yml
@@ -30,7 +30,9 @@ steps:
     secrets: *secrets
     command:
       - |
+        echo '--- :package: uv sync'
         uv sync --locked --python 3.12 --extra test --extra dev --extra runtime --no-editable --compile-bytecode
+        echo '--- :hammer: rebel-compiler-override'
         bash .buildkite/scripts/rebel-compiler-override.sh
 
   # ===========================================================================

--- a/.buildkite/pipelines/optimum-pr/pipeline.yml
+++ b/.buildkite/pipelines/optimum-pr/pipeline.yml
@@ -21,10 +21,11 @@ _secrets: &secrets
 
 # Every job hashes to the same editable entry in the shared NFS cache and uv holds that
 # lock for the whole build, so the project install skips the cache (astral-sh/uv#15380).
+# uv rejects --no-cache under this pipeline's symlink link mode, hence the copy override.
 _sync: &sync |
   echo '--- :package: uv sync'
   uv sync --locked --python 3.12 --extra test --extra dev --extra runtime --no-install-project
-  uv pip install -e . --no-deps --no-cache
+  UV_LINK_MODE=copy uv pip install -e . --no-deps --no-cache
   bash .buildkite/scripts/rebel-compiler-override.sh
   echo '+++ :pytest: pytest'
 


### PR DESCRIPTION


The optimum PR pipeline kept dying in `uv sync` with

```
Timeout (300s) when waiting for lock on `/mnt/uv_cache/sdists-v9/editable/e5311780509d7016`
```

`e5311780509d7016` is a hash of the editable install *path*. Every job checks out
to the same container path, so they all hash to one cache entry, and uv holds
that lock for the whole build rather than only while writing the result
(astral-sh/uv#15380, open). Ten jobs start within two minutes of each other, so
the project builds serialised across the group. Jobs that survived paid for it
too — a passing job in build 338 reported `Prepared 1 package in 4m 23s` for the
single editable entry, next to `Installed 187 packages in 18.61s` for everything
else.

Rather than work around the lock, this removes the contention: `/mnt/cache` is
shared across a build's jobs, so **one step builds the environment there and the
ten suites only read it**. No suite runs `uv sync` any more, and only one job
builds the project, so there is nothing left to contend for.

Two flags on that sync are load-bearing rather than incidental:

* `--no-editable` — an editable install points at the builder's checkout, and no
  other job's pod has that tree. A wheel carries the code itself.
* `--compile-bytecode` — otherwise every suite writes `.pyc` into the shared
  `site-packages` the first time it imports, and they import concurrently.

`UV_PROJECT_ENVIRONMENT` points `uv sync` and `uv run` at the shared path;
`VIRTUAL_ENV` does the same for the `uv pip` call inside
`rebel-compiler-override.sh`, which would otherwise land in the image's
`/opt/venv`.

