### PR TITLE
fix(metrics): wait for the graph on non-last PP ranks

### DIFF
--- a/tests/native/patches/test_metrics.py
+++ b/tests/native/patches/test_metrics.py
@@ -501,12 +501,16 @@ class TestModelExecutable:
     def _fake_rbln(self, monkeypatch, clock=None) -> list[str]:
         synced: list[str] = []
 
-        def synchronize(device: str) -> None:
-            synced.append(device)
-            if clock is not None:
-                clock.advance(0.5)
+        def current_stream(device: str):
+            def synchronize() -> None:
+                synced.append(device)
+                if clock is not None:
+                    clock.advance(0.5)
 
-        rbln = types.SimpleNamespace(synchronize=synchronize)
+            event = types.SimpleNamespace(synchronize=synchronize)
+            return types.SimpleNamespace(record_event=lambda: event)
+
+        rbln = types.SimpleNamespace(current_stream=current_stream)
         monkeypatch.setattr(pm, "torch", types.SimpleNamespace(rbln=rbln))
         monkeypatch.setattr(pm, "USE_DEVICE_TENSOR", True)
         return synced
@@ -523,7 +527,7 @@ class TestModelExecutable:
         assert ctx._graph_latency is not None
         assert calls == [{"step": 1}, {"step": 2}]
 
