### PR TITLE
fix(optimum): make prompt_logprobs work on the optimum path

### DIFF
--- a/vllm_rbln/v1/worker/optimum_model_runner.py
+++ b/vllm_rbln/v1/worker/optimum_model_runner.py
@@ -1617,20 +1617,6 @@ class RBLNOptimumModelRunner(
         prefill_logits: torch.Tensor,
         scheduler_output: "SchedulerOutput",
     ) -> dict[str, LogprobsTensors | None]:
-        """Prompt logprobs for the request prefilled in this step.
-
-        Upstream indexes a flattened token batch, offsetting into it per request
-        and accumulating one chunk per step. Neither applies here. This path
-        never schedules a prefill alongside another request and submits the whole
-        prompt in one call, so one request's logits fill ``prefill_logits`` from
-        row 0 and the result is complete after a single step. A request asking
-        for prompt logprobs also never reads the prefix cache
-        (``Request.skip_reading_prefix_cache``), so row i is prompt position i.
-
-        ``prefill_logits`` carries a row per prompt position only when the model
-        was compiled with ``logits_to_keep=0``; the default of 1 returns just the
-        last position and cannot serve this at all.
-        """
         if not self.num_prompt_logprobs:
             return {}
 

--- a/vllm_rbln/v1/worker/optimum_model_runner.py
+++ b/vllm_rbln/v1/worker/optimum_model_runner.py
@@ -108,7 +108,6 @@ class ExecuteModelState(NamedTuple):
     scheduler_output: "SchedulerOutput"
     logits: torch.Tensor
     hidden_states: torch.Tensor
-    sample_hidden_states: torch.Tensor
     is_prompt: bool
     ec_connector_output: "ECConnectorOutput | None" = None
 
@@ -417,22 +416,22 @@ class RBLNOptimumModelRunner(
                         token_count=0,
                         # the performance of sampler doesn't depend on token count
                     )
-                sample_hidden_states = hidden_states.clone()
 
             with record_function_or_nullcontext("rbln_model_runner: postprocess"):
                 if self.is_pooling_model:
                     return self._pool(
                         hidden_states, num_scheduled_tokens, num_scheduled_tokens_np
                     )
-                # [batch_size, 1, vocab_size] -> [batch_size, vocab_size]
-                hidden_states = hidden_states.squeeze(1)
-                logits = self.model.compute_logits(hidden_states, None)
+                # A prefill graph compiled with logits_to_keep=0 returns one
+                # row per prompt position instead of one row per request, and
+                # only the last of those rows is the token being sampled.
+                # [batch_size, num_positions, vocab_size] -> [batch_size, vocab_size]
+                logits = self.model.compute_logits(hidden_states[:, -1, :], None)
 
         self.execute_model_state = ExecuteModelState(
             scheduler_output=scheduler_output,
             logits=logits,
             hidden_states=hidden_states,
-            sample_hidden_states=sample_hidden_states,
             is_prompt=model_input.is_prompt,
             ec_connector_output=ec_connector_output,
         )
