### PR TITLE
perf(compile): dispatch compiled graphs without Dynamo's cache lookup

### DIFF
--- a/tests/native/compilation/test_compiler.py
+++ b/tests/native/compilation/test_compiler.py
@@ -175,6 +175,11 @@ class TestCompileOptions:
         compile(object(), use_cache=use_cache)
         assert "mega_cache_only" not in captured_compile["options"]
 
+    def test_direct_dispatch_requires_fullgraph(self, captured_compile):
+        # Whatever Dynamo leaves outside the one graph is unreachable from a clone.
+        with pytest.raises(ValueError, match="fullgraph"):
+            compile(object(), use_direct_dispatch=True)
+
     def test_forwards_backend_dynamic_fullgraph(self, captured_compile):
         # backend / dynamic / fullgraph pass straight through to torch.compile.
         backend = object()

--- a/tests/native/compilation/test_compiler.py
+++ b/tests/native/compilation/test_compiler.py
@@ -28,6 +28,7 @@ from vllm_rbln.compilation import (
     compile,
     create_compile_context,
 )
+from vllm_rbln.compilation.dispatch import Dispatcher
 
 
 @pytest.fixture(autouse=True)
@@ -174,6 +175,14 @@ class TestCompileOptions:
         monkeypatch.setattr(compiler.envs, "VLLM_DISABLE_COMPILE_CACHE", disabled)
         compile(object(), use_cache=use_cache)
         assert "mega_cache_only" not in captured_compile["options"]
+
+    def test_direct_dispatch_wraps_the_compiled_callable(self, captured_compile):
+        def target(x):
+            return x
+
+        assert isinstance(
+            compile(target, fullgraph=True, use_direct_dispatch=True), Dispatcher
+        )
 
     def test_direct_dispatch_requires_fullgraph(self, captured_compile):
         # Whatever Dynamo leaves outside the one graph is unreachable from a clone.

--- a/tests/native/compilation/test_compiler.py
+++ b/tests/native/compilation/test_compiler.py
@@ -105,10 +105,11 @@ class TestCompileOptions:
         compile(object(), mode="foo")
         assert captured_compile["options"]["mode"] == ["foo"]
 
-    def test_mode_empty_skipped(self, captured_compile):
-        # An empty mode is not set.
+    def test_mode_empty_becomes_an_empty_list(self, captured_compile):
+        # The backend reads options.get("mode", []), so an empty list and an
+        # absent key are the same input to it.
         compile(object(), mode="")
-        assert "mode" not in captured_compile["options"]
+        assert captured_compile["options"]["mode"] == []
 
     def test_compile_only_appended_when_env_set(self, captured_compile, monkeypatch):
         # VLLM_RBLN_COMPILE_ONLY appends "compile_only" to a str mode.
@@ -116,12 +117,13 @@ class TestCompileOptions:
         compile(object(), mode="foo")
         assert captured_compile["options"]["mode"] == ["foo", "compile_only"]
 
-    # TODO(RBLN): compile_only is appended only when mode is a str, so a
-    # list-valued mode silently drops it. Fix the source, then drop this xfail.
-    @pytest.mark.xfail(
-        strict=True,
-        reason="compile_only not appended when mode is passed as a list",
-    )
+    def test_compile_only_appended_to_empty_mode(self, captured_compile, monkeypatch):
+        # Every call site passes "" unless VLLM_RBLN_COMPILE_STRICT_MODE is on,
+        # so this is the configuration compile-only actually runs in.
+        monkeypatch.setattr(compiler.envs, "VLLM_RBLN_COMPILE_ONLY", True)
+        compile(object(), mode="")
+        assert captured_compile["options"]["mode"] == ["compile_only"]
+
     def test_compile_only_appended_for_list_mode(self, captured_compile, monkeypatch):
         monkeypatch.setattr(compiler.envs, "VLLM_RBLN_COMPILE_ONLY", True)
         compile(object(), mode=["foo"])

--- a/tests/native/compilation/test_dispatch.py
+++ b/tests/native/compilation/test_dispatch.py
@@ -231,9 +231,8 @@ class TestDispatch:
         assert first.forward(x) == ("eager", 1)
 
     def test_the_dispatched_region_lands_in_a_profile(self, monkeypatch, tmp_path):
-        # Bypassing the frame eval bypasses Dynamo's own annotation, so a dispatched
-        # call is a blank in the trace unless the dispatcher names it -- and it must
-        # do so without VLLM_CUSTOM_SCOPES_FOR_PROFILING.
+        # The dispatcher must name the region without
+        # VLLM_CUSTOM_SCOPES_FOR_PROFILING.
         target, _ = make_target()
         d = Dispatcher(target, recorder([], "compiled"))
         install_entries(monkeypatch, [target.__code__])
@@ -249,9 +248,8 @@ class TestDispatch:
         assert "Dispatched Region: 0/0" in names
 
     def test_clone_differs_from_the_target_only_in_its_code(self, monkeypatch):
-        # The FunctionType constructor takes five of the function's slots; the
-        # slots are enumerated off the type so a new one fails here rather than
-        # being dropped silently by _clone.
+        # Enumerated off the type, so a slot a future Python adds fails here
+        # rather than being dropped silently by _clone.
         def target(x, y=None, *, scale=3.0):
             """docstring."""
             return "eager"
@@ -351,12 +349,10 @@ def key_of(monkeypatch, kwargs, context_key):
 class TestKeyDiscrimination:
     """The key must separate every situation that needs its own graph.
 
-    Key completeness is the one precondition Dispatcher cannot check: a key
-    coarser than Dynamo's guards serves one graph for two situations, forever
-    and unreported, and no count of compiled graphs reveals it because the
-    second graph is never requested. What this class can do is pin the
-    situations down as an explicit list and require the key to tell them apart
-    -- so a change that collapses two of them fails here instead of in a model.
+    Dispatcher cannot check key completeness, and no count of compiled graphs
+    reveals a collapsed pair because the second graph is never requested. So
+    this pins the situations down as an explicit list and requires the key to
+    tell them apart, failing here instead of in a model.
     """
 
     def test_distinct_situations_never_share_a_key(self, monkeypatch):

--- a/tests/native/compilation/test_dispatch.py
+++ b/tests/native/compilation/test_dispatch.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 # Dispatcher's contract: first call per key goes through the compiled
-# callable and records the graph, later calls with that key run the recorded
-# bytecode directly, and a key that maps to two graphs is an error. The real
-# thing needs a compiled model; here the Dynamo pieces are stubbed.
+# callable and records the graph, and later calls with that key run the recorded
+# bytecode directly. The real thing needs a compiled model; here the Dynamo
+# pieces are stubbed.
 
 import contextlib
 import types

--- a/tests/native/compilation/test_dispatch.py
+++ b/tests/native/compilation/test_dispatch.py
@@ -1,0 +1,166 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dispatcher's contract: first call per key goes through the compiled
+# callable and records the graph, later calls with that key run the recorded
+# bytecode directly, and a key that maps to two graphs is an error. The real
+# thing needs a compiled model; here the Dynamo pieces are stubbed.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import vllm_rbln.compilation.dispatch as dispatch
+from vllm_rbln.compilation.dispatch import Dispatcher
+
+
+@pytest.fixture
+def neutral_forward_context(monkeypatch):
+    # The key's forward-context half is exercised separately; keep it constant
+    # so the argument half is the only thing varying.
+    monkeypatch.setattr(dispatch, "_forward_context_key", lambda: (False, None, False))
+
+
+def make_target():
+    calls: list[tuple] = []
+
+    def target(x, y=None):
+        calls.append(("target", x.shape if x is not None else None))
+        return "eager"
+
+    return target, calls
+
+
+def recorder(calls, result):
+    def compiled(*args, **kwargs):
+        calls.append((args, kwargs))
+        return result
+
+    return compiled
+
+
+def install_entries(monkeypatch, codes):
+    """Stub Dynamo's cache so the head of the list is `codes[-1]`."""
+    entries = [SimpleNamespace(code=c) for c in reversed(codes)]
+    monkeypatch.setattr(
+        torch._dynamo.eval_frame, "_debug_get_cache_entry_list", lambda code: entries
+    )
+
+
+class TestDispatch:
+    @pytest.fixture(autouse=True)
+    def _neutral(self, neutral_forward_context):
+        return None
+
+    def test_first_call_goes_through_the_compiled_callable(self, monkeypatch):
+        target, _ = make_target()
+        seen: list = []
+        d = Dispatcher(target, recorder(seen, "compiled"))
+        install_entries(monkeypatch, [target.__code__])
+        assert d(torch.zeros(1, 4)) == "compiled"
+        assert len(seen) == 1
+
+    def test_second_call_with_same_key_runs_the_recorded_code(self, monkeypatch):
+        target, calls = make_target()
+        compiled_calls: list = []
+        d = Dispatcher(target, recorder(compiled_calls, "compiled"))
+        install_entries(monkeypatch, [target.__code__])
+        x = torch.zeros(1, 4)
+        d(x)
+        assert d(x) == "eager"  # the recorded code object is target's own here
+        assert len(compiled_calls) == 1
+        assert len(calls) == 1
+
+    def test_new_shape_is_compiled_not_rejected(self, monkeypatch):
+        target, _ = make_target()
+        compiled_calls: list = []
+        d = Dispatcher(target, recorder(compiled_calls, "compiled"))
+        install_entries(monkeypatch, [target.__code__])
+        d(torch.zeros(1, 4))
+        d(torch.zeros(1, 8))  # a bucket warm-up never covered
+        assert len(compiled_calls) == 2
+
+    def test_optional_argument_is_part_of_the_key(self, monkeypatch):
+        target, _ = make_target()
+        compiled_calls: list = []
+        d = Dispatcher(target, recorder(compiled_calls, "compiled"))
+        install_entries(monkeypatch, [target.__code__])
+        x = torch.zeros(1, 4)
+        d(x, y=None)
+        d(x, y=torch.zeros(1))
+        assert len(compiled_calls) == 2
+
+    def test_two_graphs_for_one_key_raises(self, monkeypatch):
+        # A key coarser than Dynamo's guards shows up as one key registering two
+        # code objects; serving either would be wrong, so it has to raise.
+        target, _ = make_target()
+
+        def other_graph(x, y=None):  # a distinct code object, unlike make_target()
+            return "other"
+
+        d = Dispatcher(target, lambda *a, **k: "compiled")
+        install_entries(monkeypatch, [target.__code__])
+        d._register(("key",))
+        install_entries(monkeypatch, [other_graph.__code__])
+        with pytest.raises(RuntimeError, match="two different graphs"):
+            d._register(("key",))
+
+    def test_no_cache_entry_keeps_using_the_compiled_callable(self, monkeypatch):
+        target, _ = make_target()
+        compiled_calls: list = []
+        d = Dispatcher(target, recorder(compiled_calls, "compiled"))
+        install_entries(monkeypatch, [])
+        x = torch.zeros(1, 4)
+        d(x)
+        d(x)
+        assert len(compiled_calls) == 2
+
+    def test_rejects_a_target_without_code(self):
+        with pytest.raises(TypeError, match="plain function"):
+            Dispatcher(torch.nn.Linear(2, 2), lambda *a, **k: None)
+
+
+class TestOutsideForwardContext:
+    def test_dispatches_a_target_called_without_a_forward_context(self, monkeypatch):
+        # The samplers are compiled the same way but run after execute_model has
+        # left the forward context, so reading it unconditionally would raise.
+        target, calls = make_target()
+        compiled_calls: list = []
+        d = Dispatcher(target, recorder(compiled_calls, "compiled"))
+        install_entries(monkeypatch, [target.__code__])
+        x = torch.zeros(1, 4)
+        d(x)
+        assert d(x) == "eager"
+        assert len(compiled_calls) == 1
+        assert len(calls) == 1
+
+
+class TestForwardContextKey:
+    def test_reads_prefill_max_pad_and_connector(self, monkeypatch):
+        ctx = SimpleNamespace(
+            attn_metadata={"layer": SimpleNamespace(is_prefill=True)},
+            dp_metadata=SimpleNamespace(max_pads_across_dp=torch.zeros(7)),
+        )
+        monkeypatch.setattr(dispatch, "is_forward_context_available", lambda: True)
+        monkeypatch.setattr(dispatch, "get_forward_context", lambda: ctx)
+        monkeypatch.setattr(dispatch, "has_kv_transfer_group", lambda: True)
+        assert dispatch._forward_context_key() == (True, 7, True)
+
+    def test_tolerates_a_context_without_dp_or_attention(self, monkeypatch):
+        ctx = SimpleNamespace(attn_metadata={}, dp_metadata=None)
+        monkeypatch.setattr(dispatch, "is_forward_context_available", lambda: True)
+        monkeypatch.setattr(dispatch, "get_forward_context", lambda: ctx)
+        monkeypatch.setattr(dispatch, "has_kv_transfer_group", lambda: False)
+        assert dispatch._forward_context_key() == (None, None, False)

--- a/tests/native/compilation/test_dispatch.py
+++ b/tests/native/compilation/test_dispatch.py
@@ -153,6 +153,58 @@ class TestDispatch:
         d(x, gain=5.0)
         assert len(compiled_calls) == 2
 
+    def test_tensors_of_one_shape_on_two_devices_are_two_keys(self, monkeypatch):
+        # token_type_ids is built without a device, the staged buffers take the
+        # stager's, so a call's tensors are not all on one device.
+        target, _ = make_target()
+        compiled_calls: list = []
+        d = Dispatcher(target, recorder(compiled_calls, "compiled"))
+        install_entries(monkeypatch, [target.__code__])
+        d(torch.zeros(1, 4))
+        d(torch.zeros(1, 4, device="meta"))
+        assert len(compiled_calls) == 2
+
+    def test_tensors_of_one_shape_with_two_strides_are_two_keys(self, monkeypatch):
+        # Same shape and dtype either way; the strides are (4, 1) and (1, 2).
+        target, _ = make_target()
+        compiled_calls: list = []
+        d = Dispatcher(target, recorder(compiled_calls, "compiled"))
+        install_entries(monkeypatch, [target.__code__])
+        d(torch.zeros(4, 4)[:, :2])
+        d(torch.zeros(2, 4).t())
+        assert len(compiled_calls) == 2
+
+    def test_a_bool_and_the_int_it_equals_are_two_keys(self, monkeypatch):
+        target, _ = make_target()
+        compiled_calls: list = []
+        d = Dispatcher(target, recorder(compiled_calls, "compiled"))
+        install_entries(monkeypatch, [target.__code__])
+        x = torch.zeros(1, 4)
+        d(x, y=True)
+        d(x, y=1)
+        assert len(compiled_calls) == 2
+
+    def test_intermediate_tensors_are_keyed_like_the_tensors_they_hold(
+        self, monkeypatch
+    ):
+        # The one slot InputStager passes through: a warm-up run puts a view here,
+        # a real step the pipeline group's receive buffer.
+        target, _ = make_target()
+        compiled_calls: list = []
+        d = Dispatcher(target, recorder(compiled_calls, "compiled"))
+        install_entries(monkeypatch, [target.__code__])
+        x = torch.zeros(1, 4)
+        d(x, y=IntermediateTensors({"hidden_states": torch.zeros(4, 4)[:, :2]}))
+        d(x, y=IntermediateTensors({"hidden_states": torch.zeros(2, 4).t()}))
+        assert len(compiled_calls) == 2
+
+    def test_rejects_a_mapping_that_is_not_intermediate_tensors(self, monkeypatch):
+        target, _ = make_target()
+        d = Dispatcher(target, recorder([], "compiled"))
+        install_entries(monkeypatch, [target.__code__])
+        with pytest.raises(TypeError, match="cannot key a dict argument"):
+            d(torch.zeros(1, 4), y={"hidden_states": torch.zeros(1, 4)})
+
     def test_rejects_an_argument_it_cannot_key(self, monkeypatch):
         target, _ = make_target()
         d = Dispatcher(target, recorder([], "compiled"))

--- a/tests/native/compilation/test_dispatch.py
+++ b/tests/native/compilation/test_dispatch.py
@@ -17,15 +17,17 @@
 # bytecode directly. The real thing needs a compiled model; here the Dynamo
 # pieces are stubbed.
 
-import contextlib
+import json
 import types
 from types import SimpleNamespace
 
 import pytest
 import torch
+from vllm.sequence import IntermediateTensors
 
 import vllm_rbln.compilation.dispatch as dispatch
 from vllm_rbln.compilation.dispatch import Dispatcher
+from vllm_rbln.v1.worker.input_stager import StagedModelInputs
 
 
 @pytest.fixture
@@ -176,25 +178,23 @@ class TestDispatch:
         assert Model.forward.__code__ is original_code
         assert first.forward(x) == ("eager", 1)
 
-    def test_records_a_profiler_scope_naming_the_dispatched_graph(self, monkeypatch):
-        # Bypassing the frame eval bypasses Dynamo's own profiler scope, so the
-        # region is only identifiable in a trace if the dispatcher opens one.
+    def test_the_dispatched_region_lands_in_a_profile(self, monkeypatch, tmp_path):
+        # Bypassing the frame eval bypasses Dynamo's own annotation, so a dispatched
+        # call is a blank in the trace unless the dispatcher names it -- and it must
+        # do so without VLLM_CUSTOM_SCOPES_FOR_PROFILING.
         target, _ = make_target()
-        scopes: list = []
-
-        @contextlib.contextmanager
-        def spy(name):
-            scopes.append(name)
-            yield
-
-        monkeypatch.setattr(dispatch, "record_function_or_nullcontext", spy)
         d = Dispatcher(target, recorder([], "compiled"))
         install_entries(monkeypatch, [target.__code__])
         x = torch.zeros(1, 4)
         d(x)
-        assert scopes == []  # the cold call runs through Dynamo's own scope
-        d(x)
-        assert scopes == ["Dispatched Region: 0/0"]
+        with torch.profiler.profile(
+            activities=[torch.profiler.ProfilerActivity.CPU]
+        ) as prof:
+            d(x)
+        trace = tmp_path / "trace.json"
+        prof.export_chrome_trace(str(trace))
+        names = {e["name"] for e in json.loads(trace.read_text())["traceEvents"]}
+        assert "Dispatched Region: 0/0" in names
 
     def test_clone_differs_from_the_target_only_in_its_code(self, monkeypatch):
         # The FunctionType constructor takes five of the function's slots; the
@@ -225,6 +225,123 @@ class TestDispatch:
             if name not in ("__code__", "__builtins__")
             and getattr(clone, name, missing) != getattr(target, name, missing)
         ] == []
+
+
+# The situations one runner process stages, as (kwargs, forward-context key).
+# Faithful to what reaches a dispatched model: input_stager.StagedModelInputs
+# .as_kwargs() names the arguments, rbln_model_runner._prepare_model_inputs
+# shapes them (int32 ids, int64 positions, [num_reqs, query_len]), and
+# dispatch._forward_context_key reads (is_prefill, dp pad width, kv connector).
+#
+# Only variation a single process can produce is listed. The batch buckets and
+# the DP pad width change from step to step; the query length grows with
+# speculative tokens; intermediate tensors arrive on a non-first pipeline rank.
+# has_kv_transfer_group() is fixed for the process's lifetime, so it cannot
+# collide with itself and is not a case here.
+def _staged(num_reqs, query_len, *, token_indices=0, intermediate=False):
+    shape = (num_reqs, query_len)
+    tensors = None
+    if intermediate:
+        tensors = IntermediateTensors(
+            {"hidden_states": torch.zeros(num_reqs, query_len, 8)}
+        )
+    return {
+        "input_ids": torch.zeros(shape, dtype=torch.int32),
+        "positions": torch.zeros(shape, dtype=torch.int64),
+        "intermediate_tensors": tensors,
+        "inputs_embeds": None,
+        "token_indices": (
+            torch.zeros(token_indices, dtype=torch.int32) if token_indices else None
+        ),
+    }
+
+
+PREFILL = (True, None, False)
+DECODE = (False, None, False)
+
+SITUATIONS: dict[str, tuple[dict, tuple]] = {
+    "prefill": (_staged(1, 512, token_indices=1), PREFILL),
+    "decode-b1": (_staged(1, 1), DECODE),
+    "decode-b2": (_staged(2, 1), DECODE),
+    "decode-b4": (_staged(4, 1), DECODE),
+    "decode-b8": (_staged(8, 1), DECODE),
+    # A drafted step carries 1 + num_spec_tokens columns.
+    "decode-b4-spec4": (_staged(4, 5), DECODE),
+    # Same staged tensors as decode-b4; only the DP-agreed pad width differs,
+    # and the graph reads it as dp_metadata.max_pads_across_dp.shape[0].
+    "decode-b4-dp8": (_staged(4, 1), (False, 8, False)),
+    "decode-b4-dp16": (_staged(4, 1), (False, 16, False)),
+    # Same again, with a pipeline rank's inbound activations.
+    "decode-b4-pp": (_staged(4, 1, intermediate=True), DECODE),
+}
+
+
+def key_of(monkeypatch, kwargs, context_key):
+    """The one key a fresh Dispatcher registers for a single call."""
+
+    def model_wrapper(
+        input_ids,
+        positions,
+        intermediate_tensors=None,
+        inputs_embeds=None,
+        token_indices=None,
+    ):
+        return "eager"
+
+    monkeypatch.setattr(dispatch, "_forward_context_key", lambda: context_key)
+    d = Dispatcher(model_wrapper, recorder([], "compiled"))
+    install_entries(monkeypatch, [model_wrapper.__code__])
+    d(**kwargs)
+    (key,) = d._graphs
+    return key
+
+
+class TestKeyDiscrimination:
+    """The key must separate every situation that needs its own graph.
+
+    Key completeness is the one precondition Dispatcher cannot check: a key
+    coarser than Dynamo's guards serves one graph for two situations, forever
+    and unreported, and no count of compiled graphs reveals it because the
+    second graph is never requested. What this class can do is pin the
+    situations down as an explicit list and require the key to tell them apart
+    -- so a change that collapses two of them fails here instead of in a model.
+    """
+
+    def test_distinct_situations_never_share_a_key(self, monkeypatch):
+        keys = {
+            name: key_of(monkeypatch, kwargs, context_key)
+            for name, (kwargs, context_key) in SITUATIONS.items()
+        }
+        by_key: dict[tuple, list[str]] = {}
+        for name, key in keys.items():
+            by_key.setdefault(key, []).append(name)
+        collided = sorted(names for names in by_key.values() if len(names) > 1)
+        assert not collided, f"situations sharing one graph: {collided}"
+
+    def test_the_same_situation_reuses_its_key(self, monkeypatch):
+        # The other direction: a key finer than the guards would recompile every
+        # step. Fresh tensors of the same shape and dtype must land on one key.
+        for name, (kwargs, context_key) in SITUATIONS.items():
+            first = key_of(monkeypatch, kwargs, context_key)
+            again = key_of(monkeypatch, {**kwargs}, context_key)
+            assert first == again, f"{name} keyed two identical calls apart"
+            rebuilt, _ = SITUATIONS[name]
+            assert first == key_of(monkeypatch, rebuilt, context_key), (
+                f"{name} keys on tensor identity, not shape/dtype"
+            )
+
+    def test_the_situations_cover_every_dispatched_argument(self):
+        # Drift alarm: a new argument on the model call is a new axis the key may
+        # have to carry, and a table that does not mention it would keep passing.
+        staged = StagedModelInputs(
+            input_ids=torch.zeros(1, 1, dtype=torch.int32),
+            positions=torch.zeros(1, 1, dtype=torch.int64),
+            intermediate_tensors=None,
+            inputs_embeds=None,
+            token_indices=None,
+        )
+        for kwargs, _context_key in SITUATIONS.values():
+            assert set(kwargs) == set(staged.as_kwargs())
 
 
 @pytest.mark.use_device

--- a/tests/native/compilation/test_dispatch.py
+++ b/tests/native/compilation/test_dispatch.py
@@ -107,6 +107,22 @@ class TestDispatch:
         d(x, y=torch.zeros(1))
         assert len(compiled_calls) == 2
 
