### PR TITLE
fix(eagle3): support a pipeline-parallel MiniMax-M2 target

### DIFF
--- a/tests/native/patches/test_llama_eagle3.py
+++ b/tests/native/patches/test_llama_eagle3.py
@@ -1,0 +1,131 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The EAGLE3 head is named past the target's full depth, on every rank.
+
+Config objects only -- no checkpoint, no device.
+"""
+
+from __future__ import annotations
+
+import pytest
+from vllm.model_executor.models.llama_eagle3 import LlamaModel as Eagle3LlamaModel
+
+import vllm_rbln.patches.llama_eagle3 as patch_module
+
+# The suite truncates models via VLLM_RBLN_NUM_HIDDEN_LAYERS and the patched
+# get_pp_indices honors it; the split this reasons about is the real 62-layer one.
+from vllm_rbln.patches.distributed_utils import (
+    original_get_pp_indices as get_pp_indices,
+)
+from vllm_rbln.v1.worker.utils import pipeline_adjusted_layer_index
+
+NUM_LAYERS = 62
+PP_SIZE = 4
+
+
+def _vllm_config(per_rank_layers: int):
+    """A config shaped like the one the head's __init__ actually reads.
+
+    `model_config` is the target's and `speculative_config.draft_model_config` the
+    draft's -- the two the upstream __init__ mixes, and the reason a per-rank count
+    can pass for the full depth.
+    """
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        model_config=SimpleNamespace(
+            get_total_num_hidden_layers=lambda: NUM_LAYERS,
+            get_num_layers=lambda parallel_config: per_rank_layers,
+            hf_text_config=SimpleNamespace(num_hidden_layers=NUM_LAYERS),
+        ),
+        speculative_config=SimpleNamespace(
+            draft_model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(num_hidden_layers=1),
+            ),
+        ),
+    )
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    """Record what the patch hands upstream instead of running upstream."""
+    seen = {}
+
+    def stub_init(model, *, vllm_config, start_layer_id=0, prefix=""):
+        # Upstream builds the layers here, so anything the layers read has to be
+        # set on the config before this point.
+        seen["start_layer_id"] = start_layer_id
+        seen["target_layer_count"] = getattr(
+            vllm_config.speculative_config.draft_model_config.hf_config,
+            "target_layer_count",
+            None,
+        )
+
+    monkeypatch.setattr(patch_module, "_orig_model_init", stub_init)
+    return seen
+
+
+# 15 is stage 3's own layer count on the 62-layer PP4 split, which is what upstream
+# passes; 62 is the full depth. Only the first rank makes the two agree.
+@pytest.mark.parametrize("per_rank_layers", [15, 16, NUM_LAYERS])
+def test_the_head_is_named_past_the_full_depth(per_rank_layers, captured):
+    patch_module.patched_eagle3_llama_model_init(
+        object(), vllm_config=_vllm_config(per_rank_layers), prefix=""
+    )
+
+    assert captured["start_layer_id"] == NUM_LAYERS
+
+
+@pytest.mark.parametrize("per_rank_layers", [15, 16, NUM_LAYERS])
+def test_target_layer_count_stays_paired_with_the_name(per_rank_layers, captured):
+    # `llama.py` recovers a draft-relative index as `extract_layer_index(prefix) -
+    # target_layer_count`, i.e. off the name, not off the loop counter. Raising the
+    # name alone would give stage 3 `62 - 15 = 47` and trip the layer_types assert.
+    patch_module.patched_eagle3_llama_model_init(
+        object(), vllm_config=_vllm_config(per_rank_layers), prefix=""
+    )
+
+    assert captured["target_layer_count"] == captured["start_layer_id"]
+
+
+@pytest.mark.parametrize("rank", range(PP_SIZE))
+def test_the_named_head_lands_after_every_target_layer(rank):
+    # The point of the rename: RBLN's index rule routes a name at or past the full
+    # depth to the end of the rank's compacted KV list. Upstream's per-rank name
+    # would sort in among the target layers instead.
+    from types import SimpleNamespace
+
+    start, end = get_pp_indices(NUM_LAYERS, rank, PP_SIZE)
+    model_config = SimpleNamespace(
+        get_layers_start_end_indices=lambda parallel_config: (start, end),
+        get_total_num_hidden_layers=lambda: NUM_LAYERS,
+    )
+
+    head = pipeline_adjusted_layer_index(
+        f"model.layers.{NUM_LAYERS}.self_attn.attn", model_config, None, 1
+    )
+    targets = [
+        pipeline_adjusted_layer_index(
+            f"model.layers.{i}.self_attn.attn", model_config, None, 1
+        )
+        for i in range(start, end)
+    ]
+
+    assert targets == list(range(end - start))
+    assert head == end - start
+
+
+def test_the_patch_is_the_one_installed():
+    assert Eagle3LlamaModel.__init__ is patch_module.patched_eagle3_llama_model_init

--- a/tests/native/patches/test_llama_eagle3.py
+++ b/tests/native/patches/test_llama_eagle3.py
@@ -48,7 +48,6 @@ def _vllm_config(per_rank_layers: int):
         model_config=SimpleNamespace(
             get_total_num_hidden_layers=lambda: NUM_LAYERS,
             get_num_layers=lambda parallel_config: per_rank_layers,
-            hf_text_config=SimpleNamespace(num_hidden_layers=NUM_LAYERS),
         ),
         speculative_config=SimpleNamespace(
             draft_model_config=SimpleNamespace(

--- a/tests/native/patches/test_minimax_m2.py
+++ b/tests/native/patches/test_minimax_m2.py
@@ -47,6 +47,11 @@ AUX_LAYERS = (2, NUM_LAYERS // 2, NUM_LAYERS - 3)
 # lands one index in each of stages 0, 1 and 3, so the carry has to work for a set
 # the model did not pick itself.
 CHECKPOINT_AUX_LAYERS = (1, 30, 58)
+# Every index sits exactly on a PP4 band boundary ([0,15) [15,31) [31,47) [47,62)).
+# A boundary index is both one stage's last capture and the next stage's incoming
+# hidden state, so an off-by-one in the split double-counts all three at once --
+# and compiles, and passes a short probe, and only shows up as wrong output.
+BOUNDARY_AUX_LAYERS = (15, 31, 47)
 
 
 class _Group:
@@ -150,7 +155,9 @@ def _run_pipeline(pp_size: int, aux_layers: tuple[int, ...], monkeypatch):
 
 
 @pytest.mark.parametrize("pp_size", [2, 4])
-@pytest.mark.parametrize("aux_layers", [AUX_LAYERS, CHECKPOINT_AUX_LAYERS])
+@pytest.mark.parametrize(
+    "aux_layers", [AUX_LAYERS, CHECKPOINT_AUX_LAYERS, BOUNDARY_AUX_LAYERS]
+)
 def test_last_stage_receives_every_aux_layer_in_order(pp_size, aux_layers, monkeypatch):
     out, _ = _run_pipeline(pp_size, aux_layers, monkeypatch)
 

--- a/tests/native/patches/test_minimax_m2.py
+++ b/tests/native/patches/test_minimax_m2.py
@@ -1,0 +1,210 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""EAGLE3 aux hidden states survive the pipeline split.
+
+The stages run sequentially in one process with stub layers, so this needs no
+checkpoint and no device. Each stub layer stamps its own global index into the
+tensor it returns, which is what makes a stage-local index visible: the values
+that reach the last stage are the layer numbers actually harvested.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from vllm.model_executor.models.minimax_m2 import MiniMaxM2Model
+from vllm.model_executor.models.utils import make_empty_intermediate_tensors_factory
+
+import vllm_rbln.patches.minimax_m2 as patch_module
+
+# The suite truncates models via VLLM_RBLN_NUM_HIDDEN_LAYERS, and the patched
+# get_pp_indices honors it. These stages are stubs, so the truncation has nothing
+# to shrink -- what the split must be is the real 62-layer one.
+from vllm_rbln.patches.distributed_utils import (  # noqa: E402
+    original_get_pp_indices as get_pp_indices,
+)
+
+NUM_LAYERS = 62
+HIDDEN = 8
+BATCH = 2
+# What get_eagle3_default_aux_hidden_state_layers() returns for this depth.
+AUX_LAYERS = (2, NUM_LAYERS // 2, NUM_LAYERS - 3)
+
+
+class _Group:
+    def __init__(self, rank: int, size: int) -> None:
+        self.rank_in_group = rank
+        self._size = size
+
+    @property
+    def is_first_rank(self) -> bool:
+        return self.rank_in_group == 0
+
+    @property
+    def is_last_rank(self) -> bool:
+        return self.rank_in_group == self._size - 1
+
+
+class _StampingLayer(torch.nn.Module):
+    """Return a (hidden, residual) pair whose sum is this layer's output index.
+
+    `forward` records `hidden_states + residual`, so making the two sum to
+    `global_idx + 1` lets a caller read back which layer a captured tensor came
+    from.
+    """
+
+    def __init__(self, global_idx: int) -> None:
+        super().__init__()
+        self.out_index = global_idx + 1
+
+    def forward(self, positions, hidden_states, residual):
+        return (
+            torch.zeros_like(hidden_states),
+            torch.full_like(hidden_states, float(self.out_index)),
+        )
+
+
+class _UnownedLayer(torch.nn.Module):
+    """Stands in for PPMissingLayer: calling it means the stage band is wrong."""
+
+    def forward(self, *args, **kwargs):
+        raise AssertionError("a stage ran a layer outside its own band")
+
+
+def _build_stage(rank: int, pp_size: int) -> MiniMaxM2Model:
+    model = MiniMaxM2Model.__new__(MiniMaxM2Model)
+    torch.nn.Module.__init__(model)
+    model.config = SimpleNamespace(hidden_size=HIDDEN, num_hidden_layers=NUM_LAYERS)
+    start, end = get_pp_indices(NUM_LAYERS, rank, pp_size)
+    model.start_layer, model.end_layer = start, end
+    model.layers = torch.nn.ModuleList(
+        [
+            _StampingLayer(i) if start <= i < end else _UnownedLayer()
+            for i in range(NUM_LAYERS)
+        ]
+    )
+    model.embed_input_ids = lambda input_ids: torch.zeros(BATCH, HIDDEN)
+    model.norm = lambda hidden, residual: (
+        hidden if residual is None else hidden + residual,
+        None,
+    )
+    model.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+        ["hidden_states", "residual"], HIDDEN
+    )
+    model.aux_hidden_state_layers = ()
+    return model
+
+
+def _run_pipeline(pp_size: int, aux_layers: tuple[int, ...], monkeypatch):
+    """Drive every stage in order and return the last stage's output."""
+    carried = None
+    slots_sent = []
+    for rank in range(pp_size):
+        model = _build_stage(rank, pp_size)
+        monkeypatch.setattr(
+            patch_module, "get_pp_group", lambda rank=rank: _Group(rank, pp_size)
+        )
+        model._set_aux_hidden_state_layers(aux_layers)
+        out = model.forward(
+            input_ids=torch.zeros(BATCH, dtype=torch.long),
+            positions=torch.zeros(BATCH, dtype=torch.long),
+            intermediate_tensors=carried,
+        )
+        if rank < pp_size - 1:
+            slots_sent.append(
+                sorted(
+                    int(key.rsplit("_", 1)[1])
+                    for key in out.tensors
+                    if key.startswith("aux_hidden_states_")
+                )
+            )
+            carried = out
+    return out, slots_sent
+
+
+@pytest.mark.parametrize("pp_size", [2, 4])
+def test_last_stage_receives_every_aux_layer_in_order(pp_size, monkeypatch):
+    out, _ = _run_pipeline(pp_size, AUX_LAYERS, monkeypatch)
+
+    _, aux = out
+    stamped = [int(tensor.flatten()[0].item()) for tensor in aux]
+    assert stamped == list(AUX_LAYERS)
+
+
+def test_a_boundary_layer_is_captured_once(monkeypatch):
+    # Layer 31 of the 62-layer PP4 split ([15, 16, 16, 15]) is both stage 1's
+    # last capture and stage 2's incoming hidden state. Capturing at both would
+    # duplicate it.
+    assert get_pp_indices(NUM_LAYERS, 2, 4)[0] == 31
+
+    out, slots_sent = _run_pipeline(4, AUX_LAYERS, monkeypatch)
+
+    assert slots_sent == [[2], [2, 31], [2, 31]]
+    _, aux = out
+    assert len(aux) == len(AUX_LAYERS)
+
+
+def test_a_stage_owning_no_aux_layer_forwards_the_slots(monkeypatch):
+    # Stage 2 spans [31, 47) and owns none of (2, 31, 59); it must still pass
+    # what stage 1 sent, or the last stage comes up short.
+    _, slots_sent = _run_pipeline(4, AUX_LAYERS, monkeypatch)
+
+    assert slots_sent[2] == slots_sent[1]
+
+
+def test_handoff_carries_no_aux_slots_when_eagle3_is_off(monkeypatch):
+    model = _build_stage(0, 4)
+    monkeypatch.setattr(patch_module, "get_pp_group", lambda: _Group(0, 4))
+
+    out = model.forward(
+        input_ids=torch.zeros(BATCH, dtype=torch.long),
+        positions=torch.zeros(BATCH, dtype=torch.long),
+        intermediate_tensors=None,
+    )
+
+    assert set(out.tensors) == {"hidden_states", "residual"}
+
+
+def test_last_stage_returns_a_bare_tensor_when_eagle3_is_off(monkeypatch):
+    carried = None
+    for rank in range(4):
+        model = _build_stage(rank, 4)
+        monkeypatch.setattr(
+            patch_module, "get_pp_group", lambda rank=rank: _Group(rank, 4)
+        )
+        out = model.forward(
+            input_ids=torch.zeros(BATCH, dtype=torch.long),
+            positions=torch.zeros(BATCH, dtype=torch.long),
+            intermediate_tensors=carried,
+        )
+        carried = out
+
+    assert isinstance(out, torch.Tensor)
+
+
+def test_the_received_slot_set_follows_the_stage_band(monkeypatch):
+    # The handoff placeholder is built from start_layer, so each stage has to ask
+    # for exactly the indices an earlier stage can have captured.
+    expected = {0: (), 1: (2,), 2: (2, 31), 3: (2, 31)}
+    for rank, want in expected.items():
+        model = _build_stage(rank, 4)
+        monkeypatch.setattr(
+            patch_module, "get_pp_group", lambda rank=rank: _Group(rank, 4)
+        )
+        model._set_aux_hidden_state_layers(AUX_LAYERS)
+
+        assert patch_module._aux_slots_received(model) == want

