### PR TITLE
fix(compile): append mega-cache bundle parts instead of overwriting

### DIFF
--- a/tests/native/v1/worker/test_mega_cache.py
+++ b/tests/native/v1/worker/test_mega_cache.py
@@ -397,6 +397,10 @@ def _bundle_bytes(path: str) -> bytes:
         return f.read()
 
 
+def _parts(path: str) -> list[bytes]:
+    return [_bundle_bytes(part) for part in mega_cache.bundle_parts(path)]
+
+
 class TestSaveLoad:
     def test_round_trip(self, bundle):
         mega_cache.save(MODEL, SIG)
@@ -444,11 +448,56 @@ class TestSaveLoad:
         mega_cache.load(MODEL, SIG)
         assert bundle.loaded == []
 
-    def test_resave_replaces_in_place(self, bundle):
+    def test_resave_appends_a_part(self, bundle):
         mega_cache.save(MODEL, SIG)
         bundle.save_result = (b"second-bundle", object())
         mega_cache.save(MODEL, SIG)
-        assert _bundle_bytes(bundle.path) == b"second-bundle"
+        assert _parts(bundle.path) == [bundle.artifact, b"second-bundle"]
+
+    def test_a_hit_does_not_fall_out_of_the_bundle(self, bundle):
+        # The reported failure: save_cache_artifacts() serializes only what this
+        # session compiled, so a run that hit 6 graphs and missed 1 wrote a
+        # bundle holding just the miss -- and the next run recompiled all 7.
+        mega_cache.save(MODEL, SIG)
+        bundle.save_result = (b"one-late-graph", object())
+        mega_cache.save(MODEL, SIG)
+        mega_cache.load(MODEL, SIG)
+        assert bundle.loaded == [bundle.artifact, b"one-late-graph"]
+
+    def test_increments_live_beside_the_base(self, bundle):
+        mega_cache.save(MODEL, SIG)
+        bundle.save_result = (b"second-bundle", object())
+        mega_cache.save(MODEL, SIG)
+        directory = os.path.dirname(bundle.path)
+        assert sorted(os.listdir(directory)) == [
+            "mega_cache.bin",
+            "mega_cache.inc.1.bin",
+        ]
+
+    def test_parts_replay_in_write_order(self, bundle):
+        # Not lexicographic: inc.10 is written after inc.9, so it has to replay
+        # after it.
+        for i in range(12):
+            bundle.save_result = (f"part-{i}".encode(), object())
+            mega_cache.save(MODEL, SIG)
+        mega_cache.load(MODEL, SIG)
+        assert bundle.loaded == [f"part-{i}".encode() for i in range(12)]
+
+    def test_a_corrupt_part_does_not_hide_the_others(self, bundle, monkeypatch):
+        mega_cache.save(MODEL, SIG)
+        bundle.save_result = (b"second-bundle", object())
+        mega_cache.save(MODEL, SIG)
+        seen = []
+
+        def flaky(data):
+            seen.append(data)
+            if data == bundle.artifact:
+                raise RuntimeError("bad part")
+            return object()
+
+        monkeypatch.setattr(torch.compiler, "load_cache_artifacts", flaky)
+        mega_cache.load(MODEL, SIG)  # must not propagate
+        assert seen == [bundle.artifact, b"second-bundle"]
 
     def test_nothing_new_compiled_keeps_the_bundle(self, bundle):
         # torch returns None when the run recorded no new artifact -- i.e. every

--- a/tests/native/v1/worker/test_mega_cache.py
+++ b/tests/native/v1/worker/test_mega_cache.py
@@ -471,8 +471,40 @@ class TestSaveLoad:
         directory = os.path.dirname(bundle.path)
         assert sorted(os.listdir(directory)) == [
             "mega_cache.bin",
-            "mega_cache.inc.1.bin",
+            f"mega_cache.inc.1.{os.getpid()}.bin",
         ]
