### PR TITLE
fix(spec-decode): make the ngram proposer's numba warm-up reach the kernel

### DIFF
--- a/tests/native/patches/test_ngram_proposer.py
+++ b/tests/native/patches/test_ngram_proposer.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import types
+
+from vllm.v1.spec_decode import ngram_proposer as upstream
+
+import vllm_rbln.patches.ngram_proposer as pnp
+
+
+def _vllm_config(k: int = 2, max_model_len: int = 512) -> types.SimpleNamespace:
+    return types.SimpleNamespace(
+        speculative_config=types.SimpleNamespace(
+            prompt_lookup_min=2,
+            prompt_lookup_max=5,
+            num_speculative_tokens=k,
+        ),
+        model_config=types.SimpleNamespace(max_model_len=max_model_len),
+        parallel_config=types.SimpleNamespace(tensor_parallel_size=1),
+        scheduler_config=types.SimpleNamespace(max_num_seqs=4),
+    )
+
+
+def _spy_kernel(monkeypatch) -> list[tuple]:
+    """Replace the numba kernel so the assertions cost no JIT compile."""
+    calls: list[tuple] = []
+
+    def fake(valid_ngram_requests, *args, **kwargs):
+        calls.append(tuple(valid_ngram_requests))
+
+    monkeypatch.setattr(upstream, "batch_propose_numba", fake)
+    return calls
+
+
+def test_construction_reaches_the_numba_kernel(monkeypatch):
+    calls = _spy_kernel(monkeypatch)
+
+    pnp.__init__(upstream.NgramProposer.__new__(upstream.NgramProposer), _vllm_config())
+
+    # Upstream's own warm-up passes only empty sampled_token_ids, which propose()
+    # filters out and batch_propose() then skips: it never gets here.
+    assert calls, "construction did not reach batch_propose_numba"
+    assert calls[0] == (0,)
+
+
+def test_upstream_warmup_alone_does_not_reach_the_kernel(monkeypatch):
+    """Pins the upstream behaviour this patch exists to correct."""
+    calls = _spy_kernel(monkeypatch)
+
+    proposer = upstream.NgramProposer.__new__(upstream.NgramProposer)
+    pnp._init(proposer, _vllm_config())
+
+    assert not calls

--- a/vllm_rbln/patches/__init__.py
+++ b/vllm_rbln/patches/__init__.py
@@ -39,6 +39,7 @@ from . import (
     mla,
     models_utils,
     multi_connector,
+    ngram_proposer,
     oot,
     profiler,
     qwen2_moe,

--- a/vllm_rbln/patches/ngram_proposer.py
+++ b/vllm_rbln/patches/ngram_proposer.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Make the ngram proposer's numba JIT actually compile during construction.
+
+Upstream ends `NgramProposer.__init__` with a `self.propose(...)` call whose
+comment says it triggers the numba JIT. It does not: every entry of the
+`sampled_token_ids` it passes is empty, `propose` skips requests with no sampled
+ids, and `batch_propose` skips the numba call entirely when that leaves no valid
+request. The JIT therefore fires on the first real proposal instead, inside a
+serving step.
+
+The same call with one non-empty row compiles the kernels. numba specializes on
+dtype and ndim rather than length, so a single row covers the full-batch call.
+"""
+
+import functools
+
+import numpy as np
+from vllm.v1.spec_decode.ngram_proposer import NgramProposer
+
+from vllm_rbln.logger import init_logger
+from vllm_rbln.patches import register_patch
+
+logger = init_logger(__name__)
+
+_init = NgramProposer.__init__
+
+
+@register_patch(
+    target="vllm.v1.spec_decode.ngram_proposer.NgramProposer.__init__",
+    reason=(
+        "Upstream's JIT warm-up call passes only empty sampled_token_ids, so it "
+        "compiles nothing and the numba JIT lands in the first serving step. "
+        "TODO(vllm>0.24.0): delete once upstream's warm-up reaches the kernel."
+    ),
+    key="vllm_rbln.patches.ngram_proposer.__init__",
+    owner_module="vllm_rbln.patches.ngram_proposer",
+)
+@functools.wraps(_init)
+def __init__(self, vllm_config, *args, **kwargs) -> None:
+    _init(self, vllm_config, *args, **kwargs)
+    self.propose(
+        self.k,
+        [[0]],
+        np.zeros(1, dtype=np.int32),
+        np.zeros((1, self.max_model_len), dtype=np.int32),
+    )


### PR DESCRIPTION
### 🚀 Summary of Changes

`NgramProposer.__init__` ends with a `self.propose(...)` call whose comment says it triggers the numba JIT. It does not:

```python
self.propose(
    self.k,
    [[]] * 1024,                                          # every entry empty
    np.zeros(1024, dtype=np.int32),
    np.zeros((1024, self.max_model_len), dtype=np.int32),
)
```

`propose` drops requests whose `sampled_token_ids` is empty, and `batch_propose` skips the numba call entirely once that leaves no valid request (its own comment says why — an empty list has no fingerprint). So the warm-up compiles nothing, and `batch_propose_numba` plus the `@jit` callee it invokes are compiled on the **first real proposal**, inside a serving step. It lands on whichever pass drafts first, which is a prefill pass, and shows up there as a one-off spike rather than as start-up cost.

This patches `__init__` to repeat the warm-up with one non-empty row, which is enough to reach the kernel. One row rather than `max_num_seqs` because numba specializes on dtype and ndim, not on length — the compiled signature is the same one the full-batch call uses. That also shrinks the warm-up's throwaway `token_ids_cpu` allocation, which is `max_num_seqs × max_model_len × 4` bytes and non-trivial at a long `max_model_len`.

Model path: **vLLM-native** only (`patches/` is native-owned; the optimum path never constructs this proposer).

The removal condition is in the `reason` string, so the patch does not outlive upstream's fix.

---

### 📌 Related Issues / Tickets

* Resolves #
* Related to #

---

### ✅ Type of Change

* [x] 🛠 Bug fix (`fix`)
* [x] ⚙️ Performance improvement (`perf`)

---

### 🧪 How to Test

```
uv run --no-sync pytest tests/native/patches/test_ngram_proposer.py -q
```

- `test_construction_reaches_the_numba_kernel` — construction now reaches `batch_propose_numba`. Reverting the patch body to upstream's arguments fails this test; I checked that both ways.
- `test_upstream_warmup_alone_does_not_reach_the_kernel` — pins the upstream behaviour being corrected, so the test file states the premise rather than assuming it.

Both stub the kernel, so neither pays a JIT compile.

End to end, on any ngram spec-decode run: the JIT cost moves from the first drafting pass into proposer construction. In the metrics report that shows up as `E2E (PREFILL)` mean coming down to its median — the median never included the spike, only the mean and the tail did.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

`@register_patch` rather than an extension point: the ineffective call is inside upstream's `__init__` body, and upstream exposes no hook there. `NgramProposer.load_model` is a no-op stub, so it is not one either.

Worth reporting upstream as well — the fix there is the argument list, not a wrapper. This patch is the stop-gap until that lands.

Draft because the issue link is missing and because I have only verified the unit-level behaviour plus a standalone reproduction of the construction-time compile; I have not yet re-run the full spec-decode workload with the patch in place to confirm the prefill tail is gone.