@@ -1349,7 +1348,6 @@ class RBLNOptimumModelRunner(
         sampler_output: SamplerOutput,
         logits: torch.Tensor | None,
         hidden_states: torch.Tensor,
-        num_scheduled_tokens: int,
         use_padding: bool,
         spec_decode_metadata: SpecDecodeMetadata | None,
     ) -> tuple[
@@ -1426,8 +1424,7 @@ class RBLNOptimumModelRunner(
 
         # Compute prompt logprobs if needed.
         prompt_logprobs_dict = self._get_prompt_logprobs_dict(
-            hidden_states[:num_scheduled_tokens],
-            scheduler_output.num_scheduled_tokens,
+            hidden_states, scheduler_output
         )
 
         return (
@@ -1517,7 +1514,6 @@ class RBLNOptimumModelRunner(
             scheduler_output,
             logits,
             hidden_states,
-            sample_hidden_states,
             is_prompt,
             ec_connector_output,
         ) = self.execute_model_state
@@ -1579,7 +1575,6 @@ class RBLNOptimumModelRunner(
                 sampler_output,
                 logits,
                 hidden_states,
-                scheduler_output.total_num_scheduled_tokens,
                 use_padding,
                 spec_decode_metadata=None,
             )
@@ -1619,105 +1614,58 @@ class RBLNOptimumModelRunner(
 
     def _get_prompt_logprobs_dict(
         self,
-        hidden_states: torch.Tensor,
-        num_scheduled_tokens: dict[str, int],
+        prefill_logits: torch.Tensor,
+        scheduler_output: "SchedulerOutput",
     ) -> dict[str, LogprobsTensors | None]:
-        num_prompt_logprobs_dict = self.num_prompt_logprobs
-        if not num_prompt_logprobs_dict:
+        """Prompt logprobs for the request prefilled in this step.
+
+        Upstream indexes a flattened token batch, offsetting into it per request
+        and accumulating one chunk per step. Neither applies here. This path
+        never schedules a prefill alongside another request and submits the whole
+        prompt in one call, so one request's logits fill ``prefill_logits`` from
+        row 0 and the result is complete after a single step. A request asking
+        for prompt logprobs also never reads the prefix cache
+        (``Request.skip_reading_prefix_cache``), so row i is prompt position i.
+
+        ``prefill_logits`` carries a row per prompt position only when the model
+        was compiled with ``logits_to_keep=0``; the default of 1 returns just the
+        last position and cannot serve this at all.
+        """
+        if not self.num_prompt_logprobs:
             return {}
 
         prompt_logprobs_dict: dict[str, LogprobsTensors | None] = {}
-
-        # Since prompt logprobs are a rare feature, prioritize simple,
-        # maintainable loop over optimal performance.
-        completed_prefill_reqs = []
-        for req_id, num_prompt_logprobs in num_prompt_logprobs_dict.items():
-            num_tokens = num_scheduled_tokens.get(req_id)
-            if num_tokens is None:
-                # This can happen if the request was preempted in prefill stage.
+        for req_id in scheduler_output.num_scheduled_tokens:
+            num_prompt_logprobs = self.num_prompt_logprobs.pop(req_id, None)
+            if num_prompt_logprobs is None:
                 continue
 
-            # Get metadata for this request.
             request = self.requests[req_id]
             if request.prompt_token_ids is None:
-                # Prompt logprobs is incompatible with prompt embeddings
+                # Prompt logprobs is incompatible with prompt embeddings.
                 continue
 
             num_prompt_tokens = len(request.prompt_token_ids)
-            prompt_token_ids = torch.tensor(request.prompt_token_ids).to(
-                self.device, non_blocking=True
-            )
-
-            # Set up target LogprobsTensors object.
-            logprobs_tensors = request.in_progress_prompt_logprobs_cpu
-            if logprobs_tensors is None:
-                # Create empty logprobs CPU tensors for the entire prompt.
-                # If chunked, we'll copy in slice by slice.
-                logprobs_tensors = LogprobsTensors.empty_cpu(
-                    num_prompt_tokens - 1, num_prompt_logprobs + 1
+            num_positions = prefill_logits.shape[1]
+            if num_positions != num_prompt_tokens:
+                raise ValueError(
+                    "prompt_logprobs needs a logit for every prompt position, "
+                    f"but the prefill graph returned {num_positions} row(s) for "
+                    f"{num_prompt_tokens} prompt tokens. Compile the model with "
+                    "logits_to_keep=0 so it keeps all of them."
                 )
-                request.in_progress_prompt_logprobs_cpu = logprobs_tensors
 
-            # Determine number of logits to retrieve.
-            start_idx = request.num_computed_tokens
-            start_tok = start_idx + 1
-            num_remaining_tokens = num_prompt_tokens - start_tok
-            if num_tokens <= num_remaining_tokens:
-                # This is a chunk, more tokens remain.
-                # In the == case, there are no more prompt logprobs to produce
-                # but we want to defer returning them to the next step where we
-                # have new generated tokens to return.
-                num_logits = num_tokens
-            else:
-                # This is the last chunk of prompt tokens to return.
-                num_logits = num_remaining_tokens
-                completed_prefill_reqs.append(req_id)
-                prompt_logprobs_dict[req_id] = logprobs_tensors
-
-            if num_logits <= 0:
-                # This can happen for the final chunk if we prefilled exactly
-                # (num_prompt_tokens - 1) tokens for this request in the prior
-                # step. There are no more prompt logprobs to produce.
-                continue
-
-            # Get the logits corresponding to this req's prompt tokens.
-            # If this is a partial request (i.e. chunked prefill),
-            # then there is prompt logprob generated for each index.
-            req_idx = self.input_batch.req_id_to_index[req_id]
-            offset = self.query_start_loc.np[req_idx].item()
-            prompt_hidden_states = hidden_states[offset : offset + num_logits]
-            logits = self.model.compute_logits(prompt_hidden_states)
-
-            # Get the "target" tokens for each index. For prompt at index i,
-            # the token at prompt index i+1 is the "sampled" token we want
-            # to gather the logprob for.
-            tgt_token_ids = prompt_token_ids[start_tok : start_tok + num_logits]
-
-            # Compute prompt logprobs.
-            logprobs = self.sampler.compute_logprobs(logits)
-            token_ids, logprobs, ranks = self.sampler.gather_logprobs(
-                logprobs, num_prompt_logprobs, tgt_token_ids
+            # The logit at position i predicts prompt token i + 1, so the last
+            # position has no target and the first token has no logprob.
+            logits = self.model.compute_logits(prefill_logits[0, :-1], None)
+            target_token_ids = torch.tensor(
+                request.prompt_token_ids[1:], dtype=torch.int64
+            ).to(self.device, non_blocking=True)
+            prompt_logprobs_dict[req_id] = self.sampler.gather_logprobs(
+                self.sampler.compute_logprobs(logits),
+                num_prompt_logprobs,
+                target_token_ids,
             )
-
-            # Transfer GPU->CPU async.
-            chunk_slice = slice(start_idx, start_idx + num_logits)
-            logprobs_tensors.logprob_token_ids[chunk_slice].copy_(
-                token_ids, non_blocking=True
-            )
-            logprobs_tensors.logprobs[chunk_slice].copy_(logprobs, non_blocking=True)
-            logprobs_tensors.selected_token_ranks[chunk_slice].copy_(
-                ranks, non_blocking=True
-            )
-
-        # Remove requests that have completed prefill from the batch
-        # num_prompt_logprobs_dict.
-        for req_id in completed_prefill_reqs:
-            del num_prompt_logprobs_dict[req_id]
-            self.requests[req_id].in_progress_prompt_logprobs_cpu = None
-
-        # Must synchronize the non-blocking GPU->CPU transfers.
-        # if prompt_logprobs_dict:
-        #     self._sync_device()
 
         return prompt_logprobs_dict
 


### PR DESCRIPTION
### 🚀 Summary of Changes

`prompt_logprobs` has never worked on the optimum-rbln path. `_get_prompt_logprobs_dict` was copied from upstream `GPUModelRunner` during the vllm 0.13.0 bump and never adapted, so any request that set it killed the engine:

```
File "vllm_rbln/v1/worker/optimum_model_runner.py", line 1687, in _get_prompt_logprobs_dict
    offset = self.query_start_loc.np[req_idx].item()
AttributeError: 'RBLNOptimumModelRunner' object has no attribute 'query_start_loc'
```

`query_start_loc` only exists on the native runner. The next line would have failed too — it calls `compute_logits` with one argument where this path takes two.

Most of what upstream does is machinery this path does not need:

* It offsets into a flattened token batch because a step mixes requests. Here `_prepare_inputs` refuses to schedule a prefill alongside anything else, so the one request's logits start at row 0.
* It accumulates chunk by chunk because the scheduler splits a long prompt. `RBLNOptimumScheduler` submits the whole prompt in one step and lets the compiled binary chunk internally, so the result is complete after a single step and `in_progress_prompt_logprobs_cpu` is unnecessary.
* Row i is prompt position i, because a request asking for prompt logprobs never reads the prefix cache (`Request.skip_reading_prefix_cache`).

What survives is the gather itself, which is why the diff removes more than it adds.

Two supporting changes:

* Sampling takes the last row explicitly (`hidden_states[:, -1, :]`) instead of squeezing a length-one axis. That is the same tensor under either compile option, and it leaves the full model output available for the prompt logprobs.
* `sample_hidden_states` is gone. It cloned the whole prefill output on every step and nothing read it.

### ⚠️ Requires a `logits_to_keep=0` model

The prompt-position logits only exist if the model was compiled with `logits_to_keep=0`. The CausalLM default of 1 makes the prefill graph return a single row. That is a property of the graph, so the runner cannot recover it; a mismatch raises and names the compile option rather than producing nonsense:

```
ValueError: prompt_logprobs needs a logit for every prompt position, but the prefill
graph returned 1 row(s) for 16 prompt tokens. Compile the model with logits_to_keep=0
so it keeps all of them.
```

Requesting 0 also needs an optimum-rbln fix: `logits_to_keep or self._default_logits_to_keep` cannot express 0, on both the compile and the load path. That is RBLN-SW/optimum-rbln#698, and this PR should not land before it.

How the option is surfaced to users is still open. Today it goes through the existing override, `--additional-config '{"rbln_config": {"logits_to_keep": 0}}'`. Turning it on unconditionally is not an option: it grows the prefill output by a factor of the prompt length.

### 📌 Related Issues / Tickets

* Related to RBLN-SW/optimum-rbln#698

### ✅ Type of Change

* [x] 🛠 Bug fix (`fix`)

Affected modules: Runner (optimum), examples. The vLLM-native path is untouched.

### 🧪 How to Test

Needs optimum-rbln#698 and a model compiled with `logits_to_keep=0`.

1. Prompt logprobs on a `logits_to_keep=0` Llama-3.2-1B:

   ```
   python examples/optimum/decoder_models/basic_offline.py --model <compiled_dir> --prompt_logprobs 0
   ```

   Expect one entry per prompt token, the first `None`.

2. Same model, flag omitted: unchanged output, no prompt logprobs.
3. A default-compiled model with `--prompt_logprobs 0`: the `ValueError` above, not an `AttributeError`.

Results on Llama-3.2-1B, prompt `The capital of France is Paris, and the capital of Germany is Berlin.`:

```
prompt_logprobs len=16
[0] None
[6] ' Paris' (id=12366) logprob=-0.8655 rank=1
[14] ' Berlin' (id=20437) logprob=-0.0567 rank=1
```

Every position matches the HF CPU model to fp16 precision (max absolute difference 0.0722 over the prompt, top-1 agreement 15/16). Generation on a default-compiled model is byte-identical before and after this change.

### 💬 Notes

No test is included. A meaningful one needs a `logits_to_keep=0` compiled model, which CI does not have, and a test that is skipped as a placeholder covers nothing. Suggestions on the right shape are welcome.

The multimodal prefill path was not exercised. `sample_tokens` reshapes prompt logits to `(1, -1)` to avoid stride-driven recompiles; that reshape now always sees `[batch, vocab]`, which should be a no-op there, but it was not run.