+
+    def test_a_concurrent_run_does_not_take_the_base_twice(self, bundle, monkeypatch):
+        # Two runs of the same config that finish together both find no base and
+        # aim at it. The other run lands while this one stages its bytes, so the
+        # name is taken by the time this one publishes: it has to go beside that
+        # part rather than replace it.
+        real_open = open
+
+        def other_run_lands_first(path, *args, **kwargs):
+            handle = real_open(path, *args, **kwargs)
+            if str(path).endswith(".tmp"):
+                with real_open(bundle.path, "wb") as base:
+                    base.write(b"from-another-run")
+            return handle
+
+        with monkeypatch.context() as m:
+            m.setattr("builtins.open", other_run_lands_first)
+            mega_cache.save(MODEL, SIG)
+        assert _parts(bundle.path) == [b"from-another-run", bundle.artifact]
+
+    def test_a_concurrent_run_does_not_take_an_increment_twice(self, bundle):
+        # Same race one index along: both runs scanned before either wrote, so
+        # both want inc.1. The pid in the name keeps them apart, and load has to
+        # replay the other run's part as well as this one's.
+        mega_cache.save(MODEL, SIG)
+        directory = os.path.dirname(bundle.path)
+        with open(os.path.join(directory, "mega_cache.inc.1.999999.bin"), "wb") as f:
+            f.write(b"from-another-run")
+        bundle.save_result = (b"mine", object())
+        mega_cache.save(MODEL, SIG)
+        mega_cache.load(MODEL, SIG)
+        assert bundle.loaded == [bundle.artifact, b"from-another-run", b"mine"]
 
     def test_parts_replay_in_write_order(self, bundle):
         # Not lexicographic: inc.10 is written after inc.9, so it has to replay
@@ -552,7 +584,7 @@ class TestSaveLoad:
     def test_out_of_space_is_logged_at_error(self, bundle, monkeypatch, caplog):
         # Every restart recompiles from here on, so it cannot be a debug line.
         monkeypatch.setattr(
-            mega_cache.os, "replace", _raiser(OSError(errno.ENOSPC, "no space"))
+            mega_cache.os, "link", _raiser(OSError(errno.ENOSPC, "no space"))
         )
         with caplog.at_level(logging.ERROR, logger=mega_cache.logger.name):
             mega_cache.save(MODEL, SIG)

--- a/vllm_rbln/v1/worker/mega_cache.py
+++ b/vllm_rbln/v1/worker/mega_cache.py
@@ -13,8 +13,14 @@
 # limitations under the License.
 """torch.compiler mega-cache bundle helpers for the rbln model runner.
 
-Persists/restores `torch.compiler.{save,load}_cache_artifacts()` bundles as a
-per-(model, config-signature, rank) file under VLLM_CACHE_ROOT.
+Persists/restores `torch.compiler.{save,load}_cache_artifacts()` bundles under a
+per-(model, config-signature, rank) directory in VLLM_CACHE_ROOT.
+
+A bundle is a base file plus append-only increments: `mega_cache.bin`, then
+`mega_cache.inc.<n>.bin`. `save_cache_artifacts()` serializes only the artifacts
+*this* session compiled -- a loaded hit is never re-recorded -- so writing its
+output over the base would drop every graph that hit. Each save becomes a new
+part instead, and load replays them all.
 """
 
 import contextlib
@@ -29,6 +35,8 @@ import vllm.envs as envs
 from vllm_rbln.logger import init_logger
 
 logger = init_logger(__name__)
+
+_INCREMENT_RE = re.compile(r"^mega_cache\.inc\.(\d+)\.bin$")
 
 
 def _safe_name(model: str) -> str:
@@ -157,7 +165,7 @@ def config_signature(vllm_config) -> str:
 
 
 def bundle_path(model: str, sig: str) -> str:
