### PR TITLE
other: auto-update optimum-rbln to 0.11.2a5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "torchaudio",
     "torchcodec",
     "torch-rbln~=0.4.0rc0 ; platform_machine == 'x86_64'",
-    "optimum-rbln>=0.11.2a4",
+    "optimum-rbln>=0.11.2a5",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1533,7 +1533,7 @@ wheels = [
 
 [[package]]
 name = "optimum-rbln"
-version = "0.11.2a4"
+version = "0.11.2a5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "accelerate" },
@@ -1546,9 +1546,9 @@ dependencies = [
     { name = "torchvision", marker = "platform_python_implementation == 'CPython'" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/0e/b0407d40c3d0d8704afa70bfb5a4373ca0d0ffc630513050ed9ef9715ce1/optimum_rbln-0.11.2a4.tar.gz", hash = "sha256:a44acd38fc5137e7402fa3425fd4290ac8903211869eef317070ecf3224ce48c", size = 610974, upload-time = "2026-08-24T10:44:50.363Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/0e/a15dea3fa01d94d8364fb75f0a64bc0840d414ed7324fdd8ad13ddcd6d85/optimum_rbln-0.11.2a5.tar.gz", hash = "sha256:0fd621e088858abf78df7f9ca39c0d1556901494708b1a4fe7a4742e45ed0fd9", size = 611915, upload-time = "2026-08-25T12:54:17.273Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/a8/8e3eae93b6fccdc5845abeb24ce2adf53c57dc0869f9b0100e5eb1555a56/optimum_rbln-0.11.2a4-py3-none-any.whl", hash = "sha256:67e4865ba79ea5fd629871751462998b17b449b4b73547d897bf4aa922e6158e", size = 662958, upload-time = "2026-08-24T10:44:48.328Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ab/c719842f64ec9d195d76b844d835e1bd1938ef59f19d21b73d358906dc42/optimum_rbln-0.11.2a5-py3-none-any.whl", hash = "sha256:b51a3aa6e01504ef1bf68c340fe17feec05e2c6e9079ecf985f8a68945c86bee", size = 663561, upload-time = "2026-08-25T12:54:15.213Z" },
 ]
 
 [[package]]
@@ -2930,7 +2930,7 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = "<0.137" },
     { name = "fire", marker = "extra == 'dev'" },
     { name = "huggingface-hub", marker = "extra == 'dev'" },
-    { name = "optimum-rbln", specifier = ">=0.11.2a4" },
+    { name = "optimum-rbln", specifier = ">=0.11.2a5" },
     { name = "packaging", marker = "extra == 'dev'" },
     { name = "pynvml", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'test'" },


### PR DESCRIPTION
# Description
Backport of #994 to `release-v0.11.2`, originally by @rebel-develop.