### PR TITLE
fix(optimum): detect a compiled model dir by rbln_config.json

### DIFF
--- a/vllm_rbln/model_executor/models/optimum/model_base.py
+++ b/vllm_rbln/model_executor/models/optimum/model_base.py
@@ -36,18 +36,13 @@ from vllm_rbln import envs
 from vllm_rbln.logger import init_logger
 from vllm_rbln.utils.optimum.block_size import get_attn_block_size
 from vllm_rbln.utils.optimum.bucket import select_bucket_size
+from vllm_rbln.utils.optimum.paths import is_compiled_dir
 from vllm_rbln.utils.optimum.registry import get_rbln_model_info
 
 from .base import ModelInputForRBLN, PartialPrefixInfo
 from .compilation import RBLNCompileSpec
 
 logger = init_logger(__name__)
-
-
-def _is_compiled_dir(path: str | None) -> bool:
-    if path is None:
-        return False
-    return bool(path) and os.path.isfile(os.path.join(path, "rbln_config.json"))
 
 
 class KVCacheBlockAdapter:
@@ -188,9 +183,9 @@ class RBLNOptimumModelBase(nn.Module):
         rbln_overrides = self.vllm_config.additional_config.get("rbln_config", {})
         _, model_cls_name = get_rbln_model_info(hf_config)
         model_path = self.vllm_config.model_config.model
-        if _is_compiled_dir(model_path):
+        if is_compiled_dir(model_path):
             valid_path = model_path
-        elif _is_compiled_dir(cached_model_path):
+        elif is_compiled_dir(cached_model_path):
             valid_path = cached_model_path
         else:
             valid_path = None

--- a/vllm_rbln/model_executor/models/optimum/model_base.py
+++ b/vllm_rbln/model_executor/models/optimum/model_base.py
@@ -45,6 +45,8 @@ logger = init_logger(__name__)
 
 
 def _is_compiled_dir(path: str | None) -> bool:
+    if path is None:
+        return False
     return bool(path) and os.path.isfile(os.path.join(path, "rbln_config.json"))
 
 

--- a/vllm_rbln/model_executor/models/optimum/model_base.py
+++ b/vllm_rbln/model_executor/models/optimum/model_base.py
@@ -44,6 +44,10 @@ from .compilation import RBLNCompileSpec
 logger = init_logger(__name__)
 
 
+def _is_compiled_dir(path: str | None) -> bool:
+    return bool(path) and os.path.isfile(os.path.join(path, "rbln_config.json"))
+
+
 class KVCacheBlockAdapter:
     """
      KV cache block allocation behavior (v1 vs v0).
@@ -182,9 +186,9 @@ class RBLNOptimumModelBase(nn.Module):
         rbln_overrides = self.vllm_config.additional_config.get("rbln_config", {})
         _, model_cls_name = get_rbln_model_info(hf_config)
         model_path = self.vllm_config.model_config.model
-        if os.path.exists(model_path):
+        if _is_compiled_dir(model_path):
             valid_path = model_path
-        elif cached_model_path and os.path.exists(cached_model_path):
+        elif _is_compiled_dir(cached_model_path):
             valid_path = cached_model_path
         else:
             valid_path = None

--- a/vllm_rbln/utils/optimum/converter/dispatch.py
+++ b/vllm_rbln/utils/optimum/converter/dispatch.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 
 from vllm_rbln import envs
 from vllm_rbln.logger import init_logger
+from vllm_rbln.utils.optimum.paths import is_compiled_dir
 
 from .common import get_user_max_num_batched_tokens
 from .from_optimum import sync_from_optimum
@@ -116,7 +117,7 @@ def _resolve_rbln_config(vllm_config: VllmConfig) -> dict | None:
         _generate_model_path_name(vllm_config=vllm_config),
     )
     vllm_config.additional_config["cached_model_path"] = cached_model_path
-    if os.path.exists(os.path.join(cached_model_path, "rbln_config.json")):
+    if is_compiled_dir(cached_model_path):
         logger.info("Found cached compiled model at %s", cached_model_path)
         vllm_config.model_config.model = cached_model_path
         return load_compiled_rbln_config(vllm_config)

--- a/vllm_rbln/utils/optimum/converter/params.py
+++ b/vllm_rbln/utils/optimum/converter/params.py
@@ -15,7 +15,6 @@
 """Helpers for reading and parsing rbln_config.json parameters."""
 
 import json
-import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Union
@@ -28,6 +27,7 @@ else:
 from optimum.rbln.configuration_utils import RBLNModelConfig
 
 from vllm_rbln.logger import init_logger
+from vllm_rbln.utils.optimum.paths import RBLN_CONFIG_FILE
 from vllm_rbln.utils.optimum.registry import (
     is_enc_dec_arch,
     is_multi_modal,
@@ -60,9 +60,7 @@ def load_compiled_rbln_config(vllm_config: VllmConfig) -> dict | None:
     Returns ``None`` if the model directory has no compiled artefact yet
     (e.g. pre-compile stage or HuggingFace-only model path).
     """
-    rbln_config_path = Path(
-        os.path.join(vllm_config.model_config.model, "rbln_config.json")
-    )
+    rbln_config_path = Path(vllm_config.model_config.model) / RBLN_CONFIG_FILE
     if not rbln_config_path.exists():  # for pytest
         logger.warning(
             "rbln_config.json not found in model directory: %s. "

--- a/vllm_rbln/utils/optimum/paths.py
+++ b/vllm_rbln/utils/optimum/paths.py
@@ -1,0 +1,24 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+# The artefact optimum-rbln writes at the top level of a compiled model
+# directory. A plain HuggingFace checkpoint never has one.
+RBLN_CONFIG_FILE = "rbln_config.json"
+
+
+def is_compiled_dir(path: str | None) -> bool:
+    if not path:
+        return False
+    return os.path.isfile(os.path.join(path, RBLN_CONFIG_FILE))

--- a/vllm_rbln/utils/optimum/paths.py
+++ b/vllm_rbln/utils/optimum/paths.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 import os
 
-# The artefact optimum-rbln writes at the top level of a compiled model
-# directory. A plain HuggingFace checkpoint never has one.
 RBLN_CONFIG_FILE = "rbln_config.json"
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

`os.path.exists(model_path)` accepted any local directory, so a plain HuggingFace checkpoint -- which is what `model_path` points at under HF_HUB_OFFLINE=1 -- was taken for a pre-compiled model.

Gate on the top-level `rbln_config.json` instead. That is optimum-rbln's own marker for a compiled directory (`RBLNBaseModel._load_compiled_model_dir`), it always sits at the top level, and a plain HF checkpoint never has one.

Globbing for top-level `*.rbln` would not work: models whose config sets `_allow_no_compile_cfgs` (e.g. PaliGemma, which vLLM supports) compile no graph of their own and keep every `.rbln` inside submodule subdirectories.

Applying the same predicate to `cached_model_path` also stops a cache dir left half-written by an interrupted compile from counting as a hit.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