--- a/tests/native/patches/test_minimax_m2.py
+++ b/tests/native/patches/test_minimax_m2.py
@@ -43,6 +43,10 @@ HIDDEN = 8
 BATCH = 2
 # What get_eagle3_default_aux_hidden_state_layers() returns for this depth.
 AUX_LAYERS = (2, NUM_LAYERS // 2, NUM_LAYERS - 3)
+# What MiniMax-M2.5-Eagle3 asks for in its eagle_config, one off the default. It
+# lands one index in each of stages 0, 1 and 3, so the carry has to work for a set
+# the model did not pick itself.
+CHECKPOINT_AUX_LAYERS = (1, 30, 58)
 
 
 class _Group:
@@ -137,12 +141,13 @@ def _run_pipeline(pp_size: int, aux_layers: tuple[int, ...], monkeypatch):
 
 
 @pytest.mark.parametrize("pp_size", [2, 4])
-def test_last_stage_receives_every_aux_layer_in_order(pp_size, monkeypatch):
-    out, _ = _run_pipeline(pp_size, AUX_LAYERS, monkeypatch)
+@pytest.mark.parametrize("aux_layers", [AUX_LAYERS, CHECKPOINT_AUX_LAYERS])
+def test_last_stage_receives_every_aux_layer_in_order(pp_size, aux_layers, monkeypatch):
+    out, _ = _run_pipeline(pp_size, aux_layers, monkeypatch)
 
     _, aux = out
     stamped = [int(tensor.flatten()[0].item()) for tensor in aux]
-    assert stamped == list(AUX_LAYERS)
+    assert stamped == list(aux_layers)
 
 
 def test_a_boundary_layer_is_captured_once(monkeypatch):

--- a/tests/native/patches/test_minimax_m2.py
+++ b/tests/native/patches/test_minimax_m2.py
@@ -27,7 +27,6 @@ from types import SimpleNamespace
 import pytest
 import torch
 from vllm.model_executor.models.minimax_m2 import MiniMaxM2Model
-from vllm.model_executor.models.utils import make_empty_intermediate_tensors_factory
 
 import vllm_rbln.patches.minimax_m2 as patch_module
 
@@ -41,7 +40,8 @@ from vllm_rbln.patches.distributed_utils import (  # noqa: E402
 NUM_LAYERS = 62
 HIDDEN = 8
 BATCH = 2
-# What get_eagle3_default_aux_hidden_state_layers() returns for this depth.
+# What get_eagle3_default_aux_hidden_state_layers() returns for this depth. 31 is a
+# stage boundary of the PP4 split, which is the case that can double-count.
 AUX_LAYERS = (2, NUM_LAYERS // 2, NUM_LAYERS - 3)
 # What MiniMax-M2.5-Eagle3 asks for in its eagle_config, one off the default. It
 # lands one index in each of stages 0, 1 and 3, so the carry has to work for a set
@@ -89,39 +89,54 @@ class _UnownedLayer(torch.nn.Module):
         raise AssertionError("a stage ran a layer outside its own band")
 
 
-def _build_stage(rank: int, pp_size: int) -> MiniMaxM2Model:
+def _build_stage(rank: int, pp_size: int, monkeypatch) -> MiniMaxM2Model:
+    """Build one stage through the patched __init__, stubbing out upstream's.
+
+    Going through the real patch is what puts the handoff callable it installs
+    under test, rather than one the test wrote itself.
+    """
+
+    def stub_init(model, *, vllm_config, prefix=""):
+        torch.nn.Module.__init__(model)
+        model.config = SimpleNamespace(hidden_size=HIDDEN, num_hidden_layers=NUM_LAYERS)
+        start, end = get_pp_indices(NUM_LAYERS, rank, pp_size)
+        model.start_layer, model.end_layer = start, end
+        model.layers = torch.nn.ModuleList(
+            [
+                _StampingLayer(i) if start <= i < end else _UnownedLayer()
+                for i in range(NUM_LAYERS)
+            ]
+        )
+        model.embed_input_ids = lambda input_ids: torch.zeros(BATCH, HIDDEN)
+        model.norm = lambda hidden, residual: (
+            hidden if residual is None else hidden + residual,
+            None,
+        )
+        model.aux_hidden_state_layers = ()
+
+    monkeypatch.setattr(patch_module, "_orig_model_init", stub_init)
+    monkeypatch.setattr(
+        patch_module, "get_pp_group", lambda rank=rank: _Group(rank, pp_size)
+    )
     model = MiniMaxM2Model.__new__(MiniMaxM2Model)
-    torch.nn.Module.__init__(model)
-    model.config = SimpleNamespace(hidden_size=HIDDEN, num_hidden_layers=NUM_LAYERS)
-    start, end = get_pp_indices(NUM_LAYERS, rank, pp_size)
-    model.start_layer, model.end_layer = start, end
-    model.layers = torch.nn.ModuleList(
-        [
-            _StampingLayer(i) if start <= i < end else _UnownedLayer()
-            for i in range(NUM_LAYERS)
-        ]
-    )
-    model.embed_input_ids = lambda input_ids: torch.zeros(BATCH, HIDDEN)
-    model.norm = lambda hidden, residual: (
-        hidden if residual is None else hidden + residual,
-        None,
-    )
-    model.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
-        ["hidden_states", "residual"], HIDDEN
-    )
-    model.aux_hidden_state_layers = ()
+    patch_module.patched_minimax_m2_model_init(model, vllm_config=None, prefix="")
     return model
 
 
+def _slot_indices(keys) -> list[int]:
+    return sorted(
+        int(key.rsplit("_", 1)[1])
+        for key in keys
+        if key.startswith(patch_module._AUX_SLOT)
+    )
+
+
 def _run_pipeline(pp_size: int, aux_layers: tuple[int, ...], monkeypatch):
-    """Drive every stage in order and return the last stage's output."""
+    """Drive every stage in order; return the last output and what each stage sent."""
     carried = None
     slots_sent = []
     for rank in range(pp_size):
-        model = _build_stage(rank, pp_size)
-        monkeypatch.setattr(
-            patch_module, "get_pp_group", lambda rank=rank: _Group(rank, pp_size)
-        )
+        model = _build_stage(rank, pp_size, monkeypatch)
         model._set_aux_hidden_state_layers(aux_layers)
         out = model.forward(
             input_ids=torch.zeros(BATCH, dtype=torch.long),
@@ -129,13 +144,7 @@ def _run_pipeline(pp_size: int, aux_layers: tuple[int, ...], monkeypatch):
             intermediate_tensors=carried,
         )
         if rank < pp_size - 1:
-            slots_sent.append(
-                sorted(
-                    int(key.rsplit("_", 1)[1])
-                    for key in out.tensors
-                    if key.startswith("aux_hidden_states_")
-                )
-            )
+            slots_sent.append(_slot_indices(out.tensors))
             carried = out
     return out, slots_sent
 
@@ -164,16 +173,29 @@ def test_a_boundary_layer_is_captured_once(monkeypatch):
 
 
 def test_a_stage_owning_no_aux_layer_forwards_the_slots(monkeypatch):
-    # Stage 2 spans [31, 47) and owns none of (2, 31, 59); it must still pass
-    # what stage 1 sent, or the last stage comes up short.
-    _, slots_sent = _run_pipeline(4, AUX_LAYERS, monkeypatch)
+    # Stage 2 spans [31, 47) and owns none of (1, 30, 58); it must still pass what
+    # stage 1 sent, or the last stage comes up short.
+    _, slots_sent = _run_pipeline(4, CHECKPOINT_AUX_LAYERS, monkeypatch)
 
-    assert slots_sent[2] == slots_sent[1]
+    assert slots_sent[2] == slots_sent[1] == [1, 30]
+
+
+def test_the_handoff_placeholder_follows_a_later_setter_call(monkeypatch):
+    # MiniMaxM2ForCausalLM.__init__ copies this callable onto itself before the
+    # runner sets the aux layers, and the runner calls that copy. A callable that
+    # baked the key set in at construction leaves the copy a slot short, which the
+    # receiving stage only finds out about as a KeyError.
+    model = _build_stage(1, 4, monkeypatch)
+    snapshot = model.make_empty_intermediate_tensors
+
+    model._set_aux_hidden_state_layers(CHECKPOINT_AUX_LAYERS)
+
+    tensors = snapshot(batch_size=BATCH, dtype=torch.float32, device="cpu")
+    assert _slot_indices(tensors.tensors) == [1]
 
 
 def test_handoff_carries_no_aux_slots_when_eagle3_is_off(monkeypatch):
-    model = _build_stage(0, 4)
-    monkeypatch.setattr(patch_module, "get_pp_group", lambda: _Group(0, 4))
+    model = _build_stage(0, 4, monkeypatch)
 
     out = model.forward(
         input_ids=torch.zeros(BATCH, dtype=torch.long),
@@ -187,10 +209,7 @@ def test_handoff_carries_no_aux_slots_when_eagle3_is_off(monkeypatch):
 def test_last_stage_returns_a_bare_tensor_when_eagle3_is_off(monkeypatch):
     carried = None
     for rank in range(4):
-        model = _build_stage(rank, 4)
-        monkeypatch.setattr(
-            patch_module, "get_pp_group", lambda rank=rank: _Group(rank, 4)
-        )
+        model = _build_stage(rank, 4, monkeypatch)
         out = model.forward(
             input_ids=torch.zeros(BATCH, dtype=torch.long),
             positions=torch.zeros(BATCH, dtype=torch.long),
@@ -204,12 +223,9 @@ def test_last_stage_returns_a_bare_tensor_when_eagle3_is_off(monkeypatch):
 def test_the_received_slot_set_follows_the_stage_band(monkeypatch):
     # The handoff placeholder is built from start_layer, so each stage has to ask
     # for exactly the indices an earlier stage can have captured.
-    expected = {0: (), 1: (2,), 2: (2, 31), 3: (2, 31)}
+    expected = {0: (), 1: (1,), 2: (1, 30), 3: (1, 30)}
     for rank, want in expected.items():
-        model = _build_stage(rank, 4)
-        monkeypatch.setattr(
-            patch_module, "get_pp_group", lambda rank=rank: _Group(rank, 4)
-        )
-        model._set_aux_hidden_state_layers(AUX_LAYERS)
+        model = _build_stage(rank, 4, monkeypatch)
+        model._set_aux_hidden_state_layers(CHECKPOINT_AUX_LAYERS)
 
         assert patch_module._aux_slots_received(model) == want

--- a/tests/native/patches/test_minimax_m2.py
+++ b/tests/native/patches/test_minimax_m2.py
@@ -29,6 +29,7 @@ import torch
 from vllm.model_executor.models.minimax_m2 import MiniMaxM2Model
 
 import vllm_rbln.patches.minimax_m2 as patch_module
+import vllm_rbln.v1.spec_decode.eagle3_pp as eagle3_pp
 
 # The suite truncates models via VLLM_RBLN_NUM_HIDDEN_LAYERS, and the patched
 # get_pp_indices honors it. These stages are stubs, so the truncation has nothing
@@ -95,44 +96,41 @@ class _UnownedLayer(torch.nn.Module):
 
 
 def _build_stage(rank: int, pp_size: int, monkeypatch) -> MiniMaxM2Model:
-    """Build one stage through the patched __init__, stubbing out upstream's.
+    """Assemble one stage's state with stub layers, real bands.
 
-    Going through the real patch is what puts the handoff callable it installs
-    under test, rather than one the test wrote itself.
+    The band comes from the real `get_pp_indices`, so a stage that reads outside
+    its own band calls an `_UnownedLayer` rather than producing a tensor that still
+    happens to fit.
     """
-
-    def stub_init(model, *, vllm_config, prefix=""):
-        torch.nn.Module.__init__(model)
-        model.config = SimpleNamespace(hidden_size=HIDDEN, num_hidden_layers=NUM_LAYERS)
-        start, end = get_pp_indices(NUM_LAYERS, rank, pp_size)
-        model.start_layer, model.end_layer = start, end
-        model.layers = torch.nn.ModuleList(
-            [
-                _StampingLayer(i) if start <= i < end else _UnownedLayer()
-                for i in range(NUM_LAYERS)
-            ]
-        )
-        model.embed_input_ids = lambda input_ids: torch.zeros(BATCH, HIDDEN)
-        model.norm = lambda hidden, residual: (
-            hidden if residual is None else hidden + residual,
-            None,
-        )
-        model.aux_hidden_state_layers = ()
-
-    monkeypatch.setattr(patch_module, "_orig_model_init", stub_init)
-    monkeypatch.setattr(
-        patch_module, "get_pp_group", lambda rank=rank: _Group(rank, pp_size)
-    )
     model = MiniMaxM2Model.__new__(MiniMaxM2Model)
-    patch_module.patched_minimax_m2_model_init(model, vllm_config=None, prefix="")
+    torch.nn.Module.__init__(model)
+    model.config = SimpleNamespace(hidden_size=HIDDEN, num_hidden_layers=NUM_LAYERS)
+    start, end = get_pp_indices(NUM_LAYERS, rank, pp_size)
+    model.start_layer, model.end_layer = start, end
+    model.layers = torch.nn.ModuleList(
+        [
+            _StampingLayer(i) if start <= i < end else _UnownedLayer()
+            for i in range(NUM_LAYERS)
+        ]
+    )
+    model.embed_input_ids = lambda input_ids: torch.zeros(BATCH, HIDDEN)
+    model.norm = lambda hidden, residual: (
+        hidden if residual is None else hidden + residual,
+        None,
+    )
+    model.aux_hidden_state_layers = ()
+
+    # The forward reads the group directly; the shared slot helpers read their own
+    # import of it.
+    group = _Group(rank, pp_size)
+    monkeypatch.setattr(patch_module, "get_pp_group", lambda: group)
+    monkeypatch.setattr(eagle3_pp, "get_pp_group", lambda: group)
     return model
 
 
 def _slot_indices(keys) -> list[int]:
     return sorted(
-        int(key.rsplit("_", 1)[1])
-        for key in keys
-        if key.startswith(patch_module._AUX_SLOT)
+        int(key.rsplit("_", 1)[1]) for key in keys if key.startswith(eagle3_pp.AUX_SLOT)
     )
 
 
@@ -188,14 +186,16 @@ def test_a_stage_owning_no_aux_layer_forwards_the_slots(monkeypatch):
 
 
 def test_the_handoff_placeholder_follows_a_later_setter_call(monkeypatch):
-    # MiniMaxM2ForCausalLM.__init__ copies this callable onto itself before the
-    # runner sets the aux layers, and the runner calls that copy. A callable that
-    # baked the key set in at construction leaves the copy a slot short, which the
-    # receiving stage only finds out about as a KeyError.
-    model = _build_stage(1, 4, monkeypatch)
-    snapshot = model.make_empty_intermediate_tensors
+    # ForCausalLM.__init__ copies this callable onto itself and the runner calls
+    # that copy, so the installer binds it on the outer object and reads the key set
+    # at call time. A callable that baked the key set in when it was bound leaves the
+    # copy a slot short, which the receiving stage only finds out about as a KeyError.
+    inner = _build_stage(1, 4, monkeypatch)
+    outer = SimpleNamespace(model=inner)
+    eagle3_pp.install_aux_handoff_slots(outer)
+    snapshot = outer.make_empty_intermediate_tensors
 
-    model._set_aux_hidden_state_layers(CHECKPOINT_AUX_LAYERS)
+    inner._set_aux_hidden_state_layers(CHECKPOINT_AUX_LAYERS)
 
     tensors = snapshot(batch_size=BATCH, dtype=torch.float32, device="cpu")
     assert _slot_indices(tensors.tensors) == [1]
@@ -235,4 +235,4 @@ def test_the_received_slot_set_follows_the_stage_band(monkeypatch):
         model = _build_stage(rank, 4, monkeypatch)
         model._set_aux_hidden_state_layers(CHECKPOINT_AUX_LAYERS)
 
-        assert patch_module._aux_slots_received(model) == want
+        assert eagle3_pp.aux_slots_received(model) == want

--- a/tests/native/patches/test_speculative_config.py
+++ b/tests/native/patches/test_speculative_config.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The draft's parallel config stays off the target's pipeline split.
+
+Config objects only -- no checkpoint, no device.
+"""
+
+from __future__ import annotations
+
+import pytest
+from vllm.config import ParallelConfig, SpeculativeConfig
+from vllm.model_executor.models.interfaces import supports_pp
+from vllm.model_executor.models.llama import LlamaForCausalLM
+from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
+
+from vllm_rbln.patches.speculative_config import create_draft_parallel_config
+
+
+@pytest.mark.parametrize("target_pp", [1, 2, 4])
+def test_draft_never_inherits_target_pipeline_size(target_pp):
+    target = ParallelConfig(pipeline_parallel_size=target_pp, tensor_parallel_size=1)
+
+    draft = create_draft_parallel_config(target, 1)
+
+    assert draft.pipeline_parallel_size == 1
+    # world_size is derived in the validator, so it has to come out right at
+    # construction; there is no field to correct afterwards.
+    assert draft.world_size == 1
+
+
+def test_the_patch_is_the_one_installed():
+    assert (
+        SpeculativeConfig.create_draft_parallel_config is create_draft_parallel_config
+    )
+
+
+def test_tensor_parallel_size_still_comes_from_the_argument():
+    target = ParallelConfig(pipeline_parallel_size=4, tensor_parallel_size=1)
+
+    draft = create_draft_parallel_config(target, 2)
+
+    assert draft.tensor_parallel_size == 2
+    assert draft.world_size == 2
+
+
+def test_the_draft_head_is_what_fails_supports_pp():
+    # Why the inherited pipeline size is fatal rather than merely wasteful: the
+    # draft head reaches verify_with_parallel_config and cannot satisfy it. If
+    # upstream ever gives the head an intermediate_tensors forward, this flips and
+    # the patch has lost its reason.
+    assert supports_pp(LlamaForCausalLM)
+    assert not supports_pp(Eagle3LlamaForCausalLM)

--- a/tests/native/test_platform.py
+++ b/tests/native/test_platform.py
@@ -175,6 +175,24 @@ class TestRejectedConfigs:
                 )
             )
 
+    def test_eagle3_under_pp_needs_a_patched_target(self, reconfigure):
+        # The default model is a plain LlamaForCausalLM, whose forward still
+        # collects aux hidden states with a stage-local index. Asserting through
+        # the hook rather than on the validator directly is the point: it is what
+        # shows the guard is reached at all.
+        with pytest.raises(ValueError, match="EAGLE3 with pipeline_parallel_size"):
+            reconfigure(_eagle3_under_pp())
+
+    def test_eagle3_under_pp_accepts_a_patched_target(self, reconfigure):
+        reconfigure(_eagle3_under_pp(arch="MiniMaxM2ForCausalLM"))
+
+    def test_eagle3_under_pp_accepts_a_draft_with_aux_off(self, reconfigure):
+        # Nothing is captured anywhere then, so upstream's forward is harmless.
+        reconfigure(_eagle3_under_pp(eagle_config={"use_aux_hidden_state": False}))
+
+    def test_eagle3_at_pp1_is_not_gated(self, reconfigure):
+        reconfigure(_eagle3_under_pp(pp_size=1))
+
     def test_dp_needs_a_divisible_token_budget(self, reconfigure):
         with pytest.raises(ValueError, match="divisible"):
             reconfigure(_ranks(data_parallel_size=2, max_num_seqs=5))
@@ -194,6 +212,30 @@ class TestRejectedConfigs:
     def test_moe_tokens_mask_defaults_on(self):
         # The error above calls 1 the default; a flipped default breaks DP.
         assert platform.envs.VLLM_RBLN_USE_MOE_TOKENS_MASK is True
+
+
+def _eagle3_under_pp(*, arch: str | None = None, eagle_config=None, pp_size: int = 2):
+    """A mutator that puts an EAGLE3 draft on a pipeline-parallel target.
+
+    EngineArgs would have to resolve a real draft checkpoint to build this, so the
+    speculative config is a stand-in shaped like the fields the guard reads.
+    """
+
+    def mutate(config: VllmConfig) -> None:
+        config.parallel_config.pipeline_parallel_size = pp_size
+        # The guard runs after the per-stage decode batch check, which would
+        # otherwise raise first and mask it.
+        config.scheduler_config.max_num_seqs = pp_size * 2
+        if arch is not None:
+            config.model_config.hf_config.architectures = [arch]
+        config.speculative_config = SimpleNamespace(
+            method="eagle3",
+            draft_model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(eagle_config=eagle_config)
+            ),
+        )
+
+    return mutate
 
 
 def _ranks(*, ep: bool = False, max_num_seqs: int | None = None, **parallel):

--- a/tests/native/v1/spec_decode/test_eagle3_pp.py
+++ b/tests/native/v1/spec_decode/test_eagle3_pp.py
@@ -1,0 +1,117 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""What the EAGLE3 pipeline handoff claims to support, and what it rejects.
+
+Config objects only -- no checkpoint, no device.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from vllm.model_executor.models.minimax_m2 import MiniMaxM2Model
+
+from vllm_rbln.platform import RblnPlatform
+from vllm_rbln.v1.spec_decode.eagle3_pp import (
+    EAGLE3_PP_TARGET_ARCHS,
+    eagle3_aux_hidden_states_enabled,
+)
+
+SUPPORTED = "MiniMaxM2ForCausalLM"
+UNSUPPORTED = "LlamaForCausalLM"
+
+# Each allowlisted architecture, with the class whose patched `forward` carries the
+# aux states across the split. Growing the allowlist has to touch this map, and the
+# assertion below then bites if the patch itself is missing.
+PATCHED_FORWARD_OWNERS = {SUPPORTED: MiniMaxM2Model}
+
+
+def _config(arch: str, pp_size: int, method="eagle3", eagle_config=None):
+    spec = (
+        None
+        if method is None
+        else SimpleNamespace(
+            method=method,
+            draft_model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(eagle_config=eagle_config)
+            ),
+        )
+    )
+    return SimpleNamespace(
+        model_config=SimpleNamespace(hf_config=SimpleNamespace(architectures=[arch])),
+        parallel_config=SimpleNamespace(pipeline_parallel_size=pp_size),
+        speculative_config=spec,
+    )
+
+
+def test_the_allowlist_and_the_patched_forwards_agree():
+    assert set(PATCHED_FORWARD_OWNERS) == set(EAGLE3_PP_TARGET_ARCHS)
+    for arch, model_cls in PATCHED_FORWARD_OWNERS.items():
+        assert model_cls.forward.__module__.startswith("vllm_rbln."), (
+            f"{arch} is allowlisted for EAGLE3 under pipeline parallelism, but "
+            f"{model_cls.__name__}.forward is still upstream's"
+        )
+
+
+def test_a_supported_target_is_accepted():
+    RblnPlatform._validate_eagle3_pp_config(_config(SUPPORTED, 4))
+
+
+def test_an_unsupported_target_is_rejected_at_startup():
+    with pytest.raises(ValueError, match="EAGLE3 with pipeline_parallel_size"):
+        RblnPlatform._validate_eagle3_pp_config(_config(UNSUPPORTED, 2))
+
+
+def test_an_unsupported_target_passes_when_aux_is_off():
+    # With `use_aux_hidden_state` off nothing is captured anywhere, so upstream's
+    # unpatched forward is harmless and the split is fine. Rejecting this would
+    # block a configuration that works.
+    RblnPlatform._validate_eagle3_pp_config(
+        _config(UNSUPPORTED, 2, eagle_config={"use_aux_hidden_state": False})
+    )
+
+
+@pytest.mark.parametrize("method", [None, "eagle", "ngram", "medusa"])
+def test_only_eagle3_is_gated(method):
+    RblnPlatform._validate_eagle3_pp_config(_config(UNSUPPORTED, 4, method=method))
+
+
+@pytest.mark.parametrize(
+    "eagle_config, expected",
+    [
+        (None, True),
+        ({}, True),
+        ({"use_aux_hidden_state": True}, True),
+        ({"use_aux_hidden_state": False}, False),
+        ("not-a-dict", True),
+    ],
+)
+def test_the_aux_flag_reader_matches_the_draft_config(eagle_config, expected):
+    # One reader for the runner and the guard: a non-last stage that disagrees with
+    # the last one about this captures nothing and the drafter comes up short.
+    spec = _config(SUPPORTED, 4, eagle_config=eagle_config).speculative_config
+
+    assert eagle3_aux_hidden_states_enabled(spec) is expected
+
+
+def test_a_non_eagle3_method_needs_no_aux():
+    assert eagle3_aux_hidden_states_enabled(None) is False
+    assert (
+        eagle3_aux_hidden_states_enabled(
+            _config(SUPPORTED, 4, method="eagle").speculative_config
+        )
+        is False
+    )

