### PR TITLE
fix(envs): default to set w8a16, w8a8 is optional

### DIFF
--- a/.buildkite/pipelines/vllm-rbln/scripts/lm-eval/targets/gsm8k-minimax-m2.7.yaml
+++ b/.buildkite/pipelines/vllm-rbln/scripts/lm-eval/targets/gsm8k-minimax-m2.7.yaml
@@ -6,7 +6,6 @@ env:
   VLLM_RBLN_USE_VLLM_MODEL: "1"
   VLLM_RBLN_BATCH_ATTN_OPT: "1"
   VLLM_RBLN_SORT_BATCH: "1"
-  VLLM_RBLN_USE_W8A16: "1"
 
 serve:
   max_model_len: 16384

--- a/.buildkite/pipelines/vllm-rbln/scripts/perf/targets/minimax-m2.7.yaml
+++ b/.buildkite/pipelines/vllm-rbln/scripts/perf/targets/minimax-m2.7.yaml
@@ -6,7 +6,6 @@ env:
   VLLM_RBLN_USE_VLLM_MODEL: "1"
   VLLM_RBLN_BATCH_ATTN_OPT: "1"
   VLLM_RBLN_SORT_BATCH: "1"
-  VLLM_RBLN_USE_W8A16: "1"
 
 serve:
   max_model_len: 65536

--- a/tests/native/compile/models.py
+++ b/tests/native/compile/models.py
@@ -43,7 +43,7 @@ _MINIMAX_BASE = CompileModelSpec(
         "max_num_batched_tokens": 512,
         "enable_expert_parallel": True,
     },
-    {**OPT_ENVS, "VLLM_RBLN_USE_W8A16": "1"},
+    OPT_ENVS,
     chips=REBEL,
 )
 

--- a/tests/native/conftest.py
+++ b/tests/native/conftest.py
@@ -527,14 +527,3 @@ def _isolate_rbln_ctx_standalone():
     a device at all. Mirrors tests/torch_compile/conftest.py."""
     os.environ.pop("RBLN_CTX_STANDALONE", None)
     yield
-
-
-@pytest.fixture(autouse=True)
-def _reset_memoized_env_reads():
-    """Clear the one env read that sticks process-wide: get_use_w8a16() caches
-    into a module global, pinning the value session-wide otherwise."""
-    from vllm_rbln import envs
-
-    envs._USE_W8A16 = None
-    yield
-    envs._USE_W8A16 = None

--- a/tests/native/model_executor/kernels/linear/test_block_fp8.py
+++ b/tests/native/model_executor/kernels/linear/test_block_fp8.py
@@ -228,16 +228,16 @@ class TestCheckShape:
 
 
 class TestCanImplement:
-    def test_w8a16_applies_only_when_use_w8a16(self, monkeypatch):
-        monkeypatch.setattr(envs, "VLLM_RBLN_USE_W8A16", True)
+    def test_w8a16_applies_unless_w8a8_requested(self, monkeypatch):
+        monkeypatch.setattr(envs, "VLLM_RBLN_USE_W8A8", False)
         with _base_can_implement_ok():
             ok, _ = RBLNW8A16BlockFp8LinearKernel.can_implement(
                 _config(block_n=4, block_k=4)
             )
         assert ok is True
 
-    def test_w8a16_rejected_when_not_use_w8a16(self, monkeypatch):
-        monkeypatch.setattr(envs, "VLLM_RBLN_USE_W8A16", False)
+    def test_w8a16_rejected_when_w8a8_requested(self, monkeypatch):
+        monkeypatch.setattr(envs, "VLLM_RBLN_USE_W8A8", True)
         with _base_can_implement_ok():
             ok, reason = RBLNW8A16BlockFp8LinearKernel.can_implement(
                 _config(block_n=4, block_k=4)
@@ -245,16 +245,16 @@ class TestCanImplement:
         assert ok is False
         assert reason is not None and "W8A16" in reason
 
-    def test_w8a8_applies_only_when_not_use_w8a16(self, monkeypatch):
-        monkeypatch.setattr(envs, "VLLM_RBLN_USE_W8A16", False)
+    def test_w8a8_applies_when_requested(self, monkeypatch):
+        monkeypatch.setattr(envs, "VLLM_RBLN_USE_W8A8", True)
         with _base_can_implement_ok():
             ok, _ = RBLNW8A8BlockFp8LinearKernel.can_implement(
                 _config(block_n=4, block_k=4)
             )
         assert ok is True
 
-    def test_w8a8_rejected_when_use_w8a16(self, monkeypatch):
-        monkeypatch.setattr(envs, "VLLM_RBLN_USE_W8A16", True)
+    def test_w8a8_rejected_by_default(self, monkeypatch):
+        monkeypatch.setattr(envs, "VLLM_RBLN_USE_W8A8", False)
         with _base_can_implement_ok():
             ok, reason = RBLNW8A8BlockFp8LinearKernel.can_implement(
                 _config(block_n=4, block_k=4)

--- a/tests/native/test_envs.py
+++ b/tests/native/test_envs.py
@@ -32,8 +32,7 @@ RBLN_KEYS = sorted(
 
 
 def read(name: str) -> Any:
-    """Resolve ``name`` through the env table, clearing the one sticky cache."""
-    envs._USE_W8A16 = None
+    """Resolve ``name`` through the env table."""
     return envs.environment_variables[name]()
 
 
@@ -160,68 +159,6 @@ def test_auto_port_follows_device_tensor(
     assert envs.use_auto_port() is expected
 
 
-# Value parsing is the boolean convention's job; what matters here is only
-# that an explicit setting is consulted before the device is.
-@pytest.mark.parametrize(("raw", "expected"), [("1", True), ("0", False)])
-def test_w8a16_env_overrides_device(monkeypatch, raw, expected):
-    """An explicit setting wins without consulting the platform at all."""
-    monkeypatch.setattr(envs, "_USE_W8A16", None)
-    monkeypatch.setenv("VLLM_RBLN_USE_W8A16", raw)
-    assert envs.get_use_w8a16() is expected
-
-
-@pytest.mark.parametrize(
-    ("device_name", "expected"),
-    [
-        ("RBLN-CR13", False),  # W8A8-capable, so no need to fall back to W8A16
-        ("RBLN-CR23", False),
-        ("  rbln-cr13  ", False),  # case and padding are normalized away
-        ("RBLN-CA25", True),
-        ("", True),  # unknown device errs toward W8A16
-    ],
-)
-def test_w8a16_derived_from_device(monkeypatch, device_name, expected):
-    from vllm.platforms import current_platform
-
-    monkeypatch.delenv("VLLM_RBLN_USE_W8A16", raising=False)
-    monkeypatch.setattr(envs, "_USE_W8A16", None)
-    monkeypatch.setattr(
-        current_platform, "get_device_name", lambda *a, **kw: device_name
-    )
-    assert envs.get_use_w8a16() is expected
-
-
-def test_w8a16_survives_device_query_failure(monkeypatch):
-    """A host with no NPU mounted must still resolve, not raise."""
-    from vllm.platforms import current_platform
-
-    def explode(*args, **kwargs):
-        raise RuntimeError("no NPU mounted")
-
-    monkeypatch.delenv("VLLM_RBLN_USE_W8A16", raising=False)
-    monkeypatch.setattr(envs, "_USE_W8A16", None)
-    monkeypatch.setattr(current_platform, "get_device_name", explode)
-    assert envs.get_use_w8a16() is True
-
-
-def test_w8a16_device_lookup_is_cached(monkeypatch):
-    """The device is queried once; later calls reuse the answer."""
-    from vllm.platforms import current_platform
-
-    calls = []
-
-    def counting(*args, **kwargs):
-        calls.append(1)
-        return "RBLN-CR13"
-
-    monkeypatch.delenv("VLLM_RBLN_USE_W8A16", raising=False)
-    monkeypatch.setattr(envs, "_USE_W8A16", None)
-    monkeypatch.setattr(current_platform, "get_device_name", counting)
-    assert envs.get_use_w8a16() is False
-    assert envs.get_use_w8a16() is False
-    assert len(calls) == 1
-
-
 # The bool lambdas come in two shapes differing only in their default; an
 # unrecognized value has opposite consequences, so one of each is covered.
 BOOL_DEFAULT_OFF = "VLLM_RBLN_METRICS"
@@ -338,14 +275,7 @@ def test_type_checking_block_lists_every_variable():
     assert sorted(declared) == RBLN_KEYS
 
 
-# Resolved from the NPU present at runtime rather than from a fixed default,
-# so its declared value cannot match on every host.
-_HOST_DEPENDENT = {"VLLM_RBLN_USE_W8A16"}
-
-
-@pytest.mark.parametrize(
-    "name", [key for key in RBLN_KEYS if key not in _HOST_DEPENDENT]
-)
+@pytest.mark.parametrize("name", RBLN_KEYS)
 def test_declared_default_matches_resolved(monkeypatch, name):
     """A clean environment resolves to the declared default. All RBLN vars are
     cleared, since some derive from a neighbour (use_auto_port falls back to

--- a/tests/native/v1/worker/test_mega_cache.py
+++ b/tests/native/v1/worker/test_mega_cache.py
@@ -93,7 +93,7 @@ class TestSignatureComposition:
 # survive is the round trip through normalize_value()/hash_factors().
 GRAPH_ENV = [
     ("VLLM_RBLN_NUM_HIDDEN_LAYERS", "0", "4"),  # int
-    ("VLLM_RBLN_USE_W8A16", "0", "1"),  # bool
+    ("VLLM_RBLN_USE_W8A8", "0", "1"),  # bool
     ("VLLM_RBLN_DECODE_BATCH_BUCKET_STRATEGY", "exponential", "linear"),  # str
     ("VLLM_RBLN_DECODE_BATCH_BUCKET_MANUAL_BUCKETS", "1,2,4", "1,2,4,8"),  # list
 ]

--- a/vllm_rbln/envs.py
+++ b/vllm_rbln/envs.py
@@ -82,7 +82,7 @@ if TYPE_CHECKING:
     # --- KV CONNECTOR ---
     VLLM_RBLN_NIXL_SWA_VIEW_OPT: bool = False
     # --- QUANTIZATION ---
-    VLLM_RBLN_USE_W8A16: bool = True
+    VLLM_RBLN_USE_W8A8: bool = False
 
 
 def get_num_devices_per_local_rank() -> int:
@@ -379,8 +379,8 @@ environment_variables = {
     # --- QUANTIZATION ---
     # W8A16 runs on every RBLN NPU, W8A8 only on the ones whose kernels take an
     # fp8 activation, so W8A8 is opted into rather than derived from the device.
-    "VLLM_RBLN_USE_W8A16": (
-        lambda: os.environ.get("VLLM_RBLN_USE_W8A16", "True").lower() in ("true", "1")
+    "VLLM_RBLN_USE_W8A8": (
+        lambda: os.environ.get("VLLM_RBLN_USE_W8A8", "False").lower() in ("true", "1")
     ),
 }
 
@@ -408,7 +408,7 @@ RBLN_COMPILE_ENV = frozenset(
         "VLLM_RBLN_DECODE_BATCH_BUCKET_STEP",
         "VLLM_RBLN_DECODE_BATCH_BUCKET_LIMIT",
         "VLLM_RBLN_DECODE_BATCH_BUCKET_MANUAL_BUCKETS",
-        "VLLM_RBLN_USE_W8A16",
+        "VLLM_RBLN_USE_W8A8",
     }
 )
 

--- a/vllm_rbln/envs.py
+++ b/vllm_rbln/envs.py
@@ -82,33 +82,7 @@ if TYPE_CHECKING:
     # --- KV CONNECTOR ---
     VLLM_RBLN_NIXL_SWA_VIEW_OPT: bool = False
     # --- QUANTIZATION ---
-    VLLM_RBLN_USE_W8A16: bool = False
-
-_W8A8_CAPABLE_NPUS = frozenset({"RBLN-CR13", "RBLN-CR23"})
-
-_USE_W8A16: bool | None = None
-
-
-def get_use_w8a16() -> bool:
-    value = os.environ.get("VLLM_RBLN_USE_W8A16")
-    if value is not None:
-        return value.lower() in ("true", "1")
-
-    global _USE_W8A16
-    if _USE_W8A16 is not None:
-        return _USE_W8A16
-
-    from vllm.platforms import current_platform
-
-    try:
-        device_name = current_platform.get_device_name() or ""
-    except Exception:
-        device_name = ""
-
-    _USE_W8A16 = (
-        not device_name or device_name.strip().upper() not in _W8A8_CAPABLE_NPUS
-    )
-    return _USE_W8A16
+    VLLM_RBLN_USE_W8A16: bool = True
 
 
 def get_num_devices_per_local_rank() -> int:
@@ -403,7 +377,11 @@ environment_variables = {
         )
     ),
     # --- QUANTIZATION ---