-    """Per-(model, sig, local_rank) bundle path under VLLM_CACHE_ROOT
+    """Base part of the per-(model, sig, local_rank) bundle under VLLM_CACHE_ROOT
     (assumed node-local; override per node on a shared filesystem)."""
     raw = model or "unknown"
     suffix = hashlib.sha1(raw.encode("utf-8")).hexdigest()[:8]
@@ -172,75 +180,133 @@ def bundle_path(model: str, sig: str) -> str:
     )
 
 
+def _increment_path(directory: str, index: int) -> str:
+    return os.path.join(directory, f"mega_cache.inc.{index}.bin")
+
+
+def _increment_indices(directory: str) -> list[int]:
+    try:
+        names = os.listdir(directory)
+    except OSError:
+        return []
+    matches = (_INCREMENT_RE.match(name) for name in names)
+    return sorted(int(m.group(1)) for m in matches if m is not None)
+
+
+def bundle_parts(path: str) -> list[str]:
+    """Every part of the bundle at `path`, base first, then increments in order."""
+    directory = os.path.dirname(path)
+    parts = [path] if os.path.isfile(path) else []
+    parts.extend(_increment_path(directory, i) for i in _increment_indices(directory))
+    return parts
+
+
+def _next_part_path(path: str) -> str:
+    """Where this session's artifacts go: the base if it is not there yet, else
+    a fresh increment."""
+    if not os.path.isfile(path):
+        return path
+    directory = os.path.dirname(path)
+    index = max(_increment_indices(directory), default=0) + 1
+    while os.path.exists(_increment_path(directory, index)):
+        index += 1
+    return _increment_path(directory, index)
+
+
 def cache_root() -> str:
     """Directory the rbln backend should use for populate/lookup."""
     return os.path.join(envs.VLLM_CACHE_ROOT, "rbln")
 
 
+def _artifact_count(info) -> int:
+    """Artifacts a torch CacheInfo carries; 0 if torch stops exposing them."""
+    artifacts = getattr(info, "artifacts", None)
+    if not isinstance(artifacts, dict):
+        return 0
+    return sum(len(keys) for keys in artifacts.values())
+
+
 def load(model: str, sig: str) -> None:
-    """Restore artifacts from disk so first-compile cache-hits."""
+    """Restore artifacts from every part of the bundle so first-compile
+    cache-hits."""
     if envs.VLLM_DISABLE_COMPILE_CACHE:
         return
     from rebel.core import mega_cache as rbln_mega_cache
 
     rbln_mega_cache.set_dir(cache_root())
     path = bundle_path(model, sig)
-    if not os.path.isfile(path):
+    parts = bundle_parts(path)
+    if not parts:
         return
-    try:
-        with open(path, "rb") as src:
-            info = torch.compiler.load_cache_artifacts(src.read())
+    restored = 0
+    for part in parts:
+        try:
+            with open(part, "rb") as src:
+                info = torch.compiler.load_cache_artifacts(src.read())
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.warning("Failed to load rbln mega-cache bundle: %s", exc)
+            continue
         if info is None:
             logger.warning(
-                "Ignored an unreadable rbln mega-cache bundle at %s; recompiling",
-                path,
+                "Ignored an unreadable rbln mega-cache part at %s; recompiling "
+                "whatever it held",
+                part,
             )
-        else:
-            logger.info("Loaded rbln mega-cache bundle from %s", path)
-    except Exception as exc:  # pylint: disable=broad-exception-caught
-        logger.warning("Failed to load rbln mega-cache bundle: %s", exc)
+            continue
+        restored += _artifact_count(info)
+    logger.info(
+        "Loaded rbln mega-cache bundle from %s: %d part(s), %d artifact(s)",
+        os.path.dirname(path),
+        len(parts),
+        restored,
+    )
 
 
 def save(model: str, sig: str) -> None:
-    """Persist artifacts atomically. Call only after warm-up succeeds."""
+    """Persist this session's artifacts as a new bundle part, atomically. Call
+    only after warm-up succeeds."""
     if envs.VLLM_DISABLE_COMPILE_CACHE:
         return
     from rebel.core import mega_cache as rbln_mega_cache
 
     rbln_mega_cache.set_dir(cache_root())
     path = bundle_path(model, sig)
-    tmp_path = f"{path}.{os.getpid()}.tmp"
+    tmp_path = None
     try:
         rbln_mega_cache.flush_to_bundle()
         result = torch.compiler.save_cache_artifacts()
         if result is None:
             return
-        artifact_bytes, _ = result
+        artifact_bytes, info = result
         os.makedirs(os.path.dirname(path), exist_ok=True)
+        target = _next_part_path(path)
+        tmp_path = f"{target}.{os.getpid()}.tmp"
         with open(tmp_path, "wb") as dst:
             dst.write(artifact_bytes)
             # Delayed allocation defers ENOSPC to flush, so a bundle could be
             # renamed into place truncated without this.
             dst.flush()
             os.fsync(dst.fileno())
-        os.replace(tmp_path, path)
+        os.replace(tmp_path, target)
         logger.info(
-            "Saved rbln mega-cache bundle to %s (%.1f MiB)",
-            path,
+            "Saved rbln mega-cache bundle to %s (%.1f MiB, %d artifact(s))",
+            target,
             len(artifact_bytes) / (1 << 20),
+            _artifact_count(info),
         )
     except Exception as exc:  # pylint: disable=broad-exception-caught
-        with contextlib.suppress(OSError):
-            os.remove(tmp_path)
+        if tmp_path is not None:
+            with contextlib.suppress(OSError):
+                os.remove(tmp_path)
         out_of_space = isinstance(exc, OSError) and exc.errno in (
             errno.ENOSPC,
             errno.EDQUOT,
         )
         logger.error(
-            "Could not persist the rbln mega-cache bundle to %s: %s%s. The "
-            "previous bundle is left untouched, so every restart recompiles "
-            "from scratch until this is resolved.",
-            path,
+            "Could not persist the rbln mega-cache bundle under %s: %s%s. The "
+            "parts already on disk are left untouched, so the graphs this run "
+            "compiled are recompiled on every restart until this is resolved.",
+            os.path.dirname(path),
             exc,
             " (out of disk space)" if out_of_space else "",
         )

--- a/vllm_rbln/v1/worker/mega_cache.py
+++ b/vllm_rbln/v1/worker/mega_cache.py
@@ -17,10 +17,14 @@ Persists/restores `torch.compiler.{save,load}_cache_artifacts()` bundles under a
 per-(model, config-signature, rank) directory in VLLM_CACHE_ROOT.
 
 A bundle is a base file plus append-only increments: `mega_cache.bin`, then
-`mega_cache.inc.<n>.bin`. `save_cache_artifacts()` serializes only the artifacts
-*this* session compiled -- a loaded hit is never re-recorded -- so writing its
-output over the base would drop every graph that hit. Each save becomes a new
-part instead, and load replays them all.
+`mega_cache.inc.<n>.<pid>.bin`. `save_cache_artifacts()` serializes only the
+artifacts *this* session compiled -- a loaded hit is never re-recorded -- so
+writing its output over the base would drop every graph that hit. Each save
+becomes a new part instead, and load replays them all.
+
+Parts are claimed with `os.link`, which never overwrites, and an increment
+carries the writing pid: two runs of the same config finishing at once land
+beside each other instead of one silently replacing the other.
 """
 
 import contextlib