+    def test_forward_context_is_part_of_the_key(self, monkeypatch):
+        # Identical inputs in a different phase must not share a graph.
+        target, _ = make_target()
+        compiled_calls: list = []
+        phase = [True]
+        monkeypatch.setattr(
+            dispatch, "_forward_context_key", lambda: (phase[0], None, False)
+        )
+        d = Dispatcher(target, recorder(compiled_calls, "compiled"))
+        install_entries(monkeypatch, [target.__code__])
+        x = torch.zeros(1, 4)
+        d(x)
+        phase[0] = False
+        d(x)
+        assert len(compiled_calls) == 2
+
     def test_no_cache_entry_keeps_using_the_compiled_callable(self, monkeypatch):
         target, _ = make_target()
         compiled_calls: list = []
@@ -209,6 +225,52 @@ class TestDispatch:
             if name not in ("__code__", "__builtins__")
             and getattr(clone, name, missing) != getattr(target, name, missing)
         ] == []
+
+
+@pytest.mark.use_device
+class TestDynamoContract:
+    """Drift alarm against Dynamo. Everything above stubs the cache lookup, so
+    what _register reads out of it and what _clone does with the bytecode is
+    checked here against the real thing -- on the eager backend, since none of
+    it depends on how the graph was lowered."""
+
+    def test_the_clone_runs_the_graph_dynamo_recorded(self):
+        compiles: list = []
+
+        def backend(gm, example_inputs):
+            compiles.append(gm)
+            return gm.forward
+
+        scale = 2.0  # a freevar, so the clone needs the target's __closure__
+
+        def target(x, y=None):
+            out = x * scale
+            return out if y is None else out + y
+
+        d = Dispatcher(target, torch.compile(target, backend=backend, fullgraph=True))
+        x = torch.ones(2, 4)
+        assert torch.equal(d(x), target(x))
+        assert torch.equal(d(x), target(x))  # the clone, not the compiled callable
+        assert len(compiles) == 1
+        clone, _annotation = next(iter(d._graphs.values()))
+        assert clone.__code__ is not target.__code__
+
+    def test_the_cache_list_head_is_the_graph_the_last_call_used(self):
+        # _register takes entries[0], which is only the graph the call it follows
+        # used while Dynamo keeps the list MRU-ordered.
+        def target(x):
+            return x + 1
+
+        compiled = torch.compile(target, backend="eager", dynamic=False, fullgraph=True)
+        entries_of = torch._dynamo.eval_frame._debug_get_cache_entry_list
+        compiled(torch.zeros(4))
+        four = entries_of(target.__code__)[0]
+        assert isinstance(four.code, types.CodeType)  # _clone's input
+        assert four.compile_id is not None  # the profiler annotation
+        compiled(torch.zeros(8))
+        assert entries_of(target.__code__)[0] is not four
+        compiled(torch.zeros(4))
+        assert entries_of(target.__code__)[0] is four
 
 
 class TestOutsideForwardContext:

--- a/tests/native/compilation/test_dispatch.py
+++ b/tests/native/compilation/test_dispatch.py
@@ -17,6 +17,7 @@
 # bytecode directly, and a key that maps to two graphs is an error. The real
 # thing needs a compiled model; here the Dynamo pieces are stubbed.
 
+import types
 from types import SimpleNamespace
 
 import pytest
@@ -102,21 +103,6 @@ class TestDispatch:
         d(x, y=torch.zeros(1))
         assert len(compiled_calls) == 2
 
-    def test_two_graphs_for_one_key_raises(self, monkeypatch):
-        # A key coarser than Dynamo's guards shows up as one key registering two
-        # code objects; serving either would be wrong, so it has to raise.
-        target, _ = make_target()
-
-        def other_graph(x, y=None):  # a distinct code object, unlike make_target()
-            return "other"
-
-        d = Dispatcher(target, lambda *a, **k: "compiled")
-        install_entries(monkeypatch, [target.__code__])
-        d._register(("key",))
-        install_entries(monkeypatch, [other_graph.__code__])
-        with pytest.raises(RuntimeError, match="two different graphs"):
-            d._register(("key",))
-
     def test_no_cache_entry_keeps_using_the_compiled_callable(self, monkeypatch):
         target, _ = make_target()
         compiled_calls: list = []
@@ -127,9 +113,78 @@ class TestDispatch:
         d(x)
         assert len(compiled_calls) == 2
 
-    def test_rejects_a_target_without_code(self):
-        with pytest.raises(TypeError, match="plain function"):
+    def test_rejects_a_target_that_is_neither_function_nor_method(self):
+        with pytest.raises(TypeError, match="function or a bound method"):
             Dispatcher(torch.nn.Linear(2, 2), lambda *a, **k: None)
+
+    def test_scalar_arguments_are_keyed_by_value(self, monkeypatch):
+        # Dynamo guards on a float argument, so two values need two keys; a key
+        # built from the type name would serve the first graph for both.
+        def target(x, gain=2.0):
+            return "eager"
+
+        compiled_calls: list = []
+        d = Dispatcher(target, recorder(compiled_calls, "compiled"))
+        install_entries(monkeypatch, [target.__code__])
+        x = torch.zeros(1, 4)
+        d(x, gain=2.0)
+        d(x, gain=5.0)
+        assert len(compiled_calls) == 2
+
+    def test_rejects_an_argument_it_cannot_key(self, monkeypatch):
+        target, _ = make_target()
+        d = Dispatcher(target, recorder([], "compiled"))
+        install_entries(monkeypatch, [target.__code__])
+        with pytest.raises(TypeError, match="cannot key a slice argument"):
+            d(slice(0, 2))
+
+    def test_dispatches_a_bound_method_without_touching_its_class(self, monkeypatch):
+        class Model:
+            def __init__(self, bias):
+                self.bias = bias
+
+            def forward(self, x):
+                return ("eager", self.bias)
+
+        first, second = Model(1), Model(2)
+        original_code = Model.forward.__code__
+        d = Dispatcher(second.forward, recorder([], "compiled"))
+        install_entries(monkeypatch, [original_code])
+        x = torch.zeros(1, 4)
+        d(x)
+        assert d(x) == ("eager", 2)  # bound to `second`, not the class
+        assert Model.forward.__code__ is original_code
+        assert first.forward(x) == ("eager", 1)
+
+    def test_clone_differs_from_the_target_only_in_its_code(self, monkeypatch):
+        # The FunctionType constructor takes five of the function's slots; the
+        # slots are enumerated off the type so a new one fails here rather than
+        # being dropped silently by _clone.
+        def target(x, y=None, *, scale=3.0):
+            """docstring."""
+            return "eager"
+
+        setattr(target, "tagged", "attr")  # noqa: B010
+        d = Dispatcher(target, recorder([], "compiled"))
+        install_entries(monkeypatch, [target.__code__])
+        d(torch.zeros(1, 4))
+        clone = next(iter(d._graphs.values()))
+
+        slots = [
+            name
+            for name, member in vars(types.FunctionType).items()
+            if isinstance(
+                member, (types.GetSetDescriptorType, types.MemberDescriptorType)
+            )
+        ]
+        assert "__kwdefaults__" in slots  # the one that changes results
+        missing = object()
+        assert [
+            name
+            for name in slots
+            if name not in ("__code__", "__builtins__")
+            and getattr(clone, name, missing) != getattr(target, name, missing)
+        ] == []
 
 
 class TestOutsideForwardContext:

--- a/tests/native/compilation/test_dispatch.py
+++ b/tests/native/compilation/test_dispatch.py
@@ -17,6 +17,7 @@
 # bytecode directly, and a key that maps to two graphs is an error. The real
 # thing needs a compiled model; here the Dynamo pieces are stubbed.
 
+import contextlib
 import types
 from types import SimpleNamespace
 
@@ -54,7 +55,10 @@ def recorder(calls, result):
 
 def install_entries(monkeypatch, codes):
     """Stub Dynamo's cache so the head of the list is `codes[-1]`."""
-    entries = [SimpleNamespace(code=c) for c in reversed(codes)]
+    entries = [
+        SimpleNamespace(code=c, compile_id=f"0/{i}")
+        for i, c in enumerate(reversed(codes))
+    ]
     monkeypatch.setattr(
         torch._dynamo.eval_frame, "_debug_get_cache_entry_list", lambda code: entries
     )