-    "VLLM_RBLN_USE_W8A16": get_use_w8a16,
+    # W8A16 runs on every RBLN NPU, W8A8 only on the ones whose kernels take an
+    # fp8 activation, so W8A8 is opted into rather than derived from the device.
+    "VLLM_RBLN_USE_W8A16": (
+        lambda: os.environ.get("VLLM_RBLN_USE_W8A16", "True").lower() in ("true", "1")
+    ),
 }
 
 # Partition for the mega-cache config signature: COMPILE vars are hashed into

--- a/vllm_rbln/model_executor/kernels/linear/block_fp8.py
+++ b/vllm_rbln/model_executor/kernels/linear/block_fp8.py
@@ -68,8 +68,8 @@ class RBLNW8A16BlockFp8LinearKernel(Fp8BlockScaledMMLinearKernel):
 
         from vllm_rbln import envs
 
-        if not envs.VLLM_RBLN_USE_W8A16:
-            return False, "RBLN W8A16 block fp8 kernel applies only on W8A16 devices."
+        if envs.VLLM_RBLN_USE_W8A8:
+            return False, "RBLN W8A16 block fp8 kernel is off when W8A8 is requested."
         return True, None
 
     def apply_block_scaled_mm(
@@ -122,8 +122,8 @@ class RBLNW8A8BlockFp8LinearKernel(RBLNW8A16BlockFp8LinearKernel):
 
         from vllm_rbln import envs
 
-        if envs.VLLM_RBLN_USE_W8A16:
-            return False, "RBLN W8A8 block fp8 kernel applies only on W8A8 devices."
+        if not envs.VLLM_RBLN_USE_W8A8:
+            return False, "RBLN W8A8 block fp8 kernel requires VLLM_RBLN_USE_W8A8."
         return True, None
 
     def apply_weights(

--- a/vllm_rbln/model_executor/layers/quantization/fp8.py
+++ b/vllm_rbln/model_executor/layers/quantization/fp8.py
@@ -329,7 +329,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
         from vllm_rbln import envs
 
-        if not envs.VLLM_RBLN_USE_W8A16:
+        if envs.VLLM_RBLN_USE_W8A8:
             # W8A8: dynamically quantize hidden_states to fp8 per (1, block_k)
             # group along K and hand both the fp8 tensor and the per-(token,
             # K-block) scale to the W8A8 MoE custom op.


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

`VLLM_RBLN_USE_W8A16`  This flag will now always be set to 1 by default, regardless of the device, and has been changed to allow the use of w8a8 (=0) depending on the situation.

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

> *What does this PR do? What feature, fix, or improvement does it bring?*

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [x] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