@@ -36,7 +40,7 @@ from vllm_rbln.logger import init_logger
 
 logger = init_logger(__name__)
 
-_INCREMENT_RE = re.compile(r"^mega_cache\.inc\.(\d+)\.bin$")
+_INCREMENT_RE = re.compile(r"^mega_cache\.inc\.(\d+)\.(\d+)\.bin$")
 
 
 def _safe_name(model: str) -> str:
@@ -180,37 +184,54 @@ def bundle_path(model: str, sig: str) -> str:
     )
 
 
-def _increment_path(directory: str, index: int) -> str:
-    return os.path.join(directory, f"mega_cache.inc.{index}.bin")
+def _increment_path(directory: str, index: int, pid: int) -> str:
+    return os.path.join(directory, f"mega_cache.inc.{index}.{pid}.bin")
 
 
-def _increment_indices(directory: str) -> list[int]:
+def _increments(directory: str) -> list[tuple[int, int, str]]:
+    """(index, pid, path) per increment in `directory`, oldest index first."""
     try:
         names = os.listdir(directory)
     except OSError:
         return []
-    matches = (_INCREMENT_RE.match(name) for name in names)
-    return sorted(int(m.group(1)) for m in matches if m is not None)
+    found = []
+    for name in names:
+        match = _INCREMENT_RE.match(name)
+        if match is not None:
+            found.append(
+                (
+                    int(match.group(1)),
+                    int(match.group(2)),
+                    os.path.join(directory, name),
+                )
+            )
+    return sorted(found)
 
 
 def bundle_parts(path: str) -> list[str]:
     """Every part of the bundle at `path`, base first, then increments in order."""
     directory = os.path.dirname(path)
     parts = [path] if os.path.isfile(path) else []
