### PR TITLE
fix(kv-cache): port RBLN SWA external-token allocation to vllm 0.24 hooks

### DIFF
--- a/tests/native/v1/test_kv_cache.py
+++ b/tests/native/v1/test_kv_cache.py
@@ -126,11 +126,13 @@ class TestRBLNSlidingWindowManager:
         assert len(m.req_to_blocks["r"]) == 1
         assert pool.get_num_free_blocks() == free0 - 1
 
-    def test_allocate_external_noop_when_present(self):
+    def test_allocate_external_rejects_preexisting_blocks(self):
+        # add_local_computed_blocks runs first and leaves the list empty; a
+        # block already present means the coordinator sequence broke.
         m = _manager(_never_pool())
         m.req_to_blocks["r"] = [object()]
-        m.allocate_external_computed_blocks("r", 0, 5)
-        assert len(m.req_to_blocks["r"]) == 1
+        with pytest.raises(AssertionError):
+            m.allocate_external_computed_blocks("r", 0, 5)
 
     def test_find_longest_cache_hit_returns_empty_per_group(self):
         # Prefix caching disabled: one empty list per kv_cache_group_id.

--- a/tests/native/v1/test_kv_cache.py
+++ b/tests/native/v1/test_kv_cache.py
@@ -100,33 +100,37 @@ class TestRBLNSlidingWindowManager:
         m.req_to_blocks["r"] = [object()]
         assert m.allocate_new_blocks("r", 10, 10) == []
 
-    def test_allocate_computed_fresh_no_external_allocates_nothing(self):
+    def test_add_local_computed_fresh_marks_cached_without_blocks(self):
         m = _manager(_never_pool())
-        m.allocate_new_computed_blocks("r", [], 0, 0)
+        m.add_local_computed_blocks("r", [], 0, 5)
         assert m.num_cached_block["r"] == 0
         assert m.req_to_blocks["r"] == []
 
-    def test_allocate_computed_fresh_with_external_allocates_one(self):
-        pool = _pool()
-        free0 = pool.get_num_free_blocks()
-        m = _manager(pool)
-        m.allocate_new_computed_blocks("r", [], 0, 5)
-        assert len(m.req_to_blocks["r"]) == 1
-        assert pool.get_num_free_blocks() == free0 - 1
-
-    def test_allocate_computed_already_cached_is_noop(self):
-        # Idempotent fast path: a request already in num_cached_block draws no
-        # block (external tokens are ignored once cached).
-        m = _manager(_never_pool())
-        m.num_cached_block["r"] = 0
-        m.allocate_new_computed_blocks("r", [], 0, 5)
-        assert m.req_to_blocks["r"] == []
-
-    def test_allocate_computed_rejects_prefix_hit_blocks(self):
+    def test_add_local_computed_rejects_prefix_hit_blocks(self):
         # A prefix-cache hit (non-empty new_computed_blocks) is unsupported.
         m = _manager(_never_pool())
         with pytest.raises(AssertionError):
-            m.allocate_new_computed_blocks("r", [object()], 0, 0)
+            m.add_local_computed_blocks("r", [object()], 0, 0)
+
+    def test_allocate_external_no_external_allocates_nothing(self):
+        m = _manager(_never_pool())
+        m.allocate_external_computed_blocks("r", 0, 0)
+        assert m.req_to_blocks["r"] == []
+
+    def test_allocate_external_allocates_one_regardless_of_token_count(self):
+        # cdiv(6077, 16) would be 380 blocks upstream; RBLN keeps one.
+        pool = _pool()
+        free0 = pool.get_num_free_blocks()
+        m = _manager(pool)
+        m.allocate_external_computed_blocks("r", 0, 6077)
+        assert len(m.req_to_blocks["r"]) == 1
+        assert pool.get_num_free_blocks() == free0 - 1
+
+    def test_allocate_external_noop_when_present(self):
+        m = _manager(_never_pool())
+        m.req_to_blocks["r"] = [object()]
+        m.allocate_external_computed_blocks("r", 0, 5)
+        assert len(m.req_to_blocks["r"]) == 1
 
     def test_find_longest_cache_hit_returns_empty_per_group(self):
         # Prefix caching disabled: one empty list per kv_cache_group_id.
@@ -155,3 +159,81 @@ class TestRegistration:
         assert (
             KVCacheSpecRegistry.get_manager_class(_spec()) is RBLNSlidingWindowManager
         )