@@ -156,6 +160,26 @@ class TestDispatch:
         assert Model.forward.__code__ is original_code
         assert first.forward(x) == ("eager", 1)
 
+    def test_records_a_profiler_scope_naming_the_dispatched_graph(self, monkeypatch):
+        # Bypassing the frame eval bypasses Dynamo's own profiler scope, so the
+        # region is only identifiable in a trace if the dispatcher opens one.
+        target, _ = make_target()
+        scopes: list = []
+
+        @contextlib.contextmanager
+        def spy(name):
+            scopes.append(name)
+            yield
+
+        monkeypatch.setattr(dispatch, "record_function_or_nullcontext", spy)
+        d = Dispatcher(target, recorder([], "compiled"))
+        install_entries(monkeypatch, [target.__code__])
+        x = torch.zeros(1, 4)
+        d(x)
+        assert scopes == []  # the cold call runs through Dynamo's own scope
+        d(x)
+        assert scopes == ["Dispatched Region: 0/0"]
+
     def test_clone_differs_from_the_target_only_in_its_code(self, monkeypatch):
         # The FunctionType constructor takes five of the function's slots; the
         # slots are enumerated off the type so a new one fails here rather than
@@ -168,7 +192,7 @@ class TestDispatch:
         d = Dispatcher(target, recorder([], "compiled"))
         install_entries(monkeypatch, [target.__code__])
         d(torch.zeros(1, 4))