-    parts.extend(_increment_path(directory, i) for i in _increment_indices(directory))
+    parts.extend(part for _, _, part in _increments(directory))
     return parts
 
 
-def _next_part_path(path: str) -> str:
-    """Where this session's artifacts go: the base if it is not there yet, else
-    a fresh increment."""
-    if not os.path.isfile(path):
-        return path
-    directory = os.path.dirname(path)
-    index = max(_increment_indices(directory), default=0) + 1
-    while os.path.exists(_increment_path(directory, index)):
-        index += 1
-    return _increment_path(directory, index)
+def _claim_part(tmp_path: str, base_path: str) -> str:
+    """Link the staged bytes onto a part name nothing else holds, then drop the
+    temp. os.link refuses an existing target, so a concurrent run's part is
+    never replaced; the pid keeps the fallback name collision-free."""
+    directory = os.path.dirname(base_path)
+    index = max((i for i, _, _ in _increments(directory)), default=0)
+    target = base_path
+    while True:
+        try:
+            os.link(tmp_path, target)
+        except FileExistsError:
+            index += 1
+            target = _increment_path(directory, index, os.getpid())
+            continue
+        os.remove(tmp_path)
+        return target
 
 
 def cache_root() -> str:
@@ -271,23 +292,22 @@ def save(model: str, sig: str) -> None:
 
     rbln_mega_cache.set_dir(cache_root())
     path = bundle_path(model, sig)
-    tmp_path = None
+    directory = os.path.dirname(path)
+    tmp_path = os.path.join(directory, f"mega_cache.{os.getpid()}.tmp")
     try:
         rbln_mega_cache.flush_to_bundle()
         result = torch.compiler.save_cache_artifacts()
         if result is None:
             return
         artifact_bytes, info = result
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        target = _next_part_path(path)
-        tmp_path = f"{target}.{os.getpid()}.tmp"
+        os.makedirs(directory, exist_ok=True)
         with open(tmp_path, "wb") as dst:
             dst.write(artifact_bytes)
             # Delayed allocation defers ENOSPC to flush, so a bundle could be
-            # renamed into place truncated without this.
+            # linked into place truncated without this.
             dst.flush()
             os.fsync(dst.fileno())
-        os.replace(tmp_path, target)
+        target = _claim_part(tmp_path, path)
         logger.info(
             "Saved rbln mega-cache bundle to %s (%.1f MiB, %d artifact(s))",
             target,
@@ -295,9 +315,8 @@ def save(model: str, sig: str) -> None:
             _artifact_count(info),
         )
     except Exception as exc:  # pylint: disable=broad-exception-caught