+
+
+class TestCoordinatorExternalTokens:
+    """Drive the real KVCacheCoordinator so the override is exercised through
+    the hook names the pinned vllm actually calls (the KV-connector D-side
+    receive path), not by direct method call."""
+
+    def _coordinator(self, block_size, sliding_window, num_blocks=64):
+        from vllm.v1.core.kv_cache_coordinator import get_kv_cache_coordinator
+        from vllm.v1.core.single_type_kv_cache_manager import (
+            register_all_kvcache_specs,
+        )
+        from vllm.v1.kv_cache_interface import (
+            FullAttentionSpec,
+            KVCacheConfig,
+            KVCacheGroupSpec,
+            KVCacheTensor,
+        )
+
+        from vllm_rbln.platform import RblnPlatform
+
+        # Built-in registration is lazy and skipped once any spec is present.
+        register_all_kvcache_specs(None)
+        RblnPlatform.register_custom_kv_cache_specs(None)
+        common = dict(num_kv_heads=2, head_size=8, dtype=torch.float16)
+        swa = RBLNSlidingWindowSpec(
+            block_size=block_size, sliding_window=sliding_window, **common
+        )
+        full = FullAttentionSpec(block_size=block_size, **common)
+        config = KVCacheConfig(
+            num_blocks=num_blocks,
+            kv_cache_tensors=[
+                KVCacheTensor(size=swa.page_size_bytes * num_blocks, shared_by=["l0"]),
+                KVCacheTensor(size=full.page_size_bytes * num_blocks, shared_by=["l1"]),
+            ],
+            kv_cache_groups=[
+                KVCacheGroupSpec(["l0"], swa),
+                KVCacheGroupSpec(["l1"], full),
+            ],
+        )
+        return get_kv_cache_coordinator(
+            kv_cache_config=config,
+            max_model_len=block_size * 32,
+            max_num_batched_tokens=512,
+            use_eagle=False,
+            enable_caching=False,
+            enable_kv_cache_events=False,
+            dcp_world_size=1,
+            pcp_world_size=1,
+            scheduler_block_size=block_size,
+            hash_block_size=block_size,
+        )
+
+    def test_external_tokens_over_one_block_keep_swa_group_at_one_block(self):
+        # ICR-15: gpt-oss P/D with 6077 external tokens and block_size 4096.
+        # P holds one SWA block; D must not allocate cdiv(6077, 4096) == 2.
+        block_size, ext = 4096, 6077
+        coord = self._coordinator(block_size=block_size, sliding_window=128)
+        assert isinstance(coord.single_type_managers[0], RBLNSlidingWindowManager)
+
+        coord.allocate_new_computed_blocks(
+            "r",
+            new_computed_blocks=([], []),
+            num_local_computed_tokens=0,
+            num_external_computed_tokens=ext,
+        )
+        swa_blocks, full_blocks = (
+            m.req_to_blocks["r"] for m in coord.single_type_managers
+        )
+        assert len(swa_blocks) == 1
+        assert len(full_blocks) == -(-ext // block_size) == 2
+
+        # Nothing further for the (one) new token of the remote-prefilled request.
+        new = coord.allocate_new_blocks(
+            "r", num_tokens=ext + 1, num_tokens_main_model=ext + 1
+        )
+        assert new[0] == []
+        assert len(coord.single_type_managers[0].req_to_blocks["r"]) == 1

--- a/vllm_rbln/v1/kv_cache.py
+++ b/vllm_rbln/v1/kv_cache.py
@@ -99,8 +99,7 @@ class RBLNSlidingWindowManager(SingleTypeKVCacheManager):
         if num_external_computed_tokens <= 0:
             return
         req_blocks = self.req_to_blocks[request_id]
-        if req_blocks:
-            return
+        assert len(req_blocks) == 0
         req_blocks.extend(self.block_pool.get_new_blocks(1))
 
     @classmethod

--- a/vllm_rbln/v1/kv_cache.py
+++ b/vllm_rbln/v1/kv_cache.py
@@ -68,10 +68,23 @@ class RBLNSlidingWindowManager(SingleTypeKVCacheManager):
         self.req_to_blocks[request_id].extend(new_blocks)
         return new_blocks
 
-    def allocate_new_computed_blocks(
+    def add_local_computed_blocks(
         self,
         request_id: str,
         new_computed_blocks: Sequence[KVCacheBlock],
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        assert not list(new_computed_blocks), (
+            "RBLNSlidingWindowManager does not support prefix-cache hits "
+            "(find_longest_cache_hit returns empty)"
+        )
+        assert len(self.req_to_blocks[request_id]) == 0
+        self.num_cached_block[request_id] = 0
+
+    def allocate_external_computed_blocks(
+        self,
+        request_id: str,
         num_local_computed_tokens: int,
         num_external_computed_tokens: int,
     ) -> None:
@@ -83,24 +96,12 @@ class RBLNSlidingWindowManager(SingleTypeKVCacheManager):
         through here, so without this override D over-allocates and mismatches
         the P-side single block.
         """
-        if request_id in self.num_cached_block:
-            assert len(new_computed_blocks) == 0
+        if num_external_computed_tokens <= 0:
             return
-
         req_blocks = self.req_to_blocks[request_id]
-        assert len(req_blocks) == 0
-        assert not list(new_computed_blocks), (
-            "RBLNSlidingWindowManager does not support prefix-cache hits "
-            "(find_longest_cache_hit returns empty)"
-        )
-
-        # Sentinel for the base-class fast path; 0 because RBLN neither skips
-        # nor pulls from prefix cache.
-        self.num_cached_block[request_id] = 0
-
-        if num_external_computed_tokens > 0:
-            new_blocks = self.block_pool.get_new_blocks(1)
-            req_blocks.extend(new_blocks)
+        if req_blocks:
+            return
+        req_blocks.extend(self.block_pool.get_new_blocks(1))
 
     @classmethod
     def find_longest_cache_hit(


### PR DESCRIPTION
### 🚀 Summary of Changes

### Summary

`RBLNSlidingWindowManager` overrode `allocate_new_computed_blocks`, but vllm 0.24.0 (upstream 588db18362) split that hook into `add_local_computed_blocks` + `allocate_external_computed_blocks`. Since the 0.24.0 bump (#829) the override has been dead code, so on the KV-connector D side the base implementation allocates `cdiv(num_external_tokens, block_size)` blocks for the SWA group while P holds a single block. Any remote prefill longer than one block then kills the D engine in nixl `_apply_prefix_caching` (`assert num_local_blocks <= len(remote_group)`).

This PR overrides the two new hooks and adds a test that goes through the real `KVCacheCoordinator`, so the hook names are verified against the pinned vllm instead of by direct method call.

### Details

- **Root cause (ICR-15)** — gpt-oss-120b pdd-dp2ep + `RblnNixlConnector`, block_size 4096, 6077 external tokens. The D-side dump shows `local_block_ids=[[1, 2], [3, 4]]` vs `remote.block_ids=[[2], [1, 3]]`: group 0 (SWA) got 2 blocks on D because `SingleTypeKVCacheManager.allocate_external_computed_blocks` ran instead of the RBLN override. 81-token requests passed because both sides were 1 block.

- **Fix** — `add_local_computed_blocks` keeps the "no prefix hits" assertion and seeds `num_cached_block`. `allocate_external_computed_blocks` allocates exactly one block when there are external tokens and none yet, matching `allocate_new_blocks`.

- **Test** — `TestCoordinatorExternalTokens` builds a hybrid (RBLN SWA + Full) `KVCacheCoordinator` and calls `allocate_new_computed_blocks` with 6077 external tokens; SWA group must hold 1 block, Full group `cdiv(6077, 4096) == 2`. It fails on `dev` with `assert 2 == 1` and passes with this change. Direct-call tests are renamed to the new hooks.

### Next Steps

- Re-run the ICR-15 case (`pdd-dp2ep-throughput`, `kv_connector=nixl`, long_context input) once merged.
- Consider a CI guard that fails when an override name in `vllm_rbln` no longer exists on the pinned vllm base class.

---

### 📌 Related Issues / Tickets

* Related to https://rbln.atlassian.net/browse/ICR-15

---

### ✅ Type of Change

* [x] 🛠 Bug fix (`fix`)

---

### 🧪 How to Test

1. Run `pytest tests/native/v1/test_kv_cache.py` against vllm 0.24.0+cpu — 16 passed.
2. `git stash -- vllm_rbln/v1/kv_cache.py` and rerun `-k Coordinator` — fails with `assert 2 == 1` (reproduces ICR-15).
3. E2E: prefill/decode `vllm serve openai/gpt-oss-120b --block-size 4096 --data-parallel-size 2 --enable-expert-parallel --kv-transfer-config '{"kv_connector":"RblnNixlConnector","kv_role":"kv_both","kv_buffer_device":"rbln"}' --no-enable-prefix-caching --num-gpu-blocks-override 48`, send a >4096-token prompt; D must not raise `AssertionError` in `_apply_prefix_caching`.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

Draft: unit-tested only; E2E on the ICR-15 case is pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