-        clone = next(iter(d._graphs.values()))
+        clone, _annotation = next(iter(d._graphs.values()))
 
         slots = [
             name

--- a/vllm_rbln/compilation/compiler.py
+++ b/vllm_rbln/compilation/compiler.py
@@ -102,10 +102,10 @@ def compile(
     set_option("process_group_dict", process_group_dict)
     set_option("guard_filter_fn", guard_filter_fn)
     set_option("_runtime_holder", runtime_holder)
-    if mode and isinstance(mode, str):
-        mode = [mode]
-        if envs.VLLM_RBLN_COMPILE_ONLY:
-            mode.append("compile_only")
+    if isinstance(mode, str):
+        mode = [mode] if mode else []
+    if envs.VLLM_RBLN_COMPILE_ONLY:
+        mode.append("compile_only")
     set_option("mode", mode)
     set_option("use_global_ctx", use_global_ctx)
     set_option("global_device_id", global_device_id)

--- a/vllm_rbln/compilation/compiler.py
+++ b/vllm_rbln/compilation/compiler.py
@@ -22,6 +22,7 @@ from vllm.distributed import get_dp_group, get_pp_group, get_tp_group
 
 from vllm_rbln import envs
 from vllm_rbln.compilation.backends import rbln_backend
+from vllm_rbln.compilation.dispatch import Dispatcher
 
 CompiledTarget = TypeVar("CompiledTarget")
 
@@ -84,6 +85,7 @@ def compile(
     use_cache: bool = True,
     cache_dir: str = "",
     use_static_output: bool = False,
+    use_direct_dispatch: bool = False,
 ) -> CompiledTarget:
     _ensure_torch_dynamo_configured()
 
@@ -112,13 +114,13 @@ def compile(
         set_option("cache_dir", cache_dir or os.path.join(envs.VLLM_CACHE_ROOT, "rbln"))
         set_option("mega_cache_only", True)
 
-    return cast(
-        CompiledTarget,
-        torch.compile(
-            target,
-            backend=backend,
-            dynamic=dynamic,
-            fullgraph=fullgraph,
-            options=options,
-        ),
+    compiled = torch.compile(
+        target,
+        backend=backend,
+        dynamic=dynamic,
+        fullgraph=fullgraph,
+        options=options,
     )
+    if use_direct_dispatch:
+        return cast(CompiledTarget, Dispatcher(target, compiled))
+    return cast(CompiledTarget, compiled)

--- a/vllm_rbln/compilation/compiler.py
+++ b/vllm_rbln/compilation/compiler.py
@@ -87,6 +87,14 @@ def compile(
     use_static_output: bool = False,
     use_direct_dispatch: bool = False,
 ) -> CompiledTarget:
+    if use_direct_dispatch and not fullgraph:
+        # A dispatched call runs one code object, so whatever Dynamo leaves
+        # outside the graph is unreachable: a graph break's resume function only
+        # runs compiled under the frame eval, and a recompile-limit bail-out adds
+        # no cache entry, so _register binds the previous call's graph to the new
+        # key. fullgraph turns both into an exception.
+        raise ValueError("use_direct_dispatch requires fullgraph=True")
+
     _ensure_torch_dynamo_configured()
 
     options = {}

--- a/vllm_rbln/compilation/dispatch.py
+++ b/vllm_rbln/compilation/dispatch.py
@@ -20,6 +20,7 @@ import torch
 from torch._C._profiler import _RecordFunctionFast
 from vllm.distributed.kv_transfer import has_kv_transfer_group
 from vllm.forward_context import get_forward_context, is_forward_context_available
+from vllm.sequence import IntermediateTensors
 
 from vllm_rbln.logger import init_logger
 
@@ -42,14 +43,19 @@ _COPIED_SLOTS = (
 
 
 def _value_key(value: Any) -> Any:
-    """The part of an argument that decides which graph it belongs to."""
+    """The part of an argument that decides which graph it belongs to.
+
+    A tensor contributes the members Dynamo's TENSOR_MATCH compares, less
+    requires_grad, which the step loop's inference_mode pins.
+    """
     if isinstance(value, torch.Tensor):
-        # torch.Size is a tuple, so this stays hashable and allocation-free.
-        return value.shape, value.dtype
+        return value.shape, value.dtype, value.device, value.stride()
     if value is None or isinstance(value, (bool, int, float, str, bytes, torch.dtype)):
-        return value
-    if hasattr(value, "items"):  # IntermediateTensors and friends
-        return tuple((k, t.shape, t.dtype) for k, t in value.items())
+        # Bare, True would fold into 1 and 1 into 1.0: Python hashes them equal
+        # where Dynamo specialises them apart.
+        return type(value), value
+    if isinstance(value, IntermediateTensors):
+        return tuple((k, _value_key(t)) for k, t in value.items())
     raise TypeError(
         f"Dispatcher cannot key a {type(value).__name__} argument. Dynamo may "
         "guard on its value, and a key that does not carry it would serve the "

--- a/vllm_rbln/compilation/dispatch.py
+++ b/vllm_rbln/compilation/dispatch.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 from types import CodeType, FunctionType, MethodType
 from typing import Any
 
@@ -35,7 +36,8 @@ _COPIED_SLOTS = (
     "__module__",
     "__doc__",
     "__annotations__",
-    "__type_params__",
+    # A function carries type params only from 3.12, as does the test's enumeration.
+    *(("__type_params__",) if sys.version_info >= (3, 12) else ()),
 )
 
 
@@ -65,27 +67,28 @@ def _forward_context_key() -> tuple[Any, ...]:
     is attached (which changes the attention wrapper's graph).
 
     Not every dispatched target runs inside a forward context -- the model
-    forward does, the samplers run after it has been exited -- so a missing
-    context is a normal state and contributes nothing to the key.
+    forward does, the medusa drafter runs after execute_model has left it -- so
+    a missing context is a normal state and contributes nothing to the key.
+
+    A missing context, missing DP metadata and a missing pad width are states
+    that really occur. A missing attribute is not, and must not be defaulted:
+    it would drop a key component instead of failing.
     """
     if not is_forward_context_available():
         return (None, None, has_kv_transfer_group())
 
     ctx = get_forward_context()
 
-    dp_metadata = getattr(ctx, "dp_metadata", None)
-    max_pads = getattr(dp_metadata, "max_pads_across_dp", None)
+    dp_metadata = ctx.dp_metadata
+    max_pads = None if dp_metadata is None else dp_metadata.max_pads_across_dp
     max_pad = None if max_pads is None else max_pads.shape[0]
 
     attn_metadata = ctx.attn_metadata
     if isinstance(attn_metadata, dict):
         attn_metadata = next(iter(attn_metadata.values()), None)
-    elif isinstance(attn_metadata, list):
-        first = attn_metadata[0] if attn_metadata else None
-        attn_metadata = next(iter(first.values()), None) if first else None
 
     return (
-        getattr(attn_metadata, "is_prefill", None),
+        None if attn_metadata is None else attn_metadata.is_prefill,
         max_pad,
         has_kv_transfer_group(),
     )
@@ -133,7 +136,6 @@ class Dispatcher:
         self._compiled = compiled
         self._original_code: CodeType = self._function.__code__
         self._graphs: dict[tuple, Any] = {}
-        self._unregistered = 0
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         key = (
@@ -154,15 +156,13 @@ class Dispatcher:
             self._original_code
         )
         if not entries:
-            # Dynamo ran the frame without leaving a cache entry (it bails out
-            # once accumulated_cache_size_limit is hit, for one). Nothing to
-            # dispatch to, so this key keeps taking the Dynamo path.
-            self._unregistered += 1
+            # Dynamo ran the frame without leaving a cache entry -- the frame was
+            # skipped, or an entry it had was invalidated. Nothing to dispatch to,
+            # so this key keeps taking the Dynamo path.
             logger.warning_once(
-                "no Dynamo cache entry for %s; %d key(s) will keep paying the "
-                "frame-eval cost",
+                "no Dynamo cache entry for %s; keys that reach this path keep "
+                "paying the frame-eval cost",
                 self._original_code.co_name,
-                self._unregistered,
             )
             return
 

--- a/vllm_rbln/compilation/dispatch.py
+++ b/vllm_rbln/compilation/dispatch.py
@@ -18,6 +18,7 @@ from typing import Any
 import torch
 from vllm.distributed.kv_transfer import has_kv_transfer_group
 from vllm.forward_context import get_forward_context, is_forward_context_available
+from vllm.v1.utils import record_function_or_nullcontext
 
 from vllm_rbln.logger import init_logger
 
@@ -140,12 +141,13 @@ class Dispatcher:
             tuple((name, _value_key(v)) for name, v in sorted(kwargs.items())),
             *_forward_context_key(),
         )
-        graph = self._graphs.get(key)
+        graph, annotation = self._graphs.get(key, (None, None))
         if graph is None:
             result = self._compiled(*args, **kwargs)
             self._register(key)
             return result
-        return graph(*args, **kwargs)
+        with record_function_or_nullcontext(annotation):
+            return graph(*args, **kwargs)
 
     def _register(self, key: tuple) -> None:
         entries = torch._dynamo.eval_frame._debug_get_cache_entry_list(
@@ -168,11 +170,17 @@ class Dispatcher:
         # used at the head of the list. That identification holds only while
         # nothing else calls the target in between, which the serial step loop
         # guarantees; a second concurrent caller would need this serialised.
-        code = entries[0].code
-        self._graphs[key] = self._clone(code)
+        entry = entries[0]
+        # Bypassing the frame eval also bypasses the profiler scope it opens, so
+        # the region is invisible unless we open one. Dynamo's compile id keeps a
+        # dispatched trace comparable with one taken without the dispatcher.
+        self._graphs[key] = (
+            self._clone(entry.code),
+            f"Dispatched Region: {entry.compile_id}",
+        )
         logger.debug(
             "dispatch: registered %s as entry %d for %s",
-            code.co_name,
+            entry.code.co_name,
             len(self._graphs),
             self._original_code.co_name,
         )

--- a/vllm_rbln/compilation/dispatch.py
+++ b/vllm_rbln/compilation/dispatch.py
@@ -29,8 +29,6 @@ logger = init_logger(__name__)
 # FunctionType's constructor takes five of a function's slots and the rest have
 # to be assigned, or the clone is not the target with a different body. Keyword
 # defaults are the one that changes results rather than just introspection.
-# test_dispatch.py enumerates the slots off the type, so a Python release that
-# adds one fails the test instead of silently dropping it here.
 _COPIED_SLOTS = (
     "__kwdefaults__",
     "__qualname__",
@@ -72,13 +70,10 @@ def _forward_context_key() -> tuple[Any, ...]:
     attention metadata says prefill rather than decode, or when a KV connector
     is attached (which changes the attention wrapper's graph).
 
-    Not every dispatched target runs inside a forward context -- the model
-    forward does, the medusa drafter runs after execute_model has left it -- so
-    a missing context is a normal state and contributes nothing to the key.
-
-    A missing context, missing DP metadata and a missing pad width are states
-    that really occur. A missing attribute is not, and must not be defaulted:
-    it would drop a key component instead of failing.
+    A missing context, missing DP metadata and a missing pad width really
+    occur -- the medusa drafter runs after execute_model has left the context.
+    A missing attribute does not, and must not be defaulted: it would drop a
+    key component instead of failing.
     """
     if not is_forward_context_available():
         return (None, None, has_kv_transfer_group())
@@ -103,12 +98,10 @@ def _forward_context_key() -> tuple[Any, ...]:
 class Dispatcher:
     """Owns the graph selection that Dynamo's cache lookup normally does.
 
-    Deciding which compiled graph a call belongs to costs a frame-eval entry
-    plus a guard-tree walk every step, and the answer is something the runner
-    already knows. So this keeps the mapping itself: the first call for a key
-    goes through Dynamo (which compiles it if needed) and the transformed
-    bytecode is recorded as a clone of the target, and every later call with
-    that key runs the clone directly -- no frame eval, no guards.
+    The first call for a key goes through Dynamo (which compiles it if needed)
+    and the transformed bytecode is recorded as a clone of the target; every
+    later call with that key runs the clone directly, no frame eval and no
+    guards.
 
     A clone rather than the target with its `__code__` swapped, because a swap
     is visible to every other holder of the target for as long as it is
@@ -179,8 +172,7 @@ class Dispatcher:
         entry = entries[0]
         # Bypassing the frame eval also bypasses the profiler scope it opens, so
         # the region is invisible unless we open one. Dynamo's compile id keeps a
-        # dispatched trace comparable with one taken without the dispatcher, and
-        # this scope is gated on the profiler, not on an env var like vLLM's.
+        # dispatched trace comparable with one taken without the dispatcher.
         self._graphs[key] = (
             self._clone(entry.code),
             _RecordFunctionFast(f"Dispatched Region: {entry.compile_id}"),

--- a/vllm_rbln/compilation/dispatch.py
+++ b/vllm_rbln/compilation/dispatch.py
@@ -1,0 +1,158 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import CodeType
+from typing import Any
+
+import torch
+from vllm.distributed.kv_transfer import has_kv_transfer_group
+from vllm.forward_context import get_forward_context, is_forward_context_available
+
+from vllm_rbln.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+def _value_key(value: Any) -> Any:
+    """The part of an argument that decides which graph it belongs to."""
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, torch.Tensor):
+        # torch.Size is a tuple, so this stays hashable and allocation-free.
+        return value.shape, value.dtype
+    if hasattr(value, "items"):  # IntermediateTensors and friends
+        return tuple((k, t.shape, t.dtype) for k, t in value.items())
+    return type(value).__name__
+
+
+def _forward_context_key() -> tuple[Any, ...]:
+    """Graph-selecting state that arrives through the forward context.
+
+    The staged tensors do not carry all of it: two calls with identical input
+    shapes still need different graphs when the DP padding width differs (the
+    graph reads it as `dp_metadata.max_pads_across_dp.shape[0]`), when the
+    attention metadata says prefill rather than decode, or when a KV connector
+    is attached (which changes the attention wrapper's graph).
+
+    Not every dispatched target runs inside a forward context -- the model
+    forward does, the samplers run after it has been exited -- so a missing
+    context is a normal state and contributes nothing to the key.
+    """
+    if not is_forward_context_available():
+        return (None, None, has_kv_transfer_group())
+
+    ctx = get_forward_context()
+
+    dp_metadata = getattr(ctx, "dp_metadata", None)
+    max_pads = getattr(dp_metadata, "max_pads_across_dp", None)
+    max_pad = None if max_pads is None else max_pads.shape[0]
+
+    attn_metadata = ctx.attn_metadata
+    if isinstance(attn_metadata, dict):
+        attn_metadata = next(iter(attn_metadata.values()), None)
+    elif isinstance(attn_metadata, list):
+        first = attn_metadata[0] if attn_metadata else None
+        attn_metadata = next(iter(first.values()), None) if first else None
+
+    return (
+        getattr(attn_metadata, "is_prefill", None),
+        max_pad,
+        has_kv_transfer_group(),
+    )
+
+
+class Dispatcher:
+    """Owns the graph selection that Dynamo's cache lookup normally does.
+
+    Deciding which compiled graph a call belongs to costs a frame-eval entry
+    plus a guard-tree walk every step, and the answer is something the runner
+    already knows. So this keeps the mapping itself: the first call for a key
+    goes through Dynamo (which compiles it if needed) and the transformed
+    bytecode is recorded, and every later call with that key runs the bytecode
+    directly -- no frame eval, no guards.
+
+    The table is a cache, not an allow-list: an unseen key is compiled on the
+    spot rather than rejected. What is rejected is a key that maps to two
+    different graphs -- that means the key is coarser than Dynamo's guards, and
+    serving either graph would be wrong.
+
+    Assumes one caller at a time: the swap goes through the function object, so
+    two threads calling the same target with different keys would collide. The
+    RBLN platform forces async scheduling off, so the step loop is serial.
+    """
+
+    def __init__(self, target: Any, compiled: Any) -> None:
+        if not hasattr(target, "__code__"):
+            raise TypeError(
+                "Dispatcher needs a plain function to swap code on, got "
+                f"{type(target).__name__}"
+            )
+        self._target = target
+        self._compiled = compiled
+        self._original_code: CodeType = target.__code__
+        self._codes: dict[tuple, CodeType] = {}
+        self._unregistered = 0
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        key = (
+            tuple(_value_key(a) for a in args),
+            tuple((name, _value_key(v)) for name, v in sorted(kwargs.items())),
+            *_forward_context_key(),
+        )
+        code = self._codes.get(key)
+        if code is None:
+            result = self._compiled(*args, **kwargs)
+            self._register(key)
+            return result
+
+        self._target.__code__ = code
+        try:
+            return self._target(*args, **kwargs)
+        finally:
+            self._target.__code__ = self._original_code
+
+    def _register(self, key: tuple) -> None:
+        entries = torch._dynamo.eval_frame._debug_get_cache_entry_list(
+            self._original_code
+        )
+        if not entries:
+            # Dynamo ran the frame without leaving a cache entry (it bails out
+            # once accumulated_cache_size_limit is hit, for one). Nothing to
+            # dispatch to, so this key keeps taking the Dynamo path.
+            self._unregistered += 1
+            logger.warning_once(
+                "no Dynamo cache entry for %s; %d key(s) will keep paying the "
+                "frame-eval cost",
+                self._original_code.co_name,
+                self._unregistered,
+            )
+            return
+
+        # Cache entries are MRU-ordered, so the call above put the graph it used
+        # at the head of the list.
+        code = entries[0].code
+        previous = self._codes.get(key)
+        if previous is not None and previous is not code:
+            raise RuntimeError(
+                f"dispatch key {key} selected two different graphs for "
+                f"{self._original_code.co_name}; the key is missing a factor "
+                "that Dynamo's guards do distinguish"
+            )
+        self._codes[key] = code
+        logger.debug(
+            "dispatch: registered %s as entry %d for %s",
+            code.co_name,
+            len(self._codes),
+            self._original_code.co_name,
+        )

--- a/vllm_rbln/compilation/dispatch.py
+++ b/vllm_rbln/compilation/dispatch.py
@@ -17,9 +17,9 @@ from types import CodeType, FunctionType, MethodType
 from typing import Any
 
 import torch
+from torch._C._profiler import _RecordFunctionFast
 from vllm.distributed.kv_transfer import has_kv_transfer_group
 from vllm.forward_context import get_forward_context, is_forward_context_available
-from vllm.v1.utils import record_function_or_nullcontext
 
 from vllm_rbln.logger import init_logger
 
@@ -143,12 +143,12 @@ class Dispatcher:
             tuple((name, _value_key(v)) for name, v in sorted(kwargs.items())),
             *_forward_context_key(),
         )
-        graph, annotation = self._graphs.get(key, (None, None))
+        graph, scope = self._graphs.get(key, (None, None))
         if graph is None:
             result = self._compiled(*args, **kwargs)
             self._register(key)
             return result
-        with record_function_or_nullcontext(annotation):
+        with scope:
             return graph(*args, **kwargs)
 
     def _register(self, key: tuple) -> None:
@@ -173,10 +173,11 @@ class Dispatcher:
         entry = entries[0]
         # Bypassing the frame eval also bypasses the profiler scope it opens, so
         # the region is invisible unless we open one. Dynamo's compile id keeps a
-        # dispatched trace comparable with one taken without the dispatcher.
+        # dispatched trace comparable with one taken without the dispatcher, and
+        # this scope is gated on the profiler, not on an env var like vLLM's.
         self._graphs[key] = (
             self._clone(entry.code),
-            f"Dispatched Region: {entry.compile_id}",
+            _RecordFunctionFast(f"Dispatched Region: {entry.compile_id}"),
         )
         logger.debug(
             "dispatch: registered %s as entry %d for %s",

--- a/vllm_rbln/compilation/dispatch.py
+++ b/vllm_rbln/compilation/dispatch.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from types import CodeType
+from types import CodeType, FunctionType, MethodType
 from typing import Any
 
 import torch
@@ -23,17 +23,35 @@ from vllm_rbln.logger import init_logger
 
 logger = init_logger(__name__)
 
+# FunctionType's constructor takes five of a function's slots and the rest have
+# to be assigned, or the clone is not the target with a different body. Keyword
+# defaults are the one that changes results rather than just introspection.
+# test_dispatch.py enumerates the slots off the type, so a Python release that
+# adds one fails the test instead of silently dropping it here.
+_COPIED_SLOTS = (
+    "__kwdefaults__",
+    "__qualname__",
+    "__module__",
+    "__doc__",
+    "__annotations__",
+    "__type_params__",
+)
+
 
 def _value_key(value: Any) -> Any:
     """The part of an argument that decides which graph it belongs to."""
-    if value is None or isinstance(value, (bool, int)):
-        return value
     if isinstance(value, torch.Tensor):
         # torch.Size is a tuple, so this stays hashable and allocation-free.
         return value.shape, value.dtype
+    if value is None or isinstance(value, (bool, int, float, str, bytes, torch.dtype)):
+        return value
     if hasattr(value, "items"):  # IntermediateTensors and friends
         return tuple((k, t.shape, t.dtype) for k, t in value.items())
-    return type(value).__name__
+    raise TypeError(
+        f"Dispatcher cannot key a {type(value).__name__} argument. Dynamo may "
+        "guard on its value, and a key that does not carry it would serve the "
+        "graph recorded for a different value."
+    )
 
 
 def _forward_context_key() -> tuple[Any, ...]:
@@ -79,29 +97,41 @@ class Dispatcher:
     plus a guard-tree walk every step, and the answer is something the runner
     already knows. So this keeps the mapping itself: the first call for a key
     goes through Dynamo (which compiles it if needed) and the transformed
-    bytecode is recorded, and every later call with that key runs the bytecode
-    directly -- no frame eval, no guards.
+    bytecode is recorded as a clone of the target, and every later call with
+    that key runs the clone directly -- no frame eval, no guards.
+
+    A clone rather than the target with its `__code__` swapped, because a swap
+    is visible to every other holder of the target for as long as it is
+    installed. One clone per key keeps the fast path free of shared mutable
+    state, and lets a bound method be dispatched without touching the code
+    object its whole class shares.
 
     The table is a cache, not an allow-list: an unseen key is compiled on the
-    spot rather than rejected. What is rejected is a key that maps to two
-    different graphs -- that means the key is coarser than Dynamo's guards, and
-    serving either graph would be wrong.
-
-    Assumes one caller at a time: the swap goes through the function object, so
-    two threads calling the same target with different keys would collide. The
-    RBLN platform forces async scheduling off, so the step loop is serial.
+    spot rather than rejected. Key completeness is a precondition this class
+    does not check -- once a key is registered its graph is served forever, so
+    a key coarser than Dynamo's guards is wrong rather than reported. What
+    keeps it honest is `_value_key` refusing an argument it cannot key.
     """
 
     def __init__(self, target: Any, compiled: Any) -> None:
-        if not hasattr(target, "__code__"):
+        # Annotated Any, not FunctionType: a function is a descriptor, so a
+        # FunctionType-annotated attribute reads back as MethodType in mypy.
+        self._function: Any
+        self._instance: Any
+        if isinstance(target, MethodType):
+            self._function = target.__func__
+            self._instance = target.__self__
+        elif isinstance(target, FunctionType):
+            self._function = target
+            self._instance = None
+        else:
             raise TypeError(
-                "Dispatcher needs a plain function to swap code on, got "
+                "Dispatcher needs a function or a bound method, got "
                 f"{type(target).__name__}"
             )
-        self._target = target
         self._compiled = compiled
-        self._original_code: CodeType = target.__code__
-        self._codes: dict[tuple, CodeType] = {}
+        self._original_code: CodeType = self._function.__code__
+        self._graphs: dict[tuple, Any] = {}
         self._unregistered = 0
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
@@ -110,17 +140,12 @@ class Dispatcher:
             tuple((name, _value_key(v)) for name, v in sorted(kwargs.items())),
             *_forward_context_key(),
         )
-        code = self._codes.get(key)
-        if code is None:
+        graph = self._graphs.get(key)
+        if graph is None:
             result = self._compiled(*args, **kwargs)
             self._register(key)
             return result
-
-        self._target.__code__ = code
-        try:
-            return self._target(*args, **kwargs)
-        finally:
-            self._target.__code__ = self._original_code
+        return graph(*args, **kwargs)
 
     def _register(self, key: tuple) -> None:
         entries = torch._dynamo.eval_frame._debug_get_cache_entry_list(
@@ -139,20 +164,28 @@ class Dispatcher:
             )
             return
 
-        # Cache entries are MRU-ordered, so the call above put the graph it used
-        # at the head of the list.
+        # Cache entries are MRU-ordered, so the call above left the graph it
+        # used at the head of the list. That identification holds only while
+        # nothing else calls the target in between, which the serial step loop
+        # guarantees; a second concurrent caller would need this serialised.
         code = entries[0].code
-        previous = self._codes.get(key)
-        if previous is not None and previous is not code:
-            raise RuntimeError(
-                f"dispatch key {key} selected two different graphs for "
-                f"{self._original_code.co_name}; the key is missing a factor "
-                "that Dynamo's guards do distinguish"
-            )
-        self._codes[key] = code
+        self._graphs[key] = self._clone(code)
         logger.debug(
             "dispatch: registered %s as entry %d for %s",
             code.co_name,
-            len(self._codes),
+            len(self._graphs),
             self._original_code.co_name,
         )
+
+    def _clone(self, code: CodeType) -> Any:
+        clone = FunctionType(
+            code,
+            self._function.__globals__,
+            self._function.__name__,
+            self._function.__defaults__,
+            self._function.__closure__,
+        )
+        for slot in _COPIED_SLOTS:
+            setattr(clone, slot, getattr(self._function, slot))
+        clone.__dict__.update(self._function.__dict__)
+        return clone if self._instance is None else MethodType(clone, self._instance)

--- a/vllm_rbln/v1/spec_decode/eagle.py
+++ b/vllm_rbln/v1/spec_decode/eagle.py
@@ -444,6 +444,7 @@ class RBLNEagleProposer(EagleProposer):
                 runtime_holder=self.runner.runtime_holder,
                 mode="strict" if envs.VLLM_RBLN_COMPILE_STRICT_MODE else "",
                 use_static_output=True,
+                use_direct_dispatch=True,
             )
 
     def _build_dummy_attn_metadata(

--- a/vllm_rbln/v1/spec_decode/medusa.py
+++ b/vllm_rbln/v1/spec_decode/medusa.py
@@ -78,6 +78,7 @@ class RBLNMedusaProposer(MedusaProposer):
                 process_group_dict=build_process_group_dict(),
                 guard_filter_fn=torch.compiler.keep_tensor_guards_unsafe,
                 mode="strict" if envs.VLLM_RBLN_COMPILE_STRICT_MODE else "",
+                use_direct_dispatch=True,
             )
 
     def propose(

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1895,6 +1895,9 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             self.model_executable = compile(
                 model_wrapper,
                 dynamic=False,
+                # A graph break would put part of the step in a resume frame,
+                # which the dispatcher's __code__ swap cannot reach.
+                fullgraph=True,
                 compile_context=self.compile_context,
                 num_devices=envs.VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK,
                 model_trace_method="export" if USE_DEVICE_TENSOR else "",
@@ -1905,12 +1908,14 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 # Logits are consumed by sampling within the same step, so the
                 # output buffer can be reused across steps even under async scheduling.
                 use_static_output=True,
+                use_direct_dispatch=True,
             )
             # NOTE(RBLN): We compile compute_logits separately to cover cases when
             # `self.use_wrapped_compute_logits` is `False`
             self.compute_logits = compile(
                 self.model.compute_logits,
                 dynamic=False,
+                fullgraph=True,
                 compile_context=self.compile_context,
                 num_devices=envs.VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK,
                 model_trace_method="export" if USE_DEVICE_TENSOR else "",

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1895,8 +1895,6 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             self.model_executable = compile(
                 model_wrapper,
                 dynamic=False,
-                # A graph break would put part of the step in a resume frame,
-                # which the dispatcher's __code__ swap cannot reach.
                 fullgraph=True,
                 compile_context=self.compile_context,
                 num_devices=envs.VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK,


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

Every call into a compiled graph pays a fixed cost unrelated to the graph: the `torch.compile` wrapper, the frame eval, and  cache walk, and a guard check over **every tensor that enters the graph**. RBLN needs every KV cache to enter as an input, so each step re-checks dtype/device/shape/stride on tensors that are allocated once and never replaced. `keep_tensor_guards_unsafe` already dropped the value guards; this removes what is left.

`Dispatcher` owns the mapping instead. The key is the staged inputs' shapes and dtypes plus context the runner already knows (prefill vs decode, DP pad width, KV-connector presence). The first call per key goes through Dynamo and its transformed bytecode is recorded as a clone of the target (a clone rather than a `__code__` swap, which would be visible to every other holder of the function and would mutate the code object a bound method's class shares.

**Limitations**

- **Requires `fullgraph=True`.** A graph break leaves the rest of the frame in a resume function that only runs compiled under the frame eval, and a recompile-limit bail-out adds no cache entry, so `_register` would bind the previous call's graph to the new key. `compile()` rejects the pair.
- **Key completeness is a precondition, not a check.** A registered key is served `_value_key` raises on anything it cannot key and `TestKeyDiscrimination` pins the situations the runner produces, but nothing verifies this at runtime. A `verify` mode calling `entry.guard_manager.check(...)` on the warm path would close it (designed, not implemented).
- **Assumes serial calls.`** Identifying the recorded graph relies on Dynamo's cache list being MRU-ordered; a second concurrent caller of the same target would need this serialized.
- **The sampler is compiled but not dispatched** (one lookup per step remains).

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [x] ⚙️ Performance improvement (`perf`)

---

### 🧪 How to Test
```
uv run --no-sync pytest tests/native/compilation -x
uv run --no-sync pytest tests/native -m model_compile --model-compile
```
Unit lane covers the key, the clone, and the Dynamo contract (MRU order, entry.code/compile_id) against real Dynamo. The model-compile lane covers output correctness against HF logprobs, all three dispatch sites (runner / eagle / medusa), and DP4 e2e. Device counts differ per test (1 / 2 / 4) and RBLNWorker._init_device_env asserts on a mismatch.

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

Worth putting behind an env var so it can be flipped without editing the source? It would buy A/B measurement without a rebuild (every number here came from flipping the flag by hand) and a way to confirm or rule out the dispatcher in the field, where a key that is too coarse surfaces as wrong output rather than an error.

A single global flag gating the use_direct_dispatch argument leaves the call sites that don't opt in (compute_logits, the sampler) untouched, which seems right. It would belong in RBLN_NON_COMPILE_ENV (it changes graph selection, not the compiled artifacts), so it must not invalidate the mega-cache key. Options welcome.

---