--- a/vllm_rbln/patches/__init__.py
+++ b/vllm_rbln/patches/__init__.py
@@ -44,6 +44,7 @@ from . import (
     qwen2_moe,
     qwen3_moe,
     rotary_embedding,
+    speculative_config,
 )
 
 __all__ = (

--- a/vllm_rbln/patches/__init__.py
+++ b/vllm_rbln/patches/__init__.py
@@ -34,6 +34,7 @@ from . import (
     fp8_moe_method,
     gpt_oss,
     gpt_oss_mxfp4_config,
+    llama_eagle3,
     metrics,
     minimax_m2,
     mla,

--- a/vllm_rbln/patches/llama_eagle3.py
+++ b/vllm_rbln/patches/llama_eagle3.py
@@ -14,7 +14,8 @@
 """Name the EAGLE3 head's layers past the target's full depth.
 
 Upstream names them past the count on *this* pipeline rank, which is only the
-total when PP=1. See the patch's own reason string for what that breaks.
+total when PP=1, and pairs that count with `target_layer_count`. Both move here.
+See the patch's own reason string for what that breaks.
 
 The draft->target vocab scatter is deliberately NOT patched here. Upstream builds
 that index inside ``compute_logits`` from two input-independent operands, so
@@ -56,20 +57,34 @@ _orig_model_init = Eagle3LlamaModel.__init__
         "\n"
         "Naming past the full depth also makes the head's name identical on a "
         "prefill and a decode instance, which is what NIXL matches KV regions by, "
-        "and keeps it clear of every target band for any split. The caller's "
-        "`target_layer_count` is left alone: it pairs with the `layer_idx` the "
-        "decoder layer is constructed with, which is the loop counter and not the "
-        "index the name carries, and the only reader (`llama.py:193`) sits behind a "
-        "`layer_types` walrus that this draft config leaves unset. "
+        "and keeps it clear of every target band for any split.\n"
+        "\n"
+        "`target_layer_count` moves with it. Upstream keeps the two equal because "
+        "both come from `target_layer_num` in `Eagle3LlamaForCausalLM.__init__`, and "
+        "`llama.py:193` subtracts it from `extract_layer_index(prefix)` -- the index "
+        "the *name* carries, not the loop counter the decoder layer is constructed "
+        "with. Raising one alone would make stage 3 of the 62-layer PP4 split "
+        "compute `62 - 15 = 47` and trip the `effective_layer_idx < len(layer_types)` "
+        "assert just below, for a one-layer draft. Unreachable while this draft "
+        "config leaves `layer_types` unset, which is why it has to be set here "
+        "rather than relied on. It has to be set before the original runs: the "
+        "layers that read it are built inside `LlamaModel.__init__`, off the same "
+        "config object.\n"
         "TODO(vllm-project/vllm#50514): delete once that lands and is released."
     ),
 )
 def patched_eagle3_llama_model_init(
     self, *, vllm_config: VllmConfig, start_layer_id: int = 0, prefix: str = ""
 ) -> None:
+    # The same expression `pipeline_adjusted_layer_index` compares the head's index
+    # against, so the name is guaranteed to land past the threshold.
+    target_depth = vllm_config.model_config.get_total_num_hidden_layers()
+    vllm_config.speculative_config.draft_model_config.hf_config.target_layer_count = (
+        target_depth
+    )
     _orig_model_init(
         self,
         vllm_config=vllm_config,
-        start_layer_id=vllm_config.model_config.hf_text_config.num_hidden_layers,
+        start_layer_id=target_depth,
         prefix=prefix,
     )

--- a/vllm_rbln/patches/llama_eagle3.py
+++ b/vllm_rbln/patches/llama_eagle3.py
@@ -49,6 +49,7 @@ message.
 """
 
 import torch
+from vllm.config import VllmConfig
 from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
 
 from vllm_rbln.logger import init_logger
@@ -75,8 +76,15 @@ _REASON_SUFFIX = (
     target=f"{_TARGET}.__init__",
     reason=f"Register the scatter index as a named buffer: {_REASON_SUFFIX}",
 )
-def patched_eagle3_llama_init(self, *args, **kwargs) -> None:
-    _orig_init(self, *args, **kwargs)
+def patched_eagle3_llama_init(
+    self, *, vllm_config: VllmConfig, prefix: str = ""
+) -> None:
+    # The signature has to name vllm_config and prefix, not absorb them into
+    # **kwargs: `initialize_model` inspects it and takes the new-style path only
+    # when both names are present (model_loader/utils.py:56-62). A wrapper that
+    # forwards opaquely is read as an old-style model class and called with no
+    # arguments at all.
+    _orig_init(self, vllm_config=vllm_config, prefix=prefix)
     # Identity default: safe to execute even if never filled.
     self.register_buffer(
         "target_ids",
@@ -87,7 +95,9 @@ def patched_eagle3_llama_init(self, *args, **kwargs) -> None:
 
 @register_patch(
     target=f"{_TARGET}.load_weights",
-    reason=f"Fill the named scatter index from the loaded d2t mapping: {_REASON_SUFFIX}",
+    reason=(
+        f"Fill the named scatter index from the loaded d2t mapping: {_REASON_SUFFIX}"
+    ),
 )
 def patched_eagle3_llama_load_weights(self, weights):
     loaded = _orig_load_weights(self, weights)

--- a/vllm_rbln/patches/llama_eagle3.py
+++ b/vllm_rbln/patches/llama_eagle3.py
@@ -1,0 +1,142 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""EAGLE3 draft->target vocab scatter index: keep it a NAMED buffer.
+
+The drafter emits ids in its own 32k draft vocabulary and scatters them into the
+target's 200k vocabulary. Upstream builds that scatter index inside
+``compute_logits``::
+
+    base = torch.arange(self.config.draft_vocab_size, device=logits.device)
+    targets = base + self.draft_id_to_target_id
+
+Both operands are constants with respect to the forward input, so dynamo
+const-folds the subgraph into a SINGLE anonymous constant. Under RBLN weight-free
+loading, the host-op apply pass resolves tensors through
+``named_parameters()`` / ``named_buffers()`` -- an anonymous folded constant is in
+neither, so it is never filled. It reaches execution holding whatever was in the
+FakeTensorMode allocation: garbage indices into a 200k-wide scatter, i.e. an
+out-of-bounds host-op write, which segfaults during KV warmup before the server
+ever comes up.
+
+The fix keeps the index NAMED and keeps the subgraph NON-constant:
+
+1. ``__init__`` registers ``target_ids`` as a buffer, initialised to ``arange``
+   (identity, fully in range) so that even an unfilled buffer is safe.
+2. ``load_weights`` fills it from the real loaded mapping (``arange + d2t``).
+   When the checkpoint carries no mapping, ``d2t`` is all zeros and the buffer
+   stays identity.
+3. ``compute_logits`` ties the index to an input-derived zero, so the subgraph
+   is not constant and cannot be folded. ``target_ids`` then stays a ``get_attr``
+   buffer that the apply pass fills with real, in-range values before execution.
+
+This mirrors the existing ``mask_hidden`` buffer pattern in the same class.
+
+NOTE: ``deepseek_eagle3.Eagle3DeepseekV2ForCausalLM.compute_logits`` builds the
+index the same way and has the same defect. It is deliberately NOT patched here
+because we have no DeepSeek-family EAGLE3 head to verify against; see the commit
+message.
+"""
+
+import torch
+from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
+
+from vllm_rbln.logger import init_logger
+from vllm_rbln.patches import register_patch
+
+logger = init_logger(__name__)
+
+_TARGET = "vllm.model_executor.models.llama_eagle3.Eagle3LlamaForCausalLM"
+
+# Captured at import time: the registry replaces targets outright, so wrapping
+# upstream behaviour means holding the original here rather than copying its body.
+_orig_init = Eagle3LlamaForCausalLM.__init__
+_orig_load_weights = Eagle3LlamaForCausalLM.load_weights
+
+_REASON_SUFFIX = (
+    "the draft->target scatter index is input-independent, so it const-folds "
+    "into an anonymous constant that weight-free apply (which resolves by "
+    "named_parameters/named_buffers) never fills -- garbage indices, "
+    "out-of-bounds host-op write, segfault in KV warmup."
+)
+
+
+@register_patch(
+    target=f"{_TARGET}.__init__",
+    reason=f"Register the scatter index as a named buffer: {_REASON_SUFFIX}",
+)
+def patched_eagle3_llama_init(self, *args, **kwargs) -> None:
+    _orig_init(self, *args, **kwargs)
+    # Identity default: safe to execute even if never filled.
+    self.register_buffer(
+        "target_ids",
+        torch.arange(self.config.draft_vocab_size, dtype=torch.long),
+        persistent=False,
+    )
+
+
+@register_patch(
+    target=f"{_TARGET}.load_weights",
+    reason=f"Fill the named scatter index from the loaded d2t mapping: {_REASON_SUFFIX}",
+)
+def patched_eagle3_llama_load_weights(self, weights):
+    loaded = _orig_load_weights(self, weights)
+    if self.draft_id_to_target_id is None:
+        return loaded
+    base = torch.arange(
+        self.config.draft_vocab_size,
+        dtype=torch.long,
+        device=self.target_ids.device,
+    )
+    # No mapping in the checkpoint -> d2t is all zeros -> stays identity.
+    self.target_ids.copy_(
+        base + self.draft_id_to_target_id.to(self.target_ids.device).long()
+    )
+    logger.debug(
+        "EAGLE3 scatter index filled: targets [%d, %d], target vocab %d",
+        int(self.target_ids.min()),
+        int(self.target_ids.max()),
+        self.config.vocab_size,
+    )
+    return loaded
+
+
+@register_patch(
+    target=f"{_TARGET}.compute_logits",
+    reason=f"Keep the scatter-index subgraph non-constant: {_REASON_SUFFIX}",
+)
+def patched_eagle3_llama_compute_logits(
+    self, hidden_states: torch.Tensor
+) -> torch.Tensor | None:
+    logits = self.logits_processor(self.lm_head, hidden_states)
+    if self.draft_id_to_target_id is None:
+        assert logits.shape[1] == self.config.vocab_size, (
+            "Expected logits to have shape "
+            f"(*, {self.config.vocab_size}), but got {logits.shape}"
+        )
+        return logits
+
+    # NOTE(RBLN): upstream computes the index here as
+    #   base = torch.arange(self.config.draft_vocab_size, device=logits.device)
+    #   targets = base + self.draft_id_to_target_id
+    # which is input-independent and therefore foldable. Adding an
+    # input-derived zero keeps the subgraph live so `target_ids` survives as a
+    # named buffer for the apply pass. The value is unchanged.
+    zero = (logits.reshape(-1)[:1].sum() * 0.0).to(torch.long)
+    targets = self.target_ids + zero
+    logits_new = logits.new_full(
+        (logits.shape[0], self.config.vocab_size),
+        float("-inf"),
+    )
+    logits_new[:, targets] = logits
+    return logits_new

--- a/vllm_rbln/patches/llama_eagle3.py
+++ b/vllm_rbln/patches/llama_eagle3.py
@@ -50,7 +50,12 @@ message.
 
 import torch
 from vllm.config import VllmConfig
-from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
+from vllm.model_executor.models.llama_eagle3 import (
+    Eagle3LlamaForCausalLM,
+)
+from vllm.model_executor.models.llama_eagle3 import (
+    LlamaModel as Eagle3LlamaModel,
+)
 
 from vllm_rbln.logger import init_logger
 from vllm_rbln.patches import register_patch
@@ -62,6 +67,7 @@ _TARGET = "vllm.model_executor.models.llama_eagle3.Eagle3LlamaForCausalLM"
 # Captured at import time: the registry replaces targets outright, so wrapping
 # upstream behaviour means holding the original here rather than copying its body.
 _orig_init = Eagle3LlamaForCausalLM.__init__
+_orig_model_init = Eagle3LlamaModel.__init__
 _orig_load_weights = Eagle3LlamaForCausalLM.load_weights
 
 _REASON_SUFFIX = (
@@ -150,3 +156,41 @@ def patched_eagle3_llama_compute_logits(
     )
     logits_new[:, targets] = logits
     return logits_new
+
+
+@register_patch(
+    target="vllm.model_executor.models.llama_eagle3.LlamaModel.__init__",
+    reason=(
+        "Name the EAGLE head's layers past the target's full depth, not past the "
+        "count on this pipeline rank. Upstream passes "
+        "`start_layer_id=model_config.get_num_layers(parallel_config)`, the per-rank "
+        "count; with PP=1 that already equals the total, so the naming only goes "
+        "wrong under pipeline parallelism, and then only on a rank that does not "
+        "start at zero -- which is exactly where the drafter lives.\n"
+        "\n"
+        "The head's name then sorts in among the target's. On the 62-layer PP4 split "
+        "stage 3 owns 47..61 and the head is named 15, so RBLN's KV ordering "
+        "(`_get_ordered_layer_names`, which sorts on the raw index) puts the head "
+        "first and every target layer's `name - start_layer` lookup is off by one. "
+        "Nobody binds the last entry, and KV registration fails with "
+        "`EnsureSyncedOnPhysicalView ... has no physical_view`.\n"
+        "\n"
+        "Naming past the full depth also makes the head's name identical on a "
+        "prefill and a decode instance, which is what NIXL matches KV regions by, "
+        "and keeps it clear of every target band for any split. The caller's "
+        "`target_layer_count` is left alone: it pairs with the `layer_idx` the "
+        "decoder layer is constructed with, which is the loop counter and not the "
+        "index the name carries, and the only reader (`llama.py:193`) sits behind a "
+        "`layer_types` walrus that this draft config leaves unset. "
+        "TODO(vllm-project/vllm#50514): delete once that lands and is released."
+    ),
+)
+def patched_eagle3_llama_model_init(
+    self, *, vllm_config: VllmConfig, start_layer_id: int = 0, prefix: str = ""
+) -> None:
+    _orig_model_init(
+        self,
+        vllm_config=vllm_config,
+        start_layer_id=vllm_config.model_config.hf_text_config.num_hidden_layers,
+        prefix=prefix,
+    )

--- a/vllm_rbln/patches/llama_eagle3.py
+++ b/vllm_rbln/patches/llama_eagle3.py
@@ -11,151 +11,30 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""EAGLE3 draft->target vocab scatter index: keep it a NAMED buffer.
+"""Name the EAGLE3 head's layers past the target's full depth.
 
-The drafter emits ids in its own 32k draft vocabulary and scatters them into the
-target's 200k vocabulary. Upstream builds that scatter index inside
-``compute_logits``::
+Upstream names them past the count on *this* pipeline rank, which is only the
+total when PP=1. See the patch's own reason string for what that breaks.
 
-    base = torch.arange(self.config.draft_vocab_size, device=logits.device)
-    targets = base + self.draft_id_to_target_id
-
-Both operands are constants with respect to the forward input, so dynamo
-const-folds the subgraph into a SINGLE anonymous constant. Under RBLN weight-free
-loading, the host-op apply pass resolves tensors through
-``named_parameters()`` / ``named_buffers()`` -- an anonymous folded constant is in
-neither, so it is never filled. It reaches execution holding whatever was in the
-FakeTensorMode allocation: garbage indices into a 200k-wide scatter, i.e. an
-out-of-bounds host-op write, which segfaults during KV warmup before the server
-ever comes up.
-
-The fix keeps the index NAMED and keeps the subgraph NON-constant:
-
-1. ``__init__`` registers ``target_ids`` as a buffer, initialised to ``arange``
-   (identity, fully in range) so that even an unfilled buffer is safe.
-2. ``load_weights`` fills it from the real loaded mapping (``arange + d2t``).
-   When the checkpoint carries no mapping, ``d2t`` is all zeros and the buffer
-   stays identity.
-3. ``compute_logits`` ties the index to an input-derived zero, so the subgraph
-   is not constant and cannot be folded. ``target_ids`` then stays a ``get_attr``
-   buffer that the apply pass fills with real, in-range values before execution.
-
-This mirrors the existing ``mask_hidden`` buffer pattern in the same class.
-
-NOTE: ``deepseek_eagle3.Eagle3DeepseekV2ForCausalLM.compute_logits`` builds the
-index the same way and has the same defect. It is deliberately NOT patched here
-because we have no DeepSeek-family EAGLE3 head to verify against; see the commit
-message.
+The draft->target vocab scatter is deliberately NOT patched here. Upstream builds
+that index inside ``compute_logits`` from two input-independent operands, so
+dynamo const-folds it into an anonymous constant that weight-free apply cannot
+resolve by name -- an out-of-bounds host-op write that segfaults in KV warmup.
+``RBLNEagleProposer`` already avoids it (``v1/spec_decode/eagle.py``): it stays in
+draft-vocab space and maps after the argmax, so ``compute_logits`` is never the
+path that runs.
 """
 
-import torch
 from vllm.config import VllmConfig
-from vllm.model_executor.models.llama_eagle3 import (
-    Eagle3LlamaForCausalLM,
-)
 from vllm.model_executor.models.llama_eagle3 import (
     LlamaModel as Eagle3LlamaModel,
 )
 
-from vllm_rbln.logger import init_logger
 from vllm_rbln.patches import register_patch
-
-logger = init_logger(__name__)
-
-_TARGET = "vllm.model_executor.models.llama_eagle3.Eagle3LlamaForCausalLM"
 
 # Captured at import time: the registry replaces targets outright, so wrapping
 # upstream behaviour means holding the original here rather than copying its body.
-_orig_init = Eagle3LlamaForCausalLM.__init__
 _orig_model_init = Eagle3LlamaModel.__init__
-_orig_load_weights = Eagle3LlamaForCausalLM.load_weights
-
-_REASON_SUFFIX = (
-    "the draft->target scatter index is input-independent, so it const-folds "
-    "into an anonymous constant that weight-free apply (which resolves by "
-    "named_parameters/named_buffers) never fills -- garbage indices, "
-    "out-of-bounds host-op write, segfault in KV warmup."
-)
-
-
-@register_patch(
-    target=f"{_TARGET}.__init__",
-    reason=f"Register the scatter index as a named buffer: {_REASON_SUFFIX}",
-)
-def patched_eagle3_llama_init(
-    self, *, vllm_config: VllmConfig, prefix: str = ""
-) -> None:
-    # The signature has to name vllm_config and prefix, not absorb them into
-    # **kwargs: `initialize_model` inspects it and takes the new-style path only
-    # when both names are present (model_loader/utils.py:56-62). A wrapper that
-    # forwards opaquely is read as an old-style model class and called with no
-    # arguments at all.
-    _orig_init(self, vllm_config=vllm_config, prefix=prefix)
-    # Identity default: safe to execute even if never filled.
-    self.register_buffer(
-        "target_ids",
-        torch.arange(self.config.draft_vocab_size, dtype=torch.long),
-        persistent=False,
-    )
-
-
-@register_patch(
-    target=f"{_TARGET}.load_weights",
-    reason=(
-        f"Fill the named scatter index from the loaded d2t mapping: {_REASON_SUFFIX}"
-    ),
-)
-def patched_eagle3_llama_load_weights(self, weights):
-    loaded = _orig_load_weights(self, weights)
-    if self.draft_id_to_target_id is None:
-        return loaded
-    base = torch.arange(
-        self.config.draft_vocab_size,
-        dtype=torch.long,
-        device=self.target_ids.device,
-    )
-    # No mapping in the checkpoint -> d2t is all zeros -> stays identity.
-    self.target_ids.copy_(
-        base + self.draft_id_to_target_id.to(self.target_ids.device).long()
-    )
-    logger.debug(
-        "EAGLE3 scatter index filled: targets [%d, %d], target vocab %d",
-        int(self.target_ids.min()),
-        int(self.target_ids.max()),
-        self.config.vocab_size,
-    )
-    return loaded
-
-
-@register_patch(
-    target=f"{_TARGET}.compute_logits",
-    reason=f"Keep the scatter-index subgraph non-constant: {_REASON_SUFFIX}",
-)
-def patched_eagle3_llama_compute_logits(
-    self, hidden_states: torch.Tensor
-) -> torch.Tensor | None:
-    logits = self.logits_processor(self.lm_head, hidden_states)
-    if self.draft_id_to_target_id is None:
-        assert logits.shape[1] == self.config.vocab_size, (
-            "Expected logits to have shape "
-            f"(*, {self.config.vocab_size}), but got {logits.shape}"
-        )
-        return logits
-
-    # NOTE(RBLN): upstream computes the index here as
-    #   base = torch.arange(self.config.draft_vocab_size, device=logits.device)
-    #   targets = base + self.draft_id_to_target_id
-    # which is input-independent and therefore foldable. Adding an
-    # input-derived zero keeps the subgraph live so `target_ids` survives as a
-    # named buffer for the apply pass. The value is unchanged.
-    zero = (logits.reshape(-1)[:1].sum() * 0.0).to(torch.long)
-    targets = self.target_ids + zero
-    logits_new = logits.new_full(
-        (logits.shape[0], self.config.vocab_size),
-        float("-inf"),
-    )
-    logits_new[:, targets] = logits
-    return logits_new
 
 
 @register_patch(

--- a/vllm_rbln/patches/minimax_m2.py
+++ b/vllm_rbln/patches/minimax_m2.py
@@ -209,19 +209,19 @@ def forward(
     # for a later stage that index is the previous stage's final capture, and
     # taking it again would duplicate a boundary layer. Layer 31 of the 62-layer
     # [15,16,16,15] split is exactly such a boundary.
+    #
+    # The capture is written out at both sites rather than factored into a closure
+    # over hidden_states/residual: dynamo does not inline such a closure, it lifts
+    # the captured variables into arguments and compiles the body as its own graph.
+    # For a residual-stream add that graph is two no-op bf16 casts, which the
+    # builder then rejects while registering the module.
     aux: dict[int, torch.Tensor] = {}
-
-    def capture(index: int) -> None:
-        if index in self.aux_hidden_state_layers:
-            aux[index] = (
-                hidden_states + residual if residual is not None else hidden_states
-            )
-
-    if get_pp_group().is_first_rank:
-        capture(0)
+    if get_pp_group().is_first_rank and 0 in self.aux_hidden_state_layers:
+        aux[0] = hidden_states
     for idx, layer in enumerate(islice(self.layers, self.start_layer, self.end_layer)):
         hidden_states, residual = layer(positions, hidden_states, residual)
-        capture(self.start_layer + idx + 1)
+        if self.start_layer + idx + 1 in self.aux_hidden_state_layers:
+            aux[self.start_layer + idx + 1] = hidden_states + residual
 
     # A received index is at or before start_layer and a local one is past it, so
     # the two sets never collide.

--- a/vllm_rbln/patches/minimax_m2.py
+++ b/vllm_rbln/patches/minimax_m2.py
@@ -15,19 +15,19 @@
 from itertools import islice
 
 import torch
-from vllm.config import VllmConfig
 from vllm.distributed import get_pp_group, tensor_model_parallel_all_reduce
 from vllm.model_executor.layers.minimax_rms_norm.rms_norm_tp import (
     MiniMaxText01RMSNormTP,
 )
-from vllm.model_executor.models.minimax_m2 import (
-    MiniMaxM2Attention,
-    MiniMaxM2Model,
-    MiniMaxM2MoE,
-)
+from vllm.model_executor.models.minimax_m2 import MiniMaxM2Attention, MiniMaxM2MoE
 from vllm.sequence import IntermediateTensors
 
 from vllm_rbln.patches import register_patch
+from vllm_rbln.v1.spec_decode.eagle3_pp import (
+    AUX_SLOT,
+    aux_slots_captured,
+    aux_slots_received,
+)
 
 
 @register_patch(
@@ -115,85 +115,6 @@ def patched_minimax_m2_attention_forward(
     return output
 
 
-_AUX_SLOT = "aux_hidden_states_"
-
-# Captured at import time: the registry replaces targets outright, so wrapping
-# upstream behaviour means holding the original here.
-_orig_model_init = MiniMaxM2Model.__init__
-
-
-def _aux_slots_received(model: MiniMaxM2Model) -> tuple[int, ...]:
-    """Global aux layer indices that reach this stage from upstream stages.
-
-    A capture at index ``i`` is the input to layer ``i``, so this stage receives
-    every requested index at or before its first owned layer. On the first stage
-    the set is empty: index ``start_layer == 0`` is captured locally from the
-    embedding output.
-    """
-    if get_pp_group().is_first_rank:
-        return ()
-    return tuple(
-        sorted(i for i in model.aux_hidden_state_layers if i <= model.start_layer)
-    )
-
-
-def _aux_slots_captured(model: MiniMaxM2Model) -> tuple[int, ...]:
-    """Global aux layer indices this stage produces, in the order it produces them.
-
-    The loop captures at ``start_layer + idx + 1`` for each owned layer, so the
-    reachable indices are ``start_layer + 1 .. end_layer``; the first stage adds
-    index 0 from the embedding output. Every index is a compile-time constant, so
-    deriving the order here keeps it out of the traced graph -- the capture itself
-    appends to a list and never keys a dict inside the loop.
-
-    Together with `_aux_slots_received` this partitions the requested set: received
-    indices are at or before ``start_layer``, captured ones past it. Received then
-    captured is therefore already ascending, which is the order the drafter's `fc`
-    expects its concatenated blocks in.
-    """
-    captured = [
-        i
-        for i in sorted(model.aux_hidden_state_layers)
-        if model.start_layer < i <= model.end_layer
-    ]
-    if get_pp_group().is_first_rank and 0 in model.aux_hidden_state_layers:
-        captured.insert(0, 0)
-    return tuple(captured)
-
-
-@register_patch(
-    target="vllm.model_executor.models.minimax_m2.MiniMaxM2Model.__init__",
-    reason=(
-        "Size the pipeline handoff to carry the EAGLE3 aux hidden states. Upstream "
-        "fixes the handoff key set here, but the aux layers are only known later, "
-        "when the model runner calls set_aux_hidden_state_layers -- and rebuilding "
-        "the attribute then is too late: MiniMaxM2ForCausalLM.__init__ copies this "
-        "callable onto itself, and the runner calls that copy. Read the key set at "
-        "call time instead, so the copy stays correct. "
-        "TODO(vllm-project/vllm#50514): delete once that lands and is released."
-    ),
-)
-def patched_minimax_m2_model_init(
-    self, *, vllm_config: VllmConfig, prefix: str = ""
-) -> None:
-    _orig_model_init(self, vllm_config=vllm_config, prefix=prefix)
-
-    def make_empty_intermediate_tensors(
-        batch_size: int, dtype: torch.dtype, device: torch.device
-    ) -> IntermediateTensors:
-        keys = ["hidden_states", "residual"]
-        keys += [f"{_AUX_SLOT}{i}" for i in _aux_slots_received(self)]
-        hidden_size = self.config.hidden_size
-        return IntermediateTensors(
-            {
-                key: torch.zeros((batch_size, hidden_size), dtype=dtype, device=device)
-                for key in keys
-            }
-        )
-
-    self.make_empty_intermediate_tensors = make_empty_intermediate_tensors
-
-
 @register_patch(
     target="vllm.model_executor.models.minimax_m2.MiniMaxM2Model.forward",
     reason=(
@@ -227,7 +148,7 @@ def forward(
         hidden_states = intermediate_tensors["hidden_states"]
         residual = intermediate_tensors["residual"]
         received = [
-            intermediate_tensors[f"{_AUX_SLOT}{i}"] for i in _aux_slots_received(self)
+            intermediate_tensors[f"{AUX_SLOT}{i}"] for i in aux_slots_received(self)
         ]
 
     # Index i means "input to layer i". The pre-loop capture is first-rank only:
@@ -238,7 +159,7 @@ def forward(
     # The capture appends to a list; it must not key a dict inside the loop. Doing
     # so breaks the graph at that statement -- the backend then receives the
     # residual-stream add on its own, as two no-op bf16 casts, and rejects it while
-    # registering the module. `_aux_slots_captured` recovers which global index each
+    # registering the module. `aux_slots_captured` recovers which global index each
     # append holds, from constants, outside the graph.
     captured: list[torch.Tensor] = []
     if get_pp_group().is_first_rank and 0 in self.aux_hidden_state_layers:
@@ -250,9 +171,9 @@ def forward(
 
     if not get_pp_group().is_last_rank:
         tensors = {"hidden_states": hidden_states, "residual": residual}
-        slots = _aux_slots_received(self) + _aux_slots_captured(self)
+        slots = aux_slots_received(self) + aux_slots_captured(self)
         for index, value in zip(slots, received + captured):
-            tensors[f"{_AUX_SLOT}{index}"] = value
+            tensors[f"{AUX_SLOT}{index}"] = value
         return IntermediateTensors(tensors)
 
     hidden_states, _ = self.norm(hidden_states, residual)
@@ -264,7 +185,7 @@ def forward(
     assert len(aux) == len(self.aux_hidden_state_layers), (
         f"EAGLE3 expected {len(self.aux_hidden_state_layers)} aux hidden states for "
         f"layers {sorted(self.aux_hidden_state_layers)}, but "
-        f"{len(_aux_slots_received(self))} arrived and "
-        f"{len(_aux_slots_captured(self))} were captured"
+        f"{len(aux_slots_received(self))} arrived and "
+        f"{len(aux_slots_captured(self))} were captured"
     )
     return hidden_states, aux

--- a/vllm_rbln/patches/minimax_m2.py
+++ b/vllm_rbln/patches/minimax_m2.py
@@ -132,7 +132,33 @@ def _aux_slots_received(model: MiniMaxM2Model) -> tuple[int, ...]:
     """
     if get_pp_group().is_first_rank:
         return ()
-    return tuple(i for i in model.aux_hidden_state_layers if i <= model.start_layer)
+    return tuple(
+        sorted(i for i in model.aux_hidden_state_layers if i <= model.start_layer)
+    )
+
+
+def _aux_slots_captured(model: MiniMaxM2Model) -> tuple[int, ...]:
+    """Global aux layer indices this stage produces, in the order it produces them.
+
+    The loop captures at ``start_layer + idx + 1`` for each owned layer, so the
+    reachable indices are ``start_layer + 1 .. end_layer``; the first stage adds
+    index 0 from the embedding output. Every index is a compile-time constant, so
+    deriving the order here keeps it out of the traced graph -- the capture itself
+    appends to a list and never keys a dict inside the loop.
+
+    Together with `_aux_slots_received` this partitions the requested set: received
+    indices are at or before ``start_layer``, captured ones past it. Received then
+    captured is therefore already ascending, which is the order the drafter's `fc`
+    expects its concatenated blocks in.
+    """
+    captured = [
+        i
+        for i in sorted(model.aux_hidden_state_layers)
+        if model.start_layer < i <= model.end_layer
+    ]
+    if get_pp_group().is_first_rank and 0 in model.aux_hidden_state_layers:
+        captured.insert(0, 0)
+    return tuple(captured)
 
 
 @register_patch(
@@ -189,7 +215,7 @@ def forward(
     intermediate_tensors: IntermediateTensors | None,
     inputs_embeds: torch.Tensor | None = None,
 ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
-    incoming: dict[int, torch.Tensor] = {}
+    received: list[torch.Tensor] = []
     if get_pp_group().is_first_rank:
         if inputs_embeds is not None:
             hidden_states = inputs_embeds
@@ -200,37 +226,33 @@ def forward(
         assert intermediate_tensors is not None
         hidden_states = intermediate_tensors["hidden_states"]
         residual = intermediate_tensors["residual"]
-        incoming = {
-            i: intermediate_tensors[f"{_AUX_SLOT}{i}"]
-            for i in _aux_slots_received(self)
-        }
+        received = [
+            intermediate_tensors[f"{_AUX_SLOT}{i}"] for i in _aux_slots_received(self)
+        ]
 
     # Index i means "input to layer i". The pre-loop capture is first-rank only:
     # for a later stage that index is the previous stage's final capture, and
     # taking it again would duplicate a boundary layer. Layer 31 of the 62-layer
     # [15,16,16,15] split is exactly such a boundary.
     #
-    # The capture is written out at both sites rather than factored into a closure
-    # over hidden_states/residual: dynamo does not inline such a closure, it lifts
-    # the captured variables into arguments and compiles the body as its own graph.
-    # For a residual-stream add that graph is two no-op bf16 casts, which the
-    # builder then rejects while registering the module.
-    aux: dict[int, torch.Tensor] = {}
+    # The capture appends to a list; it must not key a dict inside the loop. Doing
+    # so breaks the graph at that statement -- the backend then receives the
+    # residual-stream add on its own, as two no-op bf16 casts, and rejects it while
+    # registering the module. `_aux_slots_captured` recovers which global index each
+    # append holds, from constants, outside the graph.
+    captured: list[torch.Tensor] = []
     if get_pp_group().is_first_rank and 0 in self.aux_hidden_state_layers:
-        aux[0] = hidden_states
+        captured.append(hidden_states)
     for idx, layer in enumerate(islice(self.layers, self.start_layer, self.end_layer)):
         hidden_states, residual = layer(positions, hidden_states, residual)
         if self.start_layer + idx + 1 in self.aux_hidden_state_layers:
-            aux[self.start_layer + idx + 1] = hidden_states + residual
-
-    # A received index is at or before start_layer and a local one is past it, so
-    # the two sets never collide.
-    aux.update(incoming)
+            captured.append(hidden_states + residual)
 
     if not get_pp_group().is_last_rank:
         tensors = {"hidden_states": hidden_states, "residual": residual}
-        for i, value in aux.items():
-            tensors[f"{_AUX_SLOT}{i}"] = value
+        slots = _aux_slots_received(self) + _aux_slots_captured(self)
+        for index, value in zip(slots, received + captured):
+            tensors[f"{_AUX_SLOT}{index}"] = value
         return IntermediateTensors(tensors)
 
     hidden_states, _ = self.norm(hidden_states, residual)
@@ -238,9 +260,11 @@ def forward(
     if not self.aux_hidden_state_layers:
         return hidden_states
 
-    missing = set(self.aux_hidden_state_layers) - aux.keys()
-    assert not missing, (
-        f"EAGLE3 aux hidden states missing for layers {sorted(missing)}; "
-        f"requested {self.aux_hidden_state_layers}, arrived {sorted(aux)}"
+    aux = received + captured
+    assert len(aux) == len(self.aux_hidden_state_layers), (
+        f"EAGLE3 expected {len(self.aux_hidden_state_layers)} aux hidden states for "
+        f"layers {sorted(self.aux_hidden_state_layers)}, but "
+        f"{len(_aux_slots_received(self))} arrived and "
+        f"{len(_aux_slots_captured(self))} were captured"
     )
-    return hidden_states, [aux[i] for i in sorted(aux)]
+    return hidden_states, aux

--- a/vllm_rbln/patches/minimax_m2.py
+++ b/vllm_rbln/patches/minimax_m2.py
@@ -12,12 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from itertools import islice
+
 import torch
-from vllm.distributed import tensor_model_parallel_all_reduce
+from vllm.distributed import get_pp_group, tensor_model_parallel_all_reduce
 from vllm.model_executor.layers.minimax_rms_norm.rms_norm_tp import (
     MiniMaxText01RMSNormTP,
 )
-from vllm.model_executor.models.minimax_m2 import MiniMaxM2Attention, MiniMaxM2MoE
+from vllm.model_executor.models.minimax_m2 import (
+    MiniMaxM2Attention,
+    MiniMaxM2Model,
+    MiniMaxM2MoE,
+)
+from vllm.model_executor.models.utils import make_empty_intermediate_tensors_factory
+from vllm.sequence import IntermediateTensors
 
 from vllm_rbln.patches import register_patch
 
@@ -105,3 +113,116 @@ def patched_minimax_m2_attention_forward(
     attn_output = self.attn(q, k, v)
     output, _ = self.o_proj(attn_output)
     return output
+
+
+_AUX_SLOT = "aux_hidden_states_"
+
+
+def _aux_slots_received(model: MiniMaxM2Model) -> tuple[int, ...]:
+    """Global aux layer indices that reach this stage from upstream stages.
+
+    A capture at index ``i`` is the input to layer ``i``, so this stage receives
+    every requested index at or before its first owned layer. On the first stage
+    the set is empty: index ``start_layer == 0`` is captured locally from the
+    embedding output.
+    """
+    if get_pp_group().is_first_rank:
+        return ()
+    return tuple(i for i in model.aux_hidden_state_layers if i <= model.start_layer)
+
+
+@register_patch(
+    target="vllm.model_executor.models.minimax_m2.MiniMaxM2Model._set_aux_hidden_state_layers",
+    reason=(
+        "Size the pipeline handoff to carry the EAGLE3 aux hidden states. The "
+        "handoff key set is fixed in __init__, but the aux layers are only known "
+        "once the model runner calls this setter, so the factory has to be rebuilt "
+        "here. Upstream has no hook between the two. "
+        "TODO(vllm-project/vllm#50514): delete once that lands and is released."
+    ),
+)
+def _set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+    self.aux_hidden_state_layers = layers
+    keys = ["hidden_states", "residual"]
+    keys += [f"{_AUX_SLOT}{i}" for i in _aux_slots_received(self)]
+    self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+        keys, self.config.hidden_size
+    )
+
+
+@register_patch(
+    target="vllm.model_executor.models.minimax_m2.MiniMaxM2Model.forward",
+    reason=(
+        "Collect EAGLE3 aux hidden states correctly under pipeline parallelism. "
+        "Upstream indexes the capture with `enumerate(islice(...))`, which restarts "
+        "at zero on every stage, so a non-first stage matches a requested global "
+        "layer index against a stage-local one and harvests the wrong layer. It "
+        "then drops `aux_hidden_states` entirely on non-last stages, while the "
+        "drafter runs on the last one. Carry them in the existing IntermediateTensors "
+        "handoff under global-index slots and reassemble in layer order; no new "
+        "collective is introduced. "
+        "TODO(vllm-project/vllm#50514): delete once that lands and is released."
+    ),
+)
+def forward(
+    self,
+    input_ids: torch.Tensor | None,
+    positions: torch.Tensor,
+    intermediate_tensors: IntermediateTensors | None,
+    inputs_embeds: torch.Tensor | None = None,
+) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
+    incoming: dict[int, torch.Tensor] = {}
+    if get_pp_group().is_first_rank:
+        if inputs_embeds is not None:
+            hidden_states = inputs_embeds
+        else:
+            hidden_states = self.embed_input_ids(input_ids)
+        residual = None
+    else:
+        assert intermediate_tensors is not None
+        hidden_states = intermediate_tensors["hidden_states"]
+        residual = intermediate_tensors["residual"]
+        incoming = {
+            i: intermediate_tensors[f"{_AUX_SLOT}{i}"]
+            for i in _aux_slots_received(self)
+        }
+
+    # Index i means "input to layer i". The pre-loop capture is first-rank only:
+    # for a later stage that index is the previous stage's final capture, and
+    # taking it again would duplicate a boundary layer. Layer 31 of the 62-layer
+    # [15,16,16,15] split is exactly such a boundary.
+    aux: dict[int, torch.Tensor] = {}
+
+    def capture(index: int) -> None:
+        if index in self.aux_hidden_state_layers:
+            aux[index] = (
+                hidden_states + residual if residual is not None else hidden_states
+            )
+
+    if get_pp_group().is_first_rank:
+        capture(0)
+    for idx, layer in enumerate(islice(self.layers, self.start_layer, self.end_layer)):
+        hidden_states, residual = layer(positions, hidden_states, residual)
+        capture(self.start_layer + idx + 1)
+
+    # A received index is at or before start_layer and a local one is past it, so
+    # the two sets never collide.
+    aux.update(incoming)
+
+    if not get_pp_group().is_last_rank:
+        tensors = {"hidden_states": hidden_states, "residual": residual}
+        for i, value in aux.items():
+            tensors[f"{_AUX_SLOT}{i}"] = value
+        return IntermediateTensors(tensors)
+
+    hidden_states, _ = self.norm(hidden_states, residual)
+
+    if not self.aux_hidden_state_layers:
+        return hidden_states
+
+    missing = set(self.aux_hidden_state_layers) - aux.keys()
+    assert not missing, (
+        f"EAGLE3 aux hidden states missing for layers {sorted(missing)}; "
+        f"requested {self.aux_hidden_state_layers}, arrived {sorted(aux)}"
+    )
+    return hidden_states, [aux[i] for i in sorted(aux)]

--- a/vllm_rbln/patches/minimax_m2.py
+++ b/vllm_rbln/patches/minimax_m2.py
@@ -15,6 +15,7 @@
 from itertools import islice
 
 import torch
+from vllm.config import VllmConfig
 from vllm.distributed import get_pp_group, tensor_model_parallel_all_reduce
 from vllm.model_executor.layers.minimax_rms_norm.rms_norm_tp import (
     MiniMaxText01RMSNormTP,
@@ -24,7 +25,6 @@ from vllm.model_executor.models.minimax_m2 import (
     MiniMaxM2Model,
     MiniMaxM2MoE,
 )
-from vllm.model_executor.models.utils import make_empty_intermediate_tensors_factory
 from vllm.sequence import IntermediateTensors
 
 from vllm_rbln.patches import register_patch
@@ -117,6 +117,10 @@ def patched_minimax_m2_attention_forward(
 
 _AUX_SLOT = "aux_hidden_states_"
 
+# Captured at import time: the registry replaces targets outright, so wrapping
+# upstream behaviour means holding the original here.
+_orig_model_init = MiniMaxM2Model.__init__
+
 
 def _aux_slots_received(model: MiniMaxM2Model) -> tuple[int, ...]:
     """Global aux layer indices that reach this stage from upstream stages.
@@ -132,22 +136,36 @@ def _aux_slots_received(model: MiniMaxM2Model) -> tuple[int, ...]:
 
 
 @register_patch(
-    target="vllm.model_executor.models.minimax_m2.MiniMaxM2Model._set_aux_hidden_state_layers",
+    target="vllm.model_executor.models.minimax_m2.MiniMaxM2Model.__init__",
     reason=(
-        "Size the pipeline handoff to carry the EAGLE3 aux hidden states. The "
-        "handoff key set is fixed in __init__, but the aux layers are only known "
-        "once the model runner calls this setter, so the factory has to be rebuilt "
-        "here. Upstream has no hook between the two. "
+        "Size the pipeline handoff to carry the EAGLE3 aux hidden states. Upstream "
+        "fixes the handoff key set here, but the aux layers are only known later, "
+        "when the model runner calls set_aux_hidden_state_layers -- and rebuilding "
+        "the attribute then is too late: MiniMaxM2ForCausalLM.__init__ copies this "
+        "callable onto itself, and the runner calls that copy. Read the key set at "
+        "call time instead, so the copy stays correct. "
         "TODO(vllm-project/vllm#50514): delete once that lands and is released."
     ),
 )
-def _set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
-    self.aux_hidden_state_layers = layers
-    keys = ["hidden_states", "residual"]
-    keys += [f"{_AUX_SLOT}{i}" for i in _aux_slots_received(self)]
-    self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
-        keys, self.config.hidden_size
-    )
+def patched_minimax_m2_model_init(
+    self, *, vllm_config: VllmConfig, prefix: str = ""
+) -> None:
+    _orig_model_init(self, vllm_config=vllm_config, prefix=prefix)
+
+    def make_empty_intermediate_tensors(
+        batch_size: int, dtype: torch.dtype, device: torch.device
+    ) -> IntermediateTensors:
+        keys = ["hidden_states", "residual"]
+        keys += [f"{_AUX_SLOT}{i}" for i in _aux_slots_received(self)]
+        hidden_size = self.config.hidden_size
+        return IntermediateTensors(
+            {
+                key: torch.zeros((batch_size, hidden_size), dtype=dtype, device=device)
+                for key in keys
+            }
+        )
+
+    self.make_empty_intermediate_tensors = make_empty_intermediate_tensors
 
 
 @register_patch(

--- a/vllm_rbln/patches/speculative_config.py
+++ b/vllm_rbln/patches/speculative_config.py
@@ -1,0 +1,55 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Keep the draft model off the target's pipeline-parallel split.
+
+Upstream copies the target's `pipeline_parallel_size` onto the draft, which then
+fails `ModelConfig.verify_with_parallel_config`: the EAGLE3 draft head does not
+satisfy `SupportsPP`, because its `forward` takes no `intermediate_tensors`. The
+draft only ever runs on the last stage -- `RBLNModelRunner` already constructs it
+under `get_pp_group().is_last_rank` -- so inheriting the split describes a
+topology that never exists.
+
+`ParallelConfig` derives `world_size` in its validator, so the size has to be
+right at construction; there is no field to correct afterwards.
+"""
+
+from vllm.config import ParallelConfig
+
+from vllm_rbln.patches import register_patch
+
+
+@register_patch(
+    target="vllm.config.SpeculativeConfig.create_draft_parallel_config",
+    reason=(
+        "Upstream gives the draft the target's pipeline_parallel_size, so a "
+        "pipeline-parallel target rejects every EAGLE-family draft head at config "
+        "validation -- the heads implement no intermediate_tensors forward and so "
+        "fail SupportsPP. Upstream cannot express 'this submodel runs on one stage' "
+        "any other way; the field is the topology. "
+        "TODO(vllm-project/vllm#50514): delete once that lands and is released."
+    ),
+)
+def create_draft_parallel_config(
+    target_parallel_config: ParallelConfig,
+    speculative_draft_tensor_parallel_size: int,
+) -> ParallelConfig:
+    return ParallelConfig(
+        pipeline_parallel_size=1,
+        tensor_parallel_size=speculative_draft_tensor_parallel_size,
+        distributed_executor_backend=target_parallel_config.distributed_executor_backend,
+        max_parallel_loading_workers=target_parallel_config.max_parallel_loading_workers,
+        disable_custom_all_reduce=target_parallel_config.disable_custom_all_reduce,
+        ray_workers_use_nsight=target_parallel_config.ray_workers_use_nsight,
+        placement_group=target_parallel_config.placement_group,
+    )

--- a/vllm_rbln/platform.py
+++ b/vllm_rbln/platform.py
@@ -333,6 +333,8 @@ class RblnPlatform(Platform):
                     max_num_seqs // pp_size,
                 )
 
+                cls._validate_eagle3_pp_config(vllm_config)
+
             # FIXME(jiwoo.park) This is a temporary workaround.
             if model_config.enforce_eager:
                 if not USE_DEVICE_TENSOR:
@@ -435,6 +437,44 @@ class RblnPlatform(Platform):
                 ),
                 parallel_config.distributed_executor_backend,
             )
+
+    @staticmethod
+    def _validate_eagle3_pp_config(vllm_config: VllmConfig) -> None:
+        """Reject an EAGLE3 target whose aux collection is not pipeline-aware.
+
+        Called only when `pipeline_parallel_size > 1`. Upstream's model `forward`
+        indexes the aux capture with a stage-local `enumerate` and drops the list
+        on every non-last stage, so a target outside `EAGLE3_PP_TARGET_ARCHS`
+        harvests the wrong layers and reaches the drafter short. That surfaces as a
+        shape mismatch mid-compile, or -- where the counts happen to line up -- not
+        at all, as a silently worse draft.
+
+        TODO(vllm-project/vllm#50514): delete once that lands and is released.
+        """
+        from vllm_rbln.v1.spec_decode.eagle3_pp import (
+            EAGLE3_PP_TARGET_ARCHS,
+            eagle3_aux_hidden_states_enabled,
+        )
+
+        # A draft with `use_aux_hidden_state` off captures nothing, so upstream's
+        # forward is harmless and the split is fine.
+        if not eagle3_aux_hidden_states_enabled(vllm_config.speculative_config):
+            return
+
+        architectures = vllm_config.model_config.hf_config.architectures or []
+        if set(architectures) & EAGLE3_PP_TARGET_ARCHS:
+            return
+
+        raise ValueError(
+            "EAGLE3 with pipeline_parallel_size="
+            f"{vllm_config.parallel_config.pipeline_parallel_size} is supported on "
+            f"RBLN only for target architectures "
+            f"{sorted(EAGLE3_PP_TARGET_ARCHS)}, but got {list(architectures)}. "
+            "Collecting the target's auxiliary hidden states across pipeline "
+            "stages needs a per-architecture patch that this target does not have "
+            "yet. Run this target with pipeline_parallel_size=1, or with a draft "
+            "whose eagle_config sets use_aux_hidden_state=false."
+        )
 
     @staticmethod
     def _validate_dynamic_kv_config(vllm_config: VllmConfig) -> None:

--- a/vllm_rbln/v1/spec_decode/eagle3_pp.py
+++ b/vllm_rbln/v1/spec_decode/eagle3_pp.py
@@ -1,0 +1,147 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Carrying EAGLE3 aux hidden states across a pipeline split.
+
+Everything here is architecture-independent: the slot naming, which indices a
+stage receives versus captures, and the handoff placeholder that has to advertise
+them. Only the capture itself is not, because it lives inside a model's `forward`
+and the tensors have to be graph outputs of that forward -- see
+`vllm_rbln/patches/minimax_m2.py` for the one architecture that has it.
+
+TODO(vllm-project/vllm#50514): delete once that lands and is released.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+from vllm.config import SpeculativeConfig
+from vllm.distributed import get_pp_group
+from vllm.sequence import IntermediateTensors
+
+# Target architectures whose `forward` this plugin has patched to carry the aux
+# hidden states across the split. Upstream's own forward indexes the capture with
+# a stage-local `enumerate` and then drops the list on every non-last stage, so an
+# architecture absent from here harvests the wrong layers and comes up short at
+# the drafter. `RblnPlatform.check_and_update_config` rejects the combination
+# rather than letting it fail mid-compile.
+EAGLE3_PP_TARGET_ARCHS = frozenset({"MiniMaxM2ForCausalLM"})
+
+AUX_SLOT = "aux_hidden_states_"
+
+
+def eagle3_aux_hidden_states_enabled(
+    speculative_config: SpeculativeConfig | None,
+) -> bool:
+    """Whether an EAGLE3 draft consumes the target's aux hidden states.
+
+    A draft can turn them off in its `eagle_config`, and then nothing is captured
+    anywhere: `aux_hidden_state_layers` stays empty, so upstream's unpatched
+    forward is harmless under a pipeline split. The model runner and the startup
+    guard both have to agree on this, hence a single reader.
+
+    Read from the config rather than from the drafter, which exists only on the
+    last rank. Every stage has to know: the aux tensors are captured across the
+    stages and consumed only on the last one, so a non-last stage that thinks
+    EAGLE3 is off captures nothing and the last stage comes up short.
+    """
+    if speculative_config is None or speculative_config.method != "eagle3":
+        return False
+    eagle_config = getattr(
+        speculative_config.draft_model_config.hf_config, "eagle_config", None
+    )
+    if not isinstance(eagle_config, dict):
+        return True
+    return bool(eagle_config.get("use_aux_hidden_state", True))
+
+
+def aux_capture_module(model: nn.Module) -> nn.Module:
+    """The module that owns the capture state, resolved as upstream resolves it.
+
+    Mirrors `SupportsEagle3.set_aux_hidden_state_layers`, so the state this module
+    reads is the state the runner's setter wrote.
+    """
+    parent = model
+    if hasattr(model, "get_language_model"):
+        parent = model.get_language_model()
+    elif hasattr(model, "language_model"):
+        parent = model.language_model
+    return parent.model
+
+
+def aux_slots_received(model: nn.Module) -> tuple[int, ...]:
+    """Global aux layer indices that reach this stage from upstream stages.
+
+    A capture at index ``i`` is the input to layer ``i``, so this stage receives
+    every requested index at or before its first owned layer. On the first stage
+    the set is empty: index ``start_layer == 0`` is captured locally from the
+    embedding output.
+    """
+    if get_pp_group().is_first_rank:
+        return ()
+    return tuple(
+        sorted(i for i in model.aux_hidden_state_layers if i <= model.start_layer)
+    )
+
+
+def aux_slots_captured(model: nn.Module) -> tuple[int, ...]:
+    """Global aux layer indices this stage produces, in the order it produces them.
+
+    The loop captures at ``start_layer + idx + 1`` for each owned layer, so the
+    reachable indices are ``start_layer + 1 .. end_layer``; the first stage adds
+    index 0 from the embedding output. Every index is a compile-time constant, so
+    deriving the order here keeps it out of the traced graph -- the capture itself
+    appends to a list and never keys a dict inside the loop.
+
+    Together with `aux_slots_received` this partitions the requested set: received
+    indices are at or before ``start_layer``, captured ones past it. Received then
+    captured is therefore already ascending, which is the order the drafter's `fc`
+    expects its concatenated blocks in.
+    """
+    captured = [
+        i
+        for i in sorted(model.aux_hidden_state_layers)
+        if model.start_layer < i <= model.end_layer
+    ]
+    if get_pp_group().is_first_rank and 0 in model.aux_hidden_state_layers:
+        captured.insert(0, 0)
+    return tuple(captured)
+
+
+def install_aux_handoff_slots(model: nn.Module) -> None:
+    """Size the pipeline handoff to carry the aux hidden states.
+
+    Rebind rather than patch a model's `__init__`: the aux layers are only known
+    once the runner calls `set_aux_hidden_state_layers`, and the key set has to be
+    read at call time regardless, because a model's `__init__` builds this callable
+    from a key list fixed at construction. Bind it on the object the runner calls
+    -- `ForCausalLM.__init__` copies the inner model's callable onto itself, and
+    the runner calls that copy.
+    """
+    inner = aux_capture_module(model)
+    hidden_size = inner.config.hidden_size
+
+    def make_empty_intermediate_tensors(
+        batch_size: int, dtype: torch.dtype, device: torch.device
+    ) -> IntermediateTensors:
+        keys = ["hidden_states", "residual"]
+        keys += [f"{AUX_SLOT}{i}" for i in aux_slots_received(inner)]
+        return IntermediateTensors(
+            {
+                key: torch.zeros((batch_size, hidden_size), dtype=dtype, device=device)
+                for key in keys
+            }
+        )
+
+    model.make_empty_intermediate_tensors = make_empty_intermediate_tensors

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -292,7 +292,6 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         # indexes: [kv_cache_group_id][attn_group]
         self.attn_groups: list[list[AttentionGroup]] = []
 
-        self.use_aux_hidden_state_outputs = False
         # Set up speculative decoding.
         # NOTE(Jiayi): We put the entire draft model on the last PP rank.
         # This is not ideal if there are many layers in the draft model.

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -131,6 +131,10 @@ from vllm_rbln.v1.core.utils import (
 from vllm_rbln.v1.sample.rbln_logits_processor import build_rbln_logitsprocs
 from vllm_rbln.v1.sample.rbln_rejection_sampler import RBLNRejectionSampler
 from vllm_rbln.v1.spec_decode.eagle import RBLNEagleProposer
+from vllm_rbln.v1.spec_decode.eagle3_pp import (
+    eagle3_aux_hidden_states_enabled,
+    install_aux_handoff_slots,
+)
 from vllm_rbln.v1.spec_decode.medusa import RBLNMedusaProposer
 from vllm_rbln.v1.worker import mega_cache
 from vllm_rbln.v1.worker.bucketing import get_bucketing_manager
@@ -299,22 +303,9 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             | SuffixDecodingProposer
             | None
         ) = None
-        # Read the EAGLE3 aux-hidden-state flag from the config rather than from
-        # the drafter, which exists only on the last rank. Every stage has to know
-        # it: the aux tensors are captured across the stages and only consumed on
-        # the last one, so a non-last stage that thinks EAGLE3 is off captures
-        # nothing and the last stage comes up short.
-        if self.speculative_config and self.speculative_config.method == "eagle3":
-            eagle_config = getattr(
-                self.speculative_config.draft_model_config.hf_config,
-                "eagle_config",
-                None,
-            )
-            self.use_aux_hidden_state_outputs = (
-                True
-                if not isinstance(eagle_config, dict)
-                else eagle_config.get("use_aux_hidden_state", True)
-            )
+        self.use_aux_hidden_state_outputs = eagle3_aux_hidden_states_enabled(
+            self.speculative_config
+        )
 
         if self.speculative_config and get_pp_group().is_last_rank:
             if self.speculative_config.method == "ngram":
@@ -1819,6 +1810,10 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 aux_layers = self.model.get_eagle3_default_aux_hidden_state_layers()
 
             self.model.set_aux_hidden_state_layers(aux_layers)
+            # The handoff placeholder has to advertise the aux slots this stage
+            # expects, and the layers are only known here. A no-op at PP=1, where
+            # a stage receives nothing.
+            install_aux_handoff_slots(self.model)
 
         self._make_weights_contiguous()
 

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -299,6 +299,23 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             | SuffixDecodingProposer
             | None
         ) = None
+        # Read the EAGLE3 aux-hidden-state flag from the config rather than from
+        # the drafter, which exists only on the last rank. Every stage has to know
+        # it: the aux tensors are captured across the stages and only consumed on
+        # the last one, so a non-last stage that thinks EAGLE3 is off captures
+        # nothing and the last stage comes up short.
+        if self.speculative_config and self.speculative_config.method == "eagle3":
+            eagle_config = getattr(
+                self.speculative_config.draft_model_config.hf_config,
+                "eagle_config",
+                None,
+            )
+            self.use_aux_hidden_state_outputs = (
+                True
+                if not isinstance(eagle_config, dict)
+                else eagle_config.get("use_aux_hidden_state", True)
+            )
+
         if self.speculative_config and get_pp_group().is_last_rank:
             if self.speculative_config.method == "ngram":
                 self.drafter = NgramProposer(self.vllm_config)
@@ -308,10 +325,6 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 self.drafter = RBLNMedusaProposer(self.vllm_config, self.device)
             elif self.speculative_config.use_eagle():
                 self.drafter = RBLNEagleProposer(self.vllm_config, self.device, self)
-                if self.speculative_config.method == "eagle3":
-                    self.use_aux_hidden_state_outputs = (
-                        self.drafter.eagle3_use_aux_hidden_state
-                    )
             else:
                 raise ValueError(
                     "Unsupported speculative decoding method: "
@@ -1829,7 +1842,10 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             )
 
             logits = None
-            if self.use_aux_hidden_state_outputs:
+            # Only the last stage gets the aux tensors as a second return value;
+            # earlier stages carry them inside the IntermediateTensors handoff, which
+            # is model_output itself.
+            if self.use_aux_hidden_state_outputs and get_pp_group().is_last_rank:
                 hidden_states, aux_hidden_states = model_output
             else:
                 hidden_states = model_output
@@ -1857,8 +1873,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             # NOTE(RBLN): When eagle3 and aux hidden states are used,
             # fuse combine_hidden_states projection into the target graph.
             combined_hidden_states = None
-            if self.use_aux_hidden_state_outputs:
-                assert aux_hidden_states is not None
+            if aux_hidden_states is not None:
                 assert isinstance(self.drafter, RBLNEagleProposer)
                 target_hidden_states = torch.cat(
                     [h.view(-1, h.shape[-1]) for h in aux_hidden_states], dim=-1


### PR DESCRIPTION
## What

Makes EAGLE3 work when a MiniMax-M2 target runs pipeline-parallel, which is what a P/D deployment needs: the drafter lives on the last stage, and the aux hidden states it consumes come from layers spread across every stage.

`--speculative-config` has to be on the prefill role too, not just decode. The drafter keeps its own KV cache and the only thing that fills its prompt region is a prefill forward — `llm_base_proposer.py`'s comment sits in the `num_speculative_tokens == 0` branch, i.e. the draft forward runs even when zero draft tokens are requested, precisely to keep that cache in sync. Since `validate_same_kv_cache_group` places the draft's attention layers in `kv_cache_config.kv_cache_groups`, that cache is a full member of what NIXL registers and transfers. Upstream `vllm-project/vllm#39266` puts `--speculative-config` on its prefill role for the same reason.

## Scope

One (target, draft) pair is claimed: a **MiniMax-M2** target with an `Eagle3MiniMaxM2ForCausalLM` draft, which vLLM maps to `llama_eagle3`'s `Eagle3LlamaForCausalLM`. Anything else is rejected at startup rather than left to fail mid-compile: `RblnPlatform._validate_eagle3_pp_config` raises for a pipeline-parallel EAGLE3 target outside `EAGLE3_PP_TARGET_ARCHS`. A draft whose `eagle_config` sets `use_aux_hidden_state=false` is exempt, and has to be — nothing is captured anywhere then, `aux_hidden_state_layers` stays empty, and upstream's unpatched forward is harmless under the split. Rejecting that would block a configuration that works.

The halves of the fix have different reach, and only one of them is architecture-bound.

**Naming the EAGLE head** (`patches/llama_eagle3.py`) applies to every draft that resolves to `llama_eagle3.Eagle3LlamaForCausalLM`, which is most EAGLE3 checkpoints — the stock `yuhuili/EAGLE3-LLaMA3.1-Instruct-8B` (`LlamaForCausalLMEagle3`) included. The `deepseek_eagle3` and `qwen3_eagle3` heads carry the identical defect and are not patched.

**Carrying the aux states across stages** is split by what is actually architecture-bound. The slot naming, which indices a stage receives versus captures, the handoff placeholder, and the single reader for the draft's `use_aux_hidden_state` flag live in `v1/spec_decode/eagle3_pp.py` and are architecture-independent. What stays in `patches/minimax_m2.py` is the `forward` body alone: the captured tensors have to be graph outputs of the forward that produced them, so stashing them on the module and merging outside is the same class of thing that broke the graph in *Two things that surprised us*. Adding the next architecture is that body, not another copy of the mechanism.

The handoff placeholder is rebound where the aux layers become known — `set_aux_hidden_state_layers` in the runner's `load_model` — rather than by patching a model's `__init__`. `ForCausalLM.__init__` copies the inner model's callable onto itself and the runner calls that copy, so the installer binds it there and reads the key set at call time. At PP=1 a stage receives nothing, so it is a no-op.

The guard raises rather than warns because of how the unguarded case fails. The requested capture indices are global — `(2, num_layers // 2, num_layers - 3)` off the PPMissingLayer-padded list, so `(2, 16, 29)` for Llama-3.1-8B — while a stage matches them against its own `enumerate`, which restarts at zero. At PP=2 stage 1 owns 16..31 and therefore harvests global 18 and 32 and never sees 29, and stage 0, which did capture 2 and 16 correctly, drops them at the handoff. Two tensors reach an `fc` sized for three, and the shape mismatch surfaces mid-compile. Where the counts happen to line up the same confusion is silent: the drafter is fed the wrong layers, compiles, passes a short probe, and only loses acceptance rate.

Fifteen model files in vLLM share the defective pattern — `_maybe_add_hidden_state([], 0, ...)` plus `idx + 1` off a stage-local `enumerate`, then a non-last-rank return that drops the list — and `llama.py` is one of them. Fixing the index half once in `EagleModelMixin` is possible and is deliberately not done: it corrects which layer each capture is, but the captures still never cross a stage boundary, so no additional target starts working. On the case above it turns two wrong tensors into one right one, which still cannot fill three, and the guard rejects that configuration before it runs. Upstream #50514 fixes both halves in the mixin and has each model opt in; this branch aims to be what gets deleted when that lands.

## Why these shapes

Two facts drive most of the diff.

**A capture index is global, and an aux tensor has to survive the handoff.** Index `i` means "input to layer `i`", so a stage's incoming hidden state carries the same index as the previous stage's final capture — taking both would duplicate a boundary layer. Received indices are at or before `start_layer` and captured ones past it, so received-then-captured is already ascending, which is the order the drafter's `fc` expects its concatenated blocks in. Getting that order wrong corrupts output rather than failing.

**The EAGLE head has to be named past the target's full depth.** `pipeline_adjusted_layer_index` (added for MTP/nextn in #980) already routes a layer named past the target's layer count to `(end - start) + offset`, which is where its KV cache sits in the compacted per-rank list — and an EAGLE3 head belongs to that same class. Upstream names it with `start_layer_id=get_num_layers(parallel_config)`, the count on *this* rank, so it lands below the threshold and is treated as a target layer. With PP=1 the per-rank count already equals the full depth, which is why this is invisible until a rank that does not start at zero — the rank the drafter lives on. Renaming also makes the name identical on a prefill and a decode instance, which is what NIXL matches KV regions by.

## What is deliberately not patched

An earlier revision of this branch also patched `Eagle3LlamaForCausalLM.__init__`/`load_weights`/`compute_logits` to keep the draft->target scatter index a named buffer. That defect is real — the index is input-independent, so it const-folds into an anonymous constant that weight-free apply cannot resolve by name, and the out-of-bounds host-op write segfaults in KV warmup. But `RBLNEagleProposer` already avoids it (#831): it stays in draft-vocab space and maps ids after the argmax, so upstream's `compute_logits` is never the path that runs. Those three patches have been dropped and the module docstring records where the real fix lives.

They survived the rebase because they patch the model while #831 fixed the proposer, so git had nothing to conflict on and the suite stayed green. A patch that is merely harmless is still a patch: it asserts something about upstream that has stopped being true. **After a rebase, "no conflict" is not evidence that a patch is still needed** — that has to be checked separately.

## Two things that surprised us

**Keying a dict by a tensor index inside the layer loop breaks the graph at that statement.** The backend then receives the residual-stream add on its own, as two no-op bf16 casts, and rejects it while *registering* the module rather than while compiling it — so the error names neither a layer nor an op. Factoring the capture into a closure does the same thing, because dynamo lifts the captured variables into arguments instead of inlining. Upstream appends to a list, and this is plausibly why. `vllm_rbln/compilation/backends.py`'s own log is what showed it: its `caller=` field names the code that produced each graph, and a split shows up as anonymous input names (`l_x_0_`) instead of real ones.

**The draft and the target are named against different origins,** and #980 had already solved this for MTP/nextn before we got here. Recognising that the EAGLE3 head is the same class of layer replaced what had been a separate index rule on our side, so this branch renames the head — and moves `target_layer_count` with the name — and leaves `pipeline_adjusted_layer_index` untouched. Deriving the head's index by arithmetic on its own name does not work: subtracting the rank's start goes negative off stage 0, and subtracting the rank's layer count is right *only* on stage 0.

## Verification

Four PP4 runs on the device, one per configuration worth separating. Every one of them registers 15/16/16/16 KV layers, raises no aux-slot `KeyError`, and moves the spec-decode counters consistently (`draft tokens = proposing steps x num_spec`): M2.5 with the drafter's own `(1, 30, 58)`; M2.5 with `(2, 31, 59)`; then M2.7 and M2.1, which share MiniMax-M2.5's depth, hidden size and vocabulary, so they re-run the same split against different weights. Their acceptance counts are not evidence of anything — the only drafter available is M2.5's — but the handoff, the KV registration and the counters are.

**The `(2, 31, 59)` run is the one that earns its place.** 31 is stage 2's `start_layer` on the `[15, 16, 16, 15]` split, so it is both stage 1's last capture and stage 2's incoming hidden state — the index that an off-by-one in the split double-counts or drops. The drafter is byte-identical to M2.5's (same `model.safetensors` md5); only the aux ids in its config differ, so the run moves one variable. Its greedy output is identical to the `(1, 30, 58)` run's. Speculative decoding is lossless, so the target's output cannot depend on which layers the drafter reads: had the boundary been mishandled, the drafter would have been fed a different hidden state, proposed differently, and the verified tokens would have diverged. None of the other three aux sets touches a boundary at all.

The startup guard was exercised through the CLI rather than only through its own unit test: a Qwen3-1.7B target with an EAGLE3 draft at PP=2 is rejected before any compilation begins.

A 1P1D probe passes with the transfer path and the local path producing the same output. That probe predates the refactor above, and the one thing it uniquely covers — NIXL matching KV regions by name — is unaffected by it: `get_total_num_hidden_layers()` and `hf_text_config.num_hidden_layers` return the same 62 for this target, which has no arch-config convertor of its own, so the head's name is unchanged.

The layer naming was checked directly rather than inferred: on the 62-layer PP4 split the prefill instance registers 15/16/16/**16** KV layers across its stages — 63 in total, one more than the target's depth — and the decode instance registers 63 per rank. Stage 3 owns 15 target layers and registers 16, which is the head landing after them rather than sorting in among them. Both instances therefore agree on the name, which is what NIXL matches regions by.

## Tests

`tests/native/patches/test_minimax_m2.py` drives all four stages sequentially in one process with stub layers that stamp their own global index into what they return, so a stage-local index shows up as a wrong number rather than as a shape that still happens to fit. Bands come from the real `get_pp_indices`, and the handoff placeholder goes in through `install_aux_handoff_slots` on an outer object that owns the copy, which is the shape the runner calls.

The aux sets it runs are parametrized, and one of them puts every index exactly on a PP4 band boundary. A boundary index is both one stage's last capture and the next stage's incoming hidden state, so an off-by-one in the split double-counts all three at once — and compiles, and passes a short probe. Widening the capture range by one fails exactly that case and leaves the other eleven green.

`tests/native/v1/spec_decode/test_eagle3_pp.py` covers the guard and the flag reader: a supported target passes, an unsupported one raises, an unsupported one with aux off passes, and no non-EAGLE3 method is gated. It also asserts every allowlisted architecture actually has a non-upstream `forward`, so the allowlist cannot claim a target the patch does not cover.

`tests/native/patches/test_llama_eagle3.py` pins the head's name to the target's full depth on every rank, keeps `target_layer_count` equal to it, and checks against `pipeline_adjusted_layer_index` that the named head lands after every target layer on each of the four ranks rather than sorting in among them.

Config objects and stubs only — no checkpoint, no device.

## Rebased onto dev

`#980` landed the MTP/nextn KV index rule while this was in progress. That rule covers the EAGLE3 head once the head is named past the target's full depth, so the index handling this branch previously carried in `patches/attention.py` is gone and `pipeline_adjusted_layer_index` is used as-is.