-    def test_non_last_pp_rank_waits_on_the_output_device_inside_the_model_range(
+    def test_non_last_pp_rank_waits_on_its_graph_event_inside_the_model_range(
         self, monkeypatch, clock
     ):
         synced = self._fake_rbln(monkeypatch, clock=clock)

--- a/tests/native/patches/test_metrics.py
+++ b/tests/native/patches/test_metrics.py
@@ -478,19 +478,41 @@ class TestSamplerTiming:
 
 
 class TestModelExecutable:
-    def test_the_executable_is_timed_only_inside_a_pass(self, monkeypatch):
+    def _load(self, monkeypatch, *, is_last_rank: bool):
         calls: list[dict] = []
+        hidden = types.SimpleNamespace(device="rbln:1")
+        output = (types.SimpleNamespace(tensors={"hidden_states": hidden}), None, None)
 
         def fake_load_model(self, *args, **kwargs):
             def executable(**kwargs):
                 calls.append(kwargs)
-                return "logits"
+                return "logits" if is_last_rank else output
 
             self.model_executable = executable
 
         monkeypatch.setattr(pm, "_load_model", fake_load_model)
+        monkeypatch.setattr(
+            pm, "get_pp_group", lambda: types.SimpleNamespace(is_last_rank=is_last_rank)
+        )
         runner = _Runner()
         pm.load_model(runner)
+        return runner, calls
+
+    def _fake_rbln(self, monkeypatch, clock=None) -> list[str]:
+        synced: list[str] = []
+
+        def synchronize(device: str) -> None:
+            synced.append(device)
+            if clock is not None:
+                clock.advance(0.5)
+
+        rbln = types.SimpleNamespace(synchronize=synchronize)
+        monkeypatch.setattr(pm, "torch", types.SimpleNamespace(rbln=rbln))
+        monkeypatch.setattr(pm, "USE_DEVICE_TENSOR", True)
+        return synced
+
+    def test_the_executable_is_timed_only_inside_a_pass(self, monkeypatch):
+        runner, calls = self._load(monkeypatch, is_last_rank=True)
         ctx = pm._ctx(runner)
 
         assert runner.model_executable(step=1) == "logits"  # warm-up
@@ -500,6 +522,33 @@ class TestModelExecutable:
         runner.model_executable(step=2)
         assert ctx._graph_latency is not None
         assert calls == [{"step": 1}, {"step": 2}]
+
+    def test_non_last_pp_rank_waits_on_the_output_device_inside_the_model_range(
+        self, monkeypatch, clock
+    ):
+        synced = self._fake_rbln(monkeypatch, clock=clock)
+        runner, _ = self._load(monkeypatch, is_last_rank=False)
+        ctx = pm._ctx(runner)
+
+        ctx.start_pass()
+        runner.model_executable(step=1)
+        assert synced == ["rbln:1"]
+        assert ctx._graph_latency == pytest.approx(0.5)
+
+    def test_last_pp_rank_leaves_the_wait_to_the_sampler(self, monkeypatch):
+        synced = self._fake_rbln(monkeypatch)
+        runner, _ = self._load(monkeypatch, is_last_rank=True)
+
+        pm._ctx(runner).start_pass()
+        runner.model_executable(step=1)
+        assert synced == []
+
+    def test_no_wait_outside_a_pass(self, monkeypatch):
+        synced = self._fake_rbln(monkeypatch)
+        runner, _ = self._load(monkeypatch, is_last_rank=False)
+
+        runner.model_executable(step=1)
+        assert synced == []
 
 
 class TestShutdown:

--- a/vllm_rbln/patches/metrics.py
+++ b/vllm_rbln/patches/metrics.py
@@ -19,7 +19,7 @@ sum, so MODEL + SAMPLE carries the same call count as E2E and the difference of 
 means is the host overhead around the graphs. A pass is recorded only once its phase
 and its graph time are both known, which is what keeps those counts equal. The graph
 runs asynchronously: the last PP rank waits for it in the sampler, the other ranks in
-the model range.
+the model range on an event recorded right after the call.
 
 The whole feature lives in this module so the runner carries no metrics code at all. A
 range that is not a whole method -- the model call sits mid-way through execute_model --
@@ -305,9 +305,11 @@ def load_model(self, *args, **kwargs):
         start = time.perf_counter()
         output = executable(*call_args, **call_kwargs)
         if USE_DEVICE_TENSOR and not get_pp_group().is_last_rank:
-            # Without a sampler the wait would land in the worker's PP send.
+            # Without a sampler the wait would land in the worker's PP send. Wait on
+            # this graph's seq only: a device synchronize drains every stream and
+            # stalls the other in-flight PP batches.
             hidden_states = next(iter(output[0].tensors.values()))
-            torch.rbln.synchronize(hidden_states.device)
+            torch.rbln.current_stream(hidden_states.device).record_event().synchronize()
         ctx.add_graph_time(time.perf_counter() - start)
         return output
 

--- a/vllm_rbln/patches/metrics.py
+++ b/vllm_rbln/patches/metrics.py
@@ -17,7 +17,9 @@ Three ranges are timed with perf_counter: the pass (execute_model through
 sample_tokens), the model call, and the sampler call. The last two are reported as one
 sum, so MODEL + SAMPLE carries the same call count as E2E and the difference of the two
 means is the host overhead around the graphs. A pass is recorded only once its phase
-and its graph time are both known, which is what keeps those counts equal.
+and its graph time are both known, which is what keeps those counts equal. The graph
+runs asynchronously: the last PP rank waits for it in the sampler, the other ranks in
+the model range.
 
 The whole feature lives in this module so the runner carries no metrics code at all. A
 range that is not a whole method -- the model call sits mid-way through execute_model --
@@ -34,10 +36,13 @@ from dataclasses import dataclass, field
 from enum import Enum
 
 import numpy as np
+import torch
+from vllm.distributed import get_pp_group
 
 from vllm_rbln import envs
 from vllm_rbln.logger import init_logger
 from vllm_rbln.patches import register_patch
+from vllm_rbln.platform import USE_DEVICE_TENSOR
 from vllm_rbln.v1.worker.rbln_model_runner import RBLNModelRunner
 from vllm_rbln.v1.worker.rbln_worker import RBLNWorker
 
@@ -299,6 +304,10 @@ def load_model(self, *args, **kwargs):
             return executable(*call_args, **call_kwargs)
         start = time.perf_counter()
         output = executable(*call_args, **call_kwargs)
+        if USE_DEVICE_TENSOR and not get_pp_group().is_last_rank:
+            # Without a sampler the wait would land in the worker's PP send.
+            hidden_states = next(iter(output[0].tensors.values()))
+            torch.rbln.synchronize(hidden_states.device)
         ctx.add_graph_time(time.perf_counter() - start)
         return output
 


### PR DESCRIPTION
### 🚀 Summary of Changes

`VLLM_RBLN_METRICS` under-reports the model range on non-last PP ranks with device tensors: the graph returns before the device finishes and the wait sits in the worker's PP send, outside the measured pass. The last rank waits in the sampler, so it was already correct.

`patches/metrics.py` now records an event on the output's stream right after the model call and waits on it inside the model range. An event, not `torch.rbln.synchronize`: the device sync drains every stream and stalls the other in-flight PP batches.

vLLM-native path only. No change with metrics disabled.

---

### 📌 Related Issues / Tickets

* Related to #

---

### ✅ Type of Change

* [x] 🛠 Bug fix (`fix`)

---

### 🧪 How to Test

1. `uv run --no-sync pytest tests/native/patches/test_metrics.py::TestModelExecutable -x`
2. Run a PP>1 model with `VLLM_RBLN_METRICS=1 VLLM_RBLN_USE_DEVICE_TENSOR=1`; `MODEL + SAMPLE` on `PP0` should be on the same scale as on the last rank.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

Needs `torch.rbln.Event` from torch-rbln (RBLN-SW/torch-rbln#154); not in `0.4.0rc0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