-        if tmp_path is not None:
-            with contextlib.suppress(OSError):
-                os.remove(tmp_path)
+        with contextlib.suppress(OSError):
+            os.remove(tmp_path)
         out_of_space = isinstance(exc, OSError) and exc.errno in (
             errno.ENOSPC,
             errno.EDQUOT,


### PR DESCRIPTION
### 🚀 Summary of Changes

#### Summary

`torch.compiler.save_cache_artifacts()` serializes only the artifacts the current session compiled — an artifact restored from a loaded bundle is never re-recorded. `mega_cache.save()` wrote that output straight over `mega_cache.bin`, so a run that hit most of its graphs replaced the whole bundle with just its own misses, and the next run recompiled everything from scratch.

A bundle is now a base file plus append-only increments (`mega_cache.bin`, then `mega_cache.inc.<n>.<pid>.bin`): each save claims a new part, and load replays every part. Both log lines now carry part and artifact counts, so a shrunken bundle shows up in the log instead of only inside the file.

Seen on MiniMax-M2.7 dp4/ep, 10 graphs per rank — 6 rank-specific graphs that carry essentially all of the bundle, plus 4 rank-invariant drafter graphs about three orders of magnitude smaller between them. The bundle oscillated with a period of two runs: run N hit the 6 and missed the 4, replacing the bundle with one that held only those 4; run N+1 then missed all 10 and paid a full cold compile before saving a bundle without the 4. Neither run was wrong about its own graphs — each one just published only half the set.

#### Details

- **Bundle layout** — `bundle_path()` still names the base part, and a bundle is now every file in that rank directory: the base plus `mega_cache.inc.<n>.<pid>.bin`. `bundle_parts()` orders them base-first and numerically by index, so `inc.10` replays after `inc.9` rather than after `inc.1`. Nothing rewrites a part once it is renamed into place.

- **`save()` appends** — the target is the base when it does not exist yet, otherwise the next free increment index, so a single-run config still produces exactly one file as before. A part is claimed with `os.link()` rather than `os.replace()`: link refuses an existing target, so two runs of the same config finishing at once cannot publish over each other, and an increment carries the writing pid so the loser's fallback name cannot collide either. Staging to a temp file first keeps a part atomic, and a torn write is never linked in. The index does not have to stay dense — load replays whatever it finds — so a run that loses the race takes the next index instead of hunting for a free slot.

- **`load()` replays every part** — a part that fails to read or deserialize now warns and the remaining parts still load. Previously a single unreadable bundle meant a full recompile; with parts, only the graphs in the bad part are lost. Duplicate keys across parts are harmless — the rebel side keys blobs by `filename_hash`, so a later part simply overwrites an identical entry.

- **Counts in the log** — load reports `N part(s), M artifact(s)` and save reports the artifact count it wrote. `Loaded rbln mega-cache bundle from ...` previously proved only that a file was read; a bundle holding none of the graphs the run needed logged exactly the same line as a complete one.

#### Next Steps

- No compaction. Parts accumulate one per run that compiles something new, and a part whose graphs are no longer reachable (after a code change that reshapes a graph) lingers until the signature directory is deleted. Merging parts needs the artifacts torch does not hand back on load, so compaction wants a rebel-side re-record hook.
- The artifact count comes from torch's `CacheInfo`, which reports what a bundle carried, not what this run hit. Real hit/miss accounting needs counters on the rebel `take_bytes`/`take_path` side.
- Separately, this run reached a fresh signature directory even though its 24 per-graph hashes were byte-identical to the bundle in the neighbouring signature directory — a `config_signature()` false-mismatch worth its own investigation. Logging the factor dicts rather than the 8-char digests would make that a one-line diff.

---

### 📌 Related Issues / Tickets

* Resolves #
* Related to #

---

### ✅ Type of Change

* [x] 🛠 Bug fix (`fix`)

---

### 🧪 How to Test

```bash
uv run --no-sync pytest tests/native/v1/worker/test_mega_cache.py -q
```

New cases in `TestSaveLoad`, all seven red before this change:

1. `test_a_hit_does_not_fall_out_of_the_bundle` — the reported failure: save after a partial hit must not reduce the bundle to that run's misses.
2. `test_resave_appends_a_part` / `test_increments_live_beside_the_base` — a second save adds `mega_cache.inc.1.<pid>.bin` next to the base instead of replacing it.
3. `test_parts_replay_in_write_order` — 12 saves replay in write order, so ordering is numeric and not lexicographic.
4. `test_a_corrupt_part_does_not_hide_the_others` — one part that raises on load does not cost the others.
5. `test_a_concurrent_run_does_not_take_the_base_twice` / `test_a_concurrent_run_does_not_take_an_increment_twice` — another run's part appearing while this one stages its bytes sends this one to the next name rather than over it.

61 pass. The 15 failures and 2 errors are every case that builds a config through `make_vllm_config`: it resolves `meta-llama/Llama-3.2-1B-Instruct` from the Hub, which answers 401 (gated repo) in my environment. They fail the same way with this change reverted.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

Draft: the increment layout is the part worth arguing about before this lands. The alternative is to merge on save — deserialize the existing bundle, union, re-serialize — which keeps one file but doubles the save-side peak, on every rank at once — four of them share this host. A cheaper middle ground is to refuse a save whose key set is not a superset of the existing one, but that permanently locks out graphs a later run adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


