### PR TITLE
feature(nixl): transfer KV in the push direction

### DIFF
--- a/tests/native/distributed/kv_connector/test_factory.py
+++ b/tests/native/distributed/kv_connector/test_factory.py
@@ -27,6 +27,7 @@ import vllm_rbln.distributed.kv_transfer.kv_connector.factory  # noqa: F401
 def test_native_backend_registers_every_connector():
     registry = KVConnectorFactory._registry
     assert "RblnNixlPullConnector" in registry
+    assert "RblnNixlPushConnector" in registry
     assert "RBLNLMCacheConnectorV1" in registry
 
 
@@ -34,6 +35,7 @@ def test_native_backend_registers_every_connector():
     ("name", "class_name"),
     [
         ("RblnNixlPullConnector", "RblnNixlPullConnector"),
+        ("RblnNixlPushConnector", "RblnNixlPushConnector"),
         # The name the read path shipped under is what deployments carry, so it
         # has to keep resolving -- to the class that no longer bears it.
         ("RblnNixlConnector", "RblnNixlPullConnector"),

--- a/tests/native/distributed/kv_connector/test_rbln_nixl_base_scheduler.py
+++ b/tests/native/distributed/kv_connector/test_rbln_nixl_base_scheduler.py
@@ -12,21 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# RblnNixlPullConnectorScheduler: chunked-prefill save tracking, the
-# finished-request branches, and the fetch trimmed to a chunk boundary, all
-# exercised through the inherited entry points. Built bare with only the state
-# those paths read.
+# The scheduler-side shared layer: chunked-prefill save tracking, the chunk
+# alignment a fetch is trimmed to, and the finished-request branches, exercised
+# through the inherited entry points of whichever direction sits underneath.
+# Built bare with only the state those paths read.
 
 from dataclasses import dataclass, field
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
+    NixlPullConnectorScheduler,
+    NixlPushConnectorScheduler,
+)
 from vllm.v1.request import RequestStatus
 
 import vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.pull_scheduler as sm
 from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.pull_scheduler import (
     RblnNixlPullConnectorScheduler,
+)
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.push_scheduler import (
+    RblnNixlPushConnectorScheduler,
 )
 
 
@@ -79,8 +86,8 @@ def _sched_output(req_id, block_ids, num_scheduled_tokens, *, is_new=True):
     )
 
 
-def _scheduler(*, use_host_buffer=False):
-    sched = object.__new__(RblnNixlPullConnectorScheduler)
+def _scheduler(*, use_host_buffer=False, cls=RblnNixlPullConnectorScheduler):
+    sched = object.__new__(cls)
     sched.vllm_config = MagicMock()
     sched.vllm_config.parallel_config.tensor_parallel_size = 1
     sched.block_size = 16
@@ -109,6 +116,12 @@ def _scheduler(*, use_host_buffer=False):
     sched.kv_recompute_threshold = 64
     sched._has_mamba = False
     sched.vllm_config.scheduler_config.max_num_batched_tokens = 512
+    if cls is RblnNixlPushConnectorScheduler:
+        sched._push_pending_registrations = {}
+        sched._push_registration_deadlines = {}
+        sched._push_registration_timeout = 480
+        sched._finished_request_blocks = {}
+        sched._newly_finished_push_blocks = {}
     return sched
 
 
@@ -364,3 +377,86 @@ class TestChunkAlignedFetch:
             kv_transfer_params={"do_remote_prefill": True},
         )
         assert sched.get_num_new_matched_tokens(req, 0) == (900, True)
+
+
+class TestSchedulerCleanupReachesBothDirections:
+    @pytest.mark.parametrize(
+        "scheduler_cls, direction_cls",
+        [
+            (RblnNixlPullConnectorScheduler, NixlPullConnectorScheduler),
+            (RblnNixlPushConnectorScheduler, NixlPushConnectorScheduler),
+        ],
+    )
+    def test_stale_chunk_accumulation_is_dropped(
+        self, monkeypatch, scheduler_cls, direction_cls
+    ):
+        # The accumulation belongs to the shared layer, so its cleanup must run
+        # and then hand over to whichever direction scheduler is underneath.
+        seen = []
+
+        def record(self, request, block_ids):
+            seen.append(request.request_id)
+            return False, None
+
+        monkeypatch.setattr(direction_cls, "request_finished", record)
+        scheduler = object.__new__(scheduler_cls)
+        scheduler._block_ids_need_save = {"r0": ([1, 2],)}
+
+        # A real Request always carries the field, even when it is None.
+        scheduler.request_finished(
+            SimpleNamespace(request_id="r0", kv_transfer_params=None), ([1, 2],)
+        )
+
+        assert scheduler._block_ids_need_save == {}
+        assert seen == ["r0"]
+
+
+class TestRejectedBeforeScheduling:
+    """The serving layer can turn a request away before it is ever scheduled --
+    a prompt past the context length, a client that left. The base registers an
+    empty receive for it so the producer stops holding the blocks it pinned,
+    and building that receive reads a field only `update_state_after_alloc`
+    fills, which such a request never reaches."""
+
+    @staticmethod
+    def _rejected():
+        return _Request(
+            "rejected",
+            num_prompt_tokens=1,
+            status=RequestStatus.FINISHED_ABORTED,
+            # What the serving layer hands back: still flagged for a remote
+            # prefill, and without the field D fills for itself.
+            kv_transfer_params={
+                "do_remote_decode": False,
+                "do_remote_prefill": True,
+                "remote_engine_id": "prefill0",
+                "remote_request_id": "abc",
+                "remote_host": "localhost",
+                "remote_port": 5559,
+                "tp_size": 1,
+            },
+        )
+
+    def test_the_metadata_for_a_rejected_request_can_be_built(self):
+        # Calls upstream's own builder rather than checking the key by hand:
+        # what has to hold is that upstream's read of it succeeds.
+        sched = _scheduler(cls=RblnNixlPushConnectorScheduler)
+        req = self._rejected()
+
+        sched.request_finished(req, ([],))
+        meta = sched.build_connector_meta(_sched_output("other", ([9],), 16))
+
+        assert "rejected" in meta.reqs_to_recv
+        assert meta.reqs_to_recv["rejected"].remote.block_ids == ()
+
+    def test_the_producers_own_block_ids_are_not_clobbered(self):
+        # The producer's reply carries both the remote-prefill flag and its
+        # block ids, so a proxy that forwards it leaves the field already
+        # filled; only one dispatching to both sides at once leaves it absent.
+        sched = _scheduler(cls=RblnNixlPushConnectorScheduler)
+        req = self._rejected()
+        req.kv_transfer_params["remote_block_ids"] = ([4, 5],)
+
+        sched.request_finished(req, ([],))
+
+        assert req.kv_transfer_params["remote_block_ids"] == ([4, 5],)

--- a/tests/native/distributed/kv_connector/test_rbln_nixl_base_worker.py
+++ b/tests/native/distributed/kv_connector/test_rbln_nixl_base_worker.py
@@ -339,6 +339,24 @@ class TestSwaViewDelegation:
         assert worker.register_local_xfer_handler(64) == "super"
         assert calls == [64]
 
+    def test_a_fanned_out_peer_does_not_take_the_whole_engine_path(self, monkeypatch):
+        # One handle covers every region once, which cannot express a slice the
+        # peer holds on several of its chiplets.
+        worker = _build_worker(monkeypatch)  # _sw_ratio is None
+
+        monkeypatch.setattr(
+            NixlBaseConnectorWorker,
+            "register_local_xfer_handler",
+            lambda self, block_size: "super",
+        )
+        monkeypatch.setattr(
+            type(worker),
+            "_register_shard_local_xfer_handler",
+            lambda self, *args, **kwargs: "shard",
+        )
+
+        assert worker.register_local_xfer_handler(64, replica_fanout=2) == "shard"
+
     def test_add_remote_agent_delegates_when_no_swa(self, monkeypatch):
         worker = _build_worker(monkeypatch)  # _sw_ratio is None
         calls: list = []

--- a/tests/native/distributed/kv_connector/test_rbln_nixl_connector.py
+++ b/tests/native/distributed/kv_connector/test_rbln_nixl_connector.py
@@ -26,6 +26,7 @@ import vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.connector as 
 import vllm_rbln.envs as envs
 from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.connector import (
     RblnNixlPullConnector,
+    RblnNixlPushConnector,
 )
 
 
@@ -165,3 +166,46 @@ class TestSetXferHandshakeMetadataPpAware:
         # shard; fail loudly instead.
         with pytest.raises(ValueError, match="Duplicate handshake metadata"):
             self._flatten({(0, 1): "a", (1, 0): "b"}, tp_size=1)
+
+
+class TestConnectorWiring:
+    @pytest.fixture
+    def push_connector(self, monkeypatch):
+        monkeypatch.setattr(
+            cm.KVConnectorBase_V1, "__init__", lambda self, *a, **k: None
+        )
+        monkeypatch.setattr(
+            cm, "RblnNixlPushConnectorScheduler", lambda *a, **k: "SCHEDULER"
+        )
+        monkeypatch.setattr(cm, "RblnNixlPushConnectorWorker", lambda *a, **k: "WORKER")
+        monkeypatch.setattr(envs, "VLLM_RBLN_USE_DEVICE_TENSOR", True)
+
+        def build(role, kv_buffer_device="rbln"):
+            vllm_config = SimpleNamespace(
+                kv_transfer_config=SimpleNamespace(
+                    engine_id="engine-0", kv_buffer_device=kv_buffer_device
+                )
+            )
+            connector = object.__new__(RblnNixlPushConnector)
+            RblnNixlPushConnector.__init__(
+                connector, vllm_config, role, {"kv_cache": 1}
+            )
+            return connector
+
+        return build
+
+    def test_worker_role_builds_the_push_worker(self, push_connector):
+        connector = push_connector(KVConnectorRole.WORKER)
+        assert connector.connector_worker == "WORKER"
+        assert connector.connector_scheduler is None
+
+    def test_scheduler_role_builds_the_push_scheduler(self, push_connector):
+        connector = push_connector(KVConnectorRole.SCHEDULER)
+        assert connector.connector_scheduler == "SCHEDULER"
+        assert connector.connector_worker is None
+
+    def test_shares_the_construction_guards(self, push_connector):
+        # The guards live on the shared connector base; one of them is enough to
+        # pin that this direction goes through it.
+        with pytest.raises(AssertionError, match="kv_buffer_device"):
+            push_connector(KVConnectorRole.WORKER, kv_buffer_device="gpu")

--- a/tests/native/distributed/kv_connector/test_rbln_nixl_handshake.py
+++ b/tests/native/distributed/kv_connector/test_rbln_nixl_handshake.py
@@ -43,6 +43,9 @@ from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.metadata import
 from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.pull_worker import (
     RblnNixlPullConnectorWorker,
 )
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.push_worker import (
+    RblnNixlPushConnectorWorker,
+)
 
 
 def _encode_payload(
@@ -439,7 +442,8 @@ class TestPpHandshakeFanout:
         assert w._add_remote_agent_head_matched.call_args.kwargs[
             "registered_layer_names"
         ] == ("layer.2",)
-        assert w._register_shard_xfer_state.call_args.kwargs["split"] == 2
+        kwargs = w._register_shard_xfer_state.call_args.kwargs
+        assert (kwargs["split"], kwargs["replica_fanout"]) == (2, 1)
 
     def test_a_split_region_alone_forces_the_per_shard_path(self):
         # Companion to test_a_finer_peer_alone_forces_the_per_shard_path: here
@@ -610,6 +614,7 @@ class TestShardLocalRegions:
             peer_areas=None,
             split=1,
             region_ids=None,
+            replica_fanout=1,
         )
 
     def test_a_borrowed_handle_is_recorded_as_borrowed(self):
@@ -1626,8 +1631,11 @@ class TestPublishHandshakeMetadata:
             physical_blocks_per_logical_kv_block=1,
         )
 
-    def _publish(self, *, pp_rank, pp_size, layer_names, areas=1, slices=1):
-        w = object.__new__(RblnNixlPullConnectorWorker)
+    def _publish(self, *, pp_rank, pp_size, layer_names, areas=1, slices=1, cls=None):
+        w = object.__new__(cls or RblnNixlPullConnectorWorker)
+        # __init__ never ran, so the writer state shutdown() reaches through
+        # __del__ is absent; silence it rather than leak an unraisable at GC.
+        w.shutdown = lambda: None
         w.compat_hash = "BASE"
         # _check_pp_constraints reads these; a plain PP producer passes.
         w.vllm_config = MagicMock()
@@ -1650,6 +1658,18 @@ class TestPublishHandshakeMetadata:
             w._publish_handshake_metadata(self._base_meta(), layer_names)
         return w
 
+    def test_a_writer_publishes_the_write_path_hash(self):
+        # The direction is a class fact, and the hash has to come from the class
+        # that is running: a producer that writes must not present the hash a
+        # reader would accept.
+        w = self._publish(
+            pp_rank=0,
+            pp_size=1,
+            layer_names=["l0"],
+            cls=RblnNixlPushConnectorWorker,
+        )
+        assert w.compat_hash == rbln_compat_hash("BASE", writes_into_peer=True)
+
     def test_advertises_chiplet_geometry(self):
         """Head-band matching on the consumer needs the producer's areas/slices;
         they cannot be derived from the address list without assuming exactly
@@ -1662,8 +1682,9 @@ class TestPublishHandshakeMetadata:
 
     def test_wraps_upstream_and_folds_compat(self):
         w = self._publish(pp_rank=1, pp_size=2, layer_names=["l7", "l8"])
-        # compat hash folded with our version and mirrored into the payload.
-        assert w.compat_hash == rbln_compat_hash("BASE")
+        # compat hash folded with our version and direction, mirrored into the
+        # payload. A read-path worker must publish the read-path hash.
+        assert w.compat_hash == rbln_compat_hash("BASE", writes_into_peer=False)
         assert w.xfer_handshake_metadata.compatibility_hash == w.compat_hash
         decoded = msgspec.msgpack.Decoder(RblnNixlAgentMetadata).decode(
             w.xfer_handshake_metadata.agent_metadata_bytes

--- a/tests/native/distributed/kv_connector/test_rbln_nixl_metadata.py
+++ b/tests/native/distributed/kv_connector/test_rbln_nixl_metadata.py
@@ -107,20 +107,32 @@ class TestRblnNixlAgentMetadata:
 
 class TestRblnCompatHash:
     def test_deterministic(self):
-        assert rbln_compat_hash("BASE") == rbln_compat_hash("BASE")
+        assert rbln_compat_hash("BASE", writes_into_peer=False) == rbln_compat_hash(
+            "BASE", writes_into_peer=False
+        )
 
     def test_differs_from_base(self):
         # Folding our version in must move the hash, or a peer that speaks only
         # upstream's schema would match one that speaks ours.
-        assert rbln_compat_hash("BASE") != "BASE"
+        assert rbln_compat_hash("BASE", writes_into_peer=False) != "BASE"
+
+    def test_the_two_transfer_directions_do_not_share_a_hash(self):
+        # A producer that writes into the consumer and one the consumer reads
+        # from describe the same bytes, so every length check on the handshake
+        # passes and only this separates them.
+        assert rbln_compat_hash("BASE", writes_into_peer=True) != rbln_compat_hash(
+            "BASE", writes_into_peer=False
+        )
 
     def test_distinguishes_base_hashes(self):
-        assert rbln_compat_hash("hash-a") != rbln_compat_hash("hash-b")
+        assert rbln_compat_hash("hash-a", writes_into_peer=False) != rbln_compat_hash(
+            "hash-b", writes_into_peer=False
+        )
 
     def test_version_is_folded(self, monkeypatch):
         # Bumping RBLN_NIXL_CONNECTOR_VERSION changes the hash (gates schema drift).
-        h1 = md.rbln_compat_hash("BASE")
+        h1 = md.rbln_compat_hash("BASE", writes_into_peer=False)
         monkeypatch.setattr(
             md, "RBLN_NIXL_CONNECTOR_VERSION", RBLN_NIXL_CONNECTOR_VERSION + 1
         )
-        assert md.rbln_compat_hash("BASE") != h1
+        assert md.rbln_compat_hash("BASE", writes_into_peer=False) != h1

--- a/tests/native/distributed/kv_connector/test_rbln_nixl_push_worker.py
+++ b/tests/native/distributed/kv_connector/test_rbln_nixl_push_worker.py
@@ -364,7 +364,7 @@ class TestPerShardWrite:
         # WRITE would be the alternative, and it is the peer that would then
         # wait on a notification for a transfer that carries no bytes.
         worker = self._writing_worker(ranks=1)
-        worker._trim_to_consumer_blocks = lambda local, remote: ((),)
+        worker._trim_to_consumer_blocks = lambda *_: ((),)
 
         worker._xfer_blocks_for_req("r0", self._meta(([1],), ([3],)))
 
@@ -375,13 +375,20 @@ class TestPerShardWrite:
 class TestTrimToConsumerBlocks:
     def test_more_blocks_than_the_consumer_registered_trims_the_head(self):
         trimmed = RblnNixlPushConnectorWorker._trim_to_consumer_blocks(
-            ([1, 2, 3, 4],), ([7, 8],)
+            ([1, 2, 3, 4],), ([7, 8],), "eng0", "req0"
         )
         assert trimmed == ([3, 4],)
 
-    def test_a_consumer_asking_for_more_than_we_hold_is_an_error(self):
-        with pytest.raises(AssertionError, match="cannot be aligned"):
-            RblnNixlPushConnectorWorker._trim_to_consumer_blocks(([1],), ([7, 8],))
+    def test_a_consumer_asking_for_more_than_we_hold_is_refused(self):
+        # A peer's advertised length, so it is refused rather than asserted --
+        # and the message has to name the pair an operator has to go look at.
+        with pytest.raises(RuntimeError) as excinfo:
+            RblnNixlPushConnectorWorker._trim_to_consumer_blocks(
+                ([1],), ([7, 8],), "eng0", "req0"
+            )
+        msg = str(excinfo.value)
+        assert "eng0" in msg and "req0" in msg
+        assert "registered 2 block(s)" in msg and "the 1 this producer holds" in msg
 
 
 class TestWriterCountAccounting:

--- a/tests/native/distributed/kv_connector/test_rbln_nixl_push_worker.py
+++ b/tests/native/distributed/kv_connector/test_rbln_nixl_push_worker.py
@@ -1,0 +1,837 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The write path: that it inherits the shared machinery next to the upstream
+# push classes, that the writer thread survives the D2D registration deferral,
+# that a request is settled only once every writer of it has reported, and that
+# a peer holding part of what we do is written per shard.
+
+import queue
+import threading
+from collections import defaultdict
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
+    NixlBaseConnectorWorker,
+    NixlPushConnectorWorker,
+)
+
+import vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.push_worker as pw
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl import (
+    RblnNixlPullConnectorWorker,
+    RblnNixlPushConnectorWorker,
+    RblnNixlWorkerBase,
+)
+
+
+class _FakeThread:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.started = False
+
+    def start(self):
+        self.started = True
+
+
+@pytest.fixture
+def fake_thread(monkeypatch):
+    """Capture the writer thread instead of running it."""
+    created = []
+
+    def factory(**kwargs):
+        created.append(_FakeThread(**kwargs))
+        return created[-1]
+
+    monkeypatch.setattr(pw.threading, "Thread", factory)
+    return created
+
+
+def _push_worker():
+    w = object.__new__(RblnNixlPushConnectorWorker)
+    w._push_writer_thread = None
+    w.tp_rank = 0
+    # What __init__ leaves on a D2D worker with the SWA view-opt off, which is
+    # the shape the pairing predicates read before an engine is registered.
+    w.use_host_buffer = False
+    w._sw_ratio = None
+    # __init__ never ran, so the writer state shutdown() reaches through
+    # __del__ is absent; silence it rather than leak an unraisable at GC.
+    w.shutdown = lambda: None
+    return w
+
+
+class TestInheritance:
+    def test_shared_machinery_sits_next_to_the_upstream_push_classes(self):
+        # The pairing layer must come first so its overrides win, and the
+        # upstream push class must follow so the write path is the inherited one.
+        assert RblnNixlPushConnectorWorker.__mro__[1:4] == (
+            RblnNixlWorkerBase,
+            NixlPushConnectorWorker,
+            NixlBaseConnectorWorker,
+        )
+
+    def test_only_the_write_direction_carries_the_direction_flag(self):
+        # The flag decides whether descriptors fan out over a peer's replicas and
+        # it joins the compatibility hash, so the shared layer holding it would
+        # make the read path claim both.
+        assert RblnNixlPushConnectorWorker._writes_into_peer is True
+        assert RblnNixlWorkerBase._writes_into_peer is False
+
+    def test_teardown_reaches_the_writer_thread(self):
+        # Nothing of ours overrides shutdown, so the upstream push one runs and
+        # joins the writer; an override that forgot to chain would strand it.
+        assert RblnNixlPushConnectorWorker.shutdown is NixlPushConnectorWorker.shutdown
+
+    def test_the_read_path_does_not_leak_in(self):
+        # The shared layer is direction-free, so nothing of the read path may
+        # arrive through it.
+        assert not hasattr(RblnNixlPushConnectorWorker, "_read_blocks_for_req")
+
+    def test_the_submission_itself_stays_the_upstream_one(self):
+        # We choose the peers and the descriptors; posting the transfer and
+        # its failure handling remain upstream's.
+        assert (
+            RblnNixlPushConnectorWorker._xfer_blocks
+            is NixlPushConnectorWorker._xfer_blocks
+        )
+
+
+class TestMlaOnTheWritePath:
+    # MLA lives in the shared layer, so the write path gets it by inheritance.
+    # What that has to mean in practice is that the guards fire here too: a
+    # peer at a different TP degree would otherwise have its bands derived from
+    # the configured KV-head count -- which these models report as their
+    # attention head count -- and the descriptors would be plausible and wrong.
+    def test_unequal_tp_is_refused_when_writing_a_latent_cache(self):
+        worker = _push_worker()
+        worker.use_mla = True
+        worker.transfer_topo = SimpleNamespace(tp_ratio=lambda peer: 2, tp_size=1)
+
+        with pytest.raises(RuntimeError, match="heterogeneous tensor"):
+            worker._check_mla_constraints(SimpleNamespace(), remote_tp_size=2)
+
+    def test_a_peer_whose_chiplet_geometry_differs_is_refused(self):
+        # Positional pairing needs both sides to expand a logical region the
+        # same way; each derives it from its own device buffers, so a mismatch
+        # moves the wrong bytes without failing.
+        worker = _push_worker()
+        worker.use_mla = True
+        worker.transfer_topo = SimpleNamespace(tp_ratio=lambda peer: 1, tp_size=1)
+        worker._kv_areas, worker._kv_slices = 4, 1
+
+        with pytest.raises(RuntimeError, match="chiplet geometry"):
+            worker._check_mla_constraints(
+                SimpleNamespace(kv_areas=2, kv_slices=1), remote_tp_size=1
+            )
+
+    def test_a_matching_peer_passes(self):
+        worker = _push_worker()
+        worker.use_mla = True
+        worker.transfer_topo = SimpleNamespace(tp_ratio=lambda peer: 1, tp_size=1)
+        worker._kv_areas, worker._kv_slices = 4, 1
+
+        worker._check_mla_constraints(
+            SimpleNamespace(kv_areas=4, kv_slices=1), remote_tp_size=1
+        )
+
+
+class TestPushWriterStart:
+    def test_finalize_starts_the_writer_after_the_deferred_registration(
+        self, monkeypatch, fake_thread
+    ):
+        # D2D registers at finalize, so the start upstream hangs off
+        # register_kv_caches has to happen here instead -- and only after the
+        # memory it writes into exists.
+        order = []
+        monkeypatch.setattr(
+            RblnNixlWorkerBase,
+            "_register_kv_caches_impl",
+            lambda self, pending: order.append("register"),
+        )
+        worker = _push_worker()
+        worker._pending_kv_caches = {"layer.0": object()}
+
+        worker.finalize_kv_cache_registration()
+
+        order.append("start" if fake_thread[0].started else "not-started")
+        assert order == ["register", "start"]
+        assert fake_thread[0].kwargs["name"] == "nixl-push-writer"
+
+    def test_start_is_skipped_when_the_upstream_path_already_ran(self, fake_thread):
+        # Host staging reaches the upstream register_kv_caches, so the thread is
+        # already up by the time finalize no-ops; replacing it would orphan one.
+        worker = _push_worker()
+        worker._pending_kv_caches = None
+        existing = object()
+        worker._push_writer_thread = existing
+
+        worker.finalize_kv_cache_registration()
+
+        assert worker._push_writer_thread is existing
+        assert fake_thread == []
+
+
+class TestPerShardWrite:
+    """One WRITE per peer rank this one pairs with, each over that peer's own
+    narrowed descriptors -- the mirror of the read path's per-shard loop."""
+
+    @staticmethod
+    def _writing_worker(ranks):
+        w = _push_worker()
+        w._remote_pp_size = {"eng": 1}
+        w._overlapping_ranks = {"eng": list(range(ranks))}
+        w.vllm_config = MagicMock()
+        w.vllm_config.parallel_config.pipeline_parallel_size = 1
+        w.world_size = 1
+        w.num_blocks = 8
+        w.dst_num_blocks = {"eng": 8}
+        w._engine_last_active = {}
+        w.kv_cache_config = MagicMock(kv_cache_groups=[0])
+        # single group, 2 regions per shard
+        w._shard_region_group_ids = {("eng", r): (0, 0) for r in range(ranks)}
+        w._shard_descs_per_block = {}
+        w.src_xfer_handles_by_remote = {("eng", r, 16): 100 + r for r in range(ranks)}
+        w.dst_xfer_side_handles = {"eng": {r: 200 + r for r in range(ranks)}}
+        w._sending_transfers = defaultdict(list)
+        w._sending_transfers_lock = threading.Lock()
+        topo = MagicMock()
+        topo.get_engine_info.return_value = MagicMock(
+            remote_tp_size=1,
+            remote_block_size=16,
+            remote_physical_blocks_per_logical=1,
+        )
+        topo.block_size_ratio.return_value = 1
+        w.transfer_topo = topo
+        w._logical_to_remote_kernel_block_ids = lambda ids, _n: ids
+        w.nixl_wrapper = MagicMock()
+        w.nixl_wrapper.make_prepped_xfer.side_effect = lambda *a, **k: object()
+        return w
+
+    @staticmethod
+    def _meta(local_ids, remote_ids):
+        remote = MagicMock()
+        remote.engine_id = "eng"
+        remote.request_id = "r0"
+        remote.block_ids = remote_ids
+        meta = MagicMock()
+        meta.remote = remote
+        meta.local_physical_block_ids = local_ids
+        return meta
+
+    def test_one_write_per_paired_rank_with_that_rank_s_handles(self):
+        worker = self._writing_worker(ranks=2)
+
+        worker._xfer_blocks_for_req("r0", self._meta(([1, 2],), ([3, 4],)))
+
+        calls = worker.nixl_wrapper.make_prepped_xfer.call_args_list
+        assert len(calls) == 2
+        assert [c.args[0] for c in calls] == ["WRITE", "WRITE"]
+        assert (calls[0].args[1], calls[0].args[3]) == (100, 200)
+        assert (calls[1].args[1], calls[1].args[3]) == (101, 201)
+        # The request settles only once every WRITE it issued has completed.
+        assert len(worker._sending_transfers["r0"]) == 2
+
+    def test_upstreams_own_submission_path_reaches_our_override(self):
+        # Calling the override directly keeps passing if upstream renames the
+        # hook it dispatches to, so one case has to arrive through the caller.
+        worker = self._writing_worker(ranks=1)
+        worker._ensure_d_handshake = lambda *_args: True
+        worker._physical_blocks_per_logical_kv_block = 1
+
+        NixlPushConnectorWorker._do_start_push_kv(
+            worker,
+            request_id="r0",
+            local_block_ids=[1, 2],
+            registration_data={
+                "decode_engine_id": "eng",
+                "local_block_ids": [3, 4],
+                "decode_host": "",
+                "decode_port": 0,
+                "request_id": "r0",
+                "decode_tp_size": 1,
+            },
+        )
+
+        assert worker.nixl_wrapper.make_prepped_xfer.call_args.args[0] == "WRITE"
+
+    def test_a_peer_a_whole_engine_handle_describes_is_delegated(self, monkeypatch):
+        # Nothing narrowed for this engine: upstream's own route covers it.
+        delegated = []
+        monkeypatch.setattr(
+            NixlPushConnectorWorker,
+            "_xfer_blocks_for_req",
+            lambda self, req_id, meta: delegated.append(req_id),
+        )
+        worker = self._writing_worker(ranks=2)
+        worker._overlapping_ranks = {}
+
+        worker._xfer_blocks_for_req("r0", self._meta(([1, 2],), ([3, 4],)))
+
+        assert delegated == ["r0"]
+        assert worker.nixl_wrapper.make_prepped_xfer.call_count == 0
+
+    def test_every_write_carries_the_same_writer_count(self):
+        worker = self._writing_worker(ranks=2)
+
+        worker._xfer_blocks_for_req("r0", self._meta(([1, 2],), ([3, 4],)))
+
+        notifs = {
+            c.kwargs["notif_msg"]
+            for c in worker.nixl_wrapper.make_prepped_xfer.call_args_list
+        }
+        # world_size 1 against a TP-1 peer: one writer, so the count divides
+        # out to one on the far side.
+        assert notifs == {b"r0:1"}
+
+    def test_a_partial_prefix_hit_keeps_our_matching_tail(self):
+        # The consumer registered only the last block of a three-block prompt,
+        # so this side has to send its LAST block, not its first.
+        worker = self._writing_worker(ranks=1)
+
+        worker._xfer_blocks_for_req("r0", self._meta(([5, 6, 7],), ([9],)))
+
+        call = worker.nixl_wrapper.make_prepped_xfer.call_args_list[0]
+        local_descs, remote_descs = call.args[2], call.args[4]
+        assert len(local_descs) == len(remote_descs)
+        # 2 regions x 1 block, and block 7 is the one that maps to descs 7 / 15
+        # of an 8-block, 2-region shard.
+        assert sorted(local_descs) == [7, 15]
+
+    def test_a_failed_submission_leaves_no_handle_on_the_request(self):
+        # Failing before a handle exists: there is nothing to release, and the
+        # request must not be left holding one.
+        worker = self._writing_worker(ranks=1)
+        worker.nixl_wrapper.make_prepped_xfer.side_effect = RuntimeError("nope")
+        worker._log_failure = MagicMock()
+        worker.xfer_stats = MagicMock()
+
+        worker._xfer_blocks_for_req("r0", self._meta(([1],), ([3],)))
+
+        assert worker._sending_transfers["r0"] == []
+        worker.xfer_stats.record_failed_transfer.assert_called_once()
+        worker.nixl_wrapper.release_xfer_handle.assert_not_called()
+
+    def test_a_failure_after_the_handle_exists_releases_it(self):
+        # The other half of the same branch: the submission succeeded, so a
+        # handle is live and only this releases it. Outbound has no local
+        # metadata to invalidate, so a leak here is silent.
+        worker = self._writing_worker(ranks=1)
+        handle = object()
+        worker.nixl_wrapper.make_prepped_xfer.side_effect = lambda *a, **k: handle
+        worker.nixl_wrapper.transfer.side_effect = RuntimeError("nope")
+        worker._log_failure = MagicMock()
+        worker.xfer_stats = MagicMock()
+
+        worker._xfer_blocks_for_req("r0", self._meta(([1],), ([3],)))
+
+        worker.nixl_wrapper.release_xfer_handle.assert_called_once_with(handle)
+        assert worker._sending_transfers["r0"] == []
+
+    def test_the_engine_is_kept_off_the_staleness_sweep(self):
+        # The sweep drops a quiet engine's state, and this path reads it. The
+        # read path asserts the same touch.
+        worker = self._writing_worker(ranks=1)
+
+        worker._xfer_blocks_for_req("r0", self._meta(([1],), ([3],)))
+
+        assert "eng" in worker._engine_last_active
+
+    def test_unequal_block_sizes_are_refused_on_the_per_shard_route(self):
+        # Descriptor ids are counted in blocks, so a peer whose blocks are a
+        # different size makes both sides agree on a count that means two
+        # different spans.
+        worker = self._writing_worker(ranks=1)
+        worker.transfer_topo.block_size_ratio.return_value = 2
+
+        with pytest.raises(AssertionError, match="equal P/D block sizes"):
+            worker._xfer_blocks_for_req("r0", self._meta(([1],), ([3],)))
+
+    def test_a_consumer_that_had_everything_cached_is_not_written_to(self):
+        # A full prefix hit trims our side to nothing. Posting a zero-descriptor
+        # WRITE would be the alternative, and it is the peer that would then
+        # wait on a notification for a transfer that carries no bytes.
+        worker = self._writing_worker(ranks=1)
+        worker._trim_to_consumer_blocks = lambda local, remote: ((),)
+
+        worker._xfer_blocks_for_req("r0", self._meta(([1],), ([3],)))
+
+        worker.nixl_wrapper.make_prepped_xfer.assert_not_called()
+        assert worker._sending_transfers["r0"] == []
+
+
+class TestTrimToConsumerBlocks:
+    def test_more_blocks_than_the_consumer_registered_trims_the_head(self):
+        trimmed = RblnNixlPushConnectorWorker._trim_to_consumer_blocks(
+            ([1, 2, 3, 4],), ([7, 8],)
+        )
+        assert trimmed == ([3, 4],)
+
+    def test_a_consumer_asking_for_more_than_we_hold_is_an_error(self):
+        with pytest.raises(AssertionError, match="cannot be aligned"):
+            RblnNixlPushConnectorWorker._trim_to_consumer_blocks(([1],), ([7, 8],))
+
+
+class TestWriterCountAccounting:
+    """The consumer must not settle a request while some writer is still going.
+
+    The count rides in the notification scaled by this side's TP, so the same
+    field also has to keep working for a transfer the upstream path submitted.
+    """
+
+    def test_the_counter_survives_a_request_it_has_not_seen(self, monkeypatch):
+        # The one place __init__ runs: every other test here builds the worker
+        # with object.__new__ and hands the counter in already made, so a plain
+        # dict would pass all of them and KeyError on the first notification.
+        monkeypatch.setattr(RblnNixlWorkerBase, "__init__", lambda self, *a: None)
+        worker = RblnNixlPushConnectorWorker(MagicMock(), "eng", MagicMock())
+        worker.shutdown = lambda: None  # the writer state __del__ reaches is absent
+        worker._writer_counts_by_req["r0"] += 1
+        assert worker._writer_counts_by_req == {"r0": 1}
+
+    @staticmethod
+    def _receiving_worker(world_size):
+        w = _push_worker()
+        w.world_size = world_size
+        w._writer_counts_by_req = defaultdict(int)
+        w._reqs_to_send = {}
+        w._reqs_to_process = set()
+        w._recving_metadata = {"r0": object()}
+        w._pending_completion_notifs = queue.Queue()
+        return w
+
+    @pytest.fixture
+    def handed_through(self, monkeypatch):
+        """What reaches upstream, in order."""
+        seen = []
+
+        def fake_base(self):
+            while True:
+                try:
+                    seen.append(self._pending_completion_notifs.get_nowait())
+                except queue.Empty:
+                    return set()
+
+        monkeypatch.setattr(NixlPushConnectorWorker, "_get_new_notifs", fake_base)
+        return seen
+
+    def test_only_the_last_of_four_writers_reaches_the_base(self, handed_through):
+        # Four peer ranks writing into this one: upstream settles on whatever it
+        # sees, so it may see exactly one notification.
+        worker = self._receiving_worker(world_size=1)
+        for _ in range(4):
+            worker._pending_completion_notifs.put(b"r0:4")
+
+        worker._get_new_notifs()
+
+        assert handed_through == [b"r0:4"]
+
+    def test_the_count_carries_across_steps(self, handed_through):
+        # Writers finish whenever they finish; the tally has to survive the
+        # steps in between.
+        worker = self._receiving_worker(world_size=1)
+        for _ in range(3):
+            worker._pending_completion_notifs.put(b"r0:4")
+        worker._get_new_notifs()
+        assert handed_through == []
+
+        worker._pending_completion_notifs.put(b"r0:4")
+        worker._get_new_notifs()
+        assert handed_through == [b"r0:4"]
+
+    def test_a_single_writer_is_passed_straight_through(self, handed_through):
+        # Equal TP with no pipeline: the upstream path submits it and puts its
+        # own tensor-parallel size in the notification, which divides out to one.
+        worker = self._receiving_worker(world_size=4)
+        worker._pending_completion_notifs.put(b"r0:4")
+
+        worker._get_new_notifs()
+
+        assert handed_through == [b"r0:4"]
+
+    @pytest.mark.parametrize(
+        "notif, reason",
+        [
+            (b"HB:engine-1", "heartbeat"),
+            (b"other:4", "not a request we are receiving"),
+        ],
+    )
+    def test_notifications_the_base_owns_are_untouched(
+        self, handed_through, notif, reason
+    ):
+        worker = self._receiving_worker(world_size=1)
+        worker._pending_completion_notifs.put(notif)
+
+        worker._get_new_notifs()
+
+        assert handed_through == [notif], reason
+        assert worker._writer_counts_by_req == {}
+
+    def test_our_own_outbound_request_is_left_to_the_base(self, handed_through):
+        # A request this rank is sending is upstream's own accounting, even
+        # though the notification looks identical.
+        worker = self._receiving_worker(world_size=1)
+        worker._reqs_to_process = {"r0"}
+        worker._pending_completion_notifs.put(b"r0:4")
+
+        worker._get_new_notifs()
+
+        assert handed_through == [b"r0:4"]
+        assert worker._writer_counts_by_req == {}
+
+    def test_upstreams_own_get_finished_is_what_reaches_the_filter(self):
+        # Same reason as the submission path's entry-point case: a direct call
+        # would survive upstream renaming the hook.
+        worker = self._receiving_worker(world_size=1)
+        worker.transfer_topo = MagicMock()
+        worker._recving_transfers = {}
+        worker._failed_recv_reqs = queue.Queue()
+        worker._pop_done_transfers = lambda _transfers: set()
+        worker._pending_completion_notifs.put(b"r0:2")
+
+        done_sending, _ = NixlBaseConnectorWorker.get_finished(worker)
+
+        # Two writers, one report: held back, and the tally advanced.
+        assert done_sending == set()
+        assert worker._writer_counts_by_req["r0"] == 1
+
+    def test_a_finished_request_drops_its_tally(self, monkeypatch):
+        # A retry reuses the request id, so a leftover partial count would
+        # settle it early.
+        worker = self._receiving_worker(world_size=1)
+        worker._writer_counts_by_req["r0"] = 2
+        monkeypatch.setattr(
+            NixlPushConnectorWorker,
+            "get_finished",
+            lambda self: (set(), {"r0"}),
+        )
+
+        worker.get_finished()
+
+        assert worker._writer_counts_by_req == {}
+
+
+class TestSaveBeforeWriteInvariant:
+    """The host copy for a step runs after this call, so a request may not be
+    staged for it and handed to the writer at the same time."""
+
+    @staticmethod
+    def _worker(use_host_buffer):
+        w = _push_worker()
+        w.use_host_buffer = use_host_buffer
+        return w
+
+    @staticmethod
+    def _meta(saves, pushes):
+        return SimpleNamespace(
+            reqs_to_save=dict.fromkeys(saves, object()),
+            push_finished_blocks=dict.fromkeys(pushes, ([1],)),
+        )
+
+    def test_the_same_request_in_both_is_refused(self, monkeypatch):
+        monkeypatch.setattr(
+            NixlPushConnectorWorker, "start_load_kv", lambda self, metadata: None
+        )
+        worker = self._worker(use_host_buffer=True)
+        with pytest.raises(AssertionError, match="unfilled buffer"):
+            worker.start_load_kv(self._meta(saves=["r0"], pushes=["r0"]))
+
+    def test_a_step_apart_is_the_normal_case(self, monkeypatch):
+        seen = []
+        monkeypatch.setattr(
+            NixlPushConnectorWorker,
+            "start_load_kv",
+            lambda self, metadata: seen.append(metadata),
+        )
+        worker = self._worker(use_host_buffer=True)
+        meta = self._meta(saves=["r0"], pushes=["r1"])
+
+        worker.start_load_kv(meta)
+
+        assert seen == [meta]
+
+    def test_direct_transfer_skips_the_check(self, monkeypatch):
+        # No staging buffer to be caught half-filled; the device KV is settled
+        # by the time a request finishes.
+        monkeypatch.setattr(
+            NixlPushConnectorWorker, "start_load_kv", lambda self, metadata: None
+        )
+        worker = self._worker(use_host_buffer=False)
+        worker.start_load_kv(self._meta(saves=["r0"], pushes=["r0"]))
+
+
+class TestHandlesArePublishedAtOnce:
+    """The engine thread settles a request once every handle it can see is
+    done. A half-published set lets it settle early, and the peers landing
+    afterwards become a second completion for a request already forgotten."""
+
+    def test_nothing_is_visible_until_every_peer_is_submitted(self):
+        worker = TestPerShardWrite._writing_worker(ranks=4)
+        seen_midway = []
+
+        def submit(*args, **kwargs):
+            # Stand in for the engine thread polling between submissions.
+            seen_midway.append(len(worker._sending_transfers.get("r0", [])))
+            return object()
+
+        worker.nixl_wrapper.make_prepped_xfer.side_effect = submit
+
+        worker._xfer_blocks_for_req("r0", TestPerShardWrite._meta(([1],), ([3],)))
+
+        # Nothing was published while the four were being prepped, and all
+        # four appeared together.
+        assert seen_midway == [0, 0, 0, 0]
+        assert len(worker._sending_transfers["r0"]) == 4
+
+    def test_a_failed_peer_does_not_hide_the_ones_that_went_out(self):
+        worker = TestPerShardWrite._writing_worker(ranks=4)
+        worker._log_failure = MagicMock()
+        worker.xfer_stats = MagicMock()
+        calls = {"n": 0}
+
+        def submit(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise RuntimeError("nope")
+            return object()
+
+        worker.nixl_wrapper.make_prepped_xfer.side_effect = submit
+
+        worker._xfer_blocks_for_req("r0", TestPerShardWrite._meta(([1],), ([3],)))
+
+        # The three that were transferred still have to be waited on.
+        assert len(worker._sending_transfers["r0"]) == 3
+        worker.xfer_stats.record_failed_transfer.assert_called_once()
+
+
+class TestReplicaFanOut:
+    """A chiplet replica is a fine thing to read from and a bad thing to be the
+    only destination written to: the peer's other chiplets would keep serving
+    what was there before. Reading takes one copy, writing takes them all."""
+
+    @staticmethod
+    def _worker(cls, *, areas=4, slices=4):
+        w = object.__new__(cls)
+        w.shutdown = lambda: None
+        w._kv_areas, w._kv_slices = areas, slices
+        w._sw_ratio = None
+        w.use_host_buffer = False
+        w.device_id = 0
+        w.block_len_per_layer = [4096] * 2
+        topo = MagicMock()
+        topo.total_num_kv_heads = 8
+        topo.tp_size = 1
+        topo.tp_rank = 0
+        topo.tp_ratio.return_value = -4  # the peer is cut four ways
+        w.transfer_topo = topo
+        w.tp_rank = 0
+        w.get_backend_aware_kv_block_len = lambda **kw: 1024
+        return w
+
+    @staticmethod
+    def _peer_meta(areas=4, slices=2):
+        # A TP4 rank of an 8-head model: 2 heads, each duplicated across two of
+        # the four chiplet areas -> two copies of every slice.
+        meta = MagicMock()
+        meta.kv_areas, meta.kv_slices = areas, slices
+        meta.num_blocks = 1
+        meta.kv_caches_base_addr = [1000 * (i + 1) for i in range(areas)]
+        meta.block_lens = [1024] * areas
+        return meta
+
+    def test_the_read_path_names_one_copy(self):
+        worker = self._worker(RblnNixlPullConnectorWorker)
+        assert worker._peer_replica_fanout(self._peer_meta(), 4) == 1
+
+    def test_the_write_path_names_every_copy(self):
+        worker = self._worker(RblnNixlPushConnectorWorker)
+        assert worker._peer_replica_fanout(self._peer_meta(), 4) == 2
+
+    def test_a_peer_without_copies_is_the_same_either_way(self):
+        # areas == slices: nothing is duplicated, so there is only one place to
+        # put the bytes and the two directions agree.
+        for cls in (RblnNixlPullConnectorWorker, RblnNixlPushConnectorWorker):
+            worker = self._worker(cls)
+            assert worker._peer_replica_fanout(self._peer_meta(slices=4), 4) == 1
+
+    def test_host_staging_has_no_copies_to_fan_out_to(self):
+        worker = self._worker(RblnNixlPushConnectorWorker)
+        worker.use_host_buffer = True
+        assert worker._peer_replica_fanout(self._peer_meta(), 4) == 1
+
+    @pytest.mark.parametrize(
+        "cls, expected_regions",
+        [
+            # Peer regions are (logical * areas + slice * replicas + copy).
+            # Reading takes copy 0 of the slice; writing takes 0 and 1.
+            (RblnNixlPullConnectorWorker, [1000]),
+            (RblnNixlPushConnectorWorker, [1000, 2000]),
+        ],
+    )
+    def test_descriptors_land_on_those_copies(self, cls, expected_regions):
+        worker = self._worker(cls)
+        fanout = worker._peer_replica_fanout(self._peer_meta(), 4)
+        meta = self._peer_meta()
+
+        descs = worker._head_matched_desc(
+            region_id=0,
+            logical_r=0,
+            area_l=0,
+            geom=(0, 2, 1),  # our area carries heads 0-1, no duplication
+            peer=(0, 2, 2, 2),  # peer: heads from 0, 2 per slice, 2 copies, 2 slices
+            areas_r=4,
+            remote_bases=meta.kv_caches_base_addr,
+            remote_lens=meta.block_lens,
+            device_id=0,
+            num_blocks=1,
+        )
+
+        assert [addr for addr, _len, _dev in descs] == expected_regions
+        assert len(descs) == fanout
+
+
+class TestTheThreeListsAgree:
+    """remote dlist, local dlist and the descriptor ids index one another, so
+    they have to expand a block by the same factor. Checking the fan-out in
+    isolation missed that the remote builder's own tally still assumed the
+    head pieces alone."""
+
+    @staticmethod
+    def _worker(cls):
+        # One layer, K and V, each expanded across four chiplet areas.
+        regions = 8
+        w = object.__new__(cls)
+        w.shutdown = lambda: None
+        w._kv_areas, w._kv_slices = 4, 4
+        w._sw_ratio = None
+        w.use_host_buffer = False
+        w.device_id = 0
+        w.engine_id = "eng-local"
+        w.tp_rank = 0
+        w.num_blocks = 2
+        w.block_size = 16
+        w._has_mamba = False
+        w.num_regions = regions
+        w.block_len_per_layer = [512] * regions
+        w.local_seen_layer_names = ["l0"]
+        w.kv_caches_base_addr = {
+            "eng-local": {0: [10_000 * (i + 1) for i in range(regions)]}
+        }
+        topo = MagicMock()
+        topo.total_num_kv_heads = 8
+        topo.tp_size = 1
+        topo.is_kv_layout_blocks_first = False
+        topo.tp_ratio.return_value = -4
+        w.transfer_topo = topo
+        w.get_backend_aware_kv_block_len = lambda **kw: 512
+        w.nixl_wrapper = MagicMock()
+        w.nixl_wrapper.get_xfer_descs.side_effect = lambda data, _t: data
+        w.nixl_wrapper.prep_xfer_dlist.return_value = 7
+        w.nixl_memory_type = "VRAM"
+        return w
+
+    @staticmethod
+    def _peer():
+        # A TP4 rank: 2 heads, each duplicated across two of its four areas.
+        meta = MagicMock()
+        meta.kv_areas, meta.kv_slices = 4, 2
+        meta.num_blocks = 2
+        meta.device_id = 0
+        # Same shape as ours: K and V, each across its four areas.
+        meta.kv_caches_base_addr = [100_000 * (i + 1) for i in range(8)]
+        meta.block_lens = [512] * 8
+        return meta
+
+    @pytest.mark.parametrize(
+        "cls", [RblnNixlPullConnectorWorker, RblnNixlPushConnectorWorker]
+    )
+    def test_both_sides_describe_the_same_number_of_pieces(self, cls):
+        worker = self._worker(cls)
+        peer = self._peer()
+        fanout = worker._peer_replica_fanout(peer, 4)
+        split = worker._peer_head_split(peer, 4)
+        areas = worker._fan_in_peer_areas(0, 4)
+
+        remote = worker._build_head_matched_remote(peer, 0, 4, peer_areas=areas)
+        _handle, local = worker._register_shard_local_xfer_handler(
+            worker.block_size,
+            ("l0",),
+            peer_areas=areas,
+            split=split,
+            replica_fanout=fanout,
+        )
+
+        assert len(remote) == len(local)
+        # And that length is the fan-out times what one copy would have needed.
+        assert len(remote) % fanout == 0
+        assert (cls is RblnNixlPushConnectorWorker) == (fanout == 2)
+
+
+class TestDelegatedRouteAlignment:
+    """A peer a whole-engine handle already describes is written by upstream,
+    whose alignment truncates the longer block list and keeps its head. Under a
+    partial prefix hit the consumer registered its tail, so the head is wrong."""
+
+    @staticmethod
+    def _worker(*, blocks_per_logical=1):
+        w = TestPerShardWrite._writing_worker(ranks=1)
+        w._overlapping_ranks = {}  # nothing narrowed: upstream's route
+        w.transfer_topo.get_engine_info.return_value = MagicMock(
+            remote_tp_size=1,
+            remote_block_size=16,
+            remote_physical_blocks_per_logical=blocks_per_logical,
+        )
+        return w
+
+    @staticmethod
+    def _local_reaching_base(monkeypatch, worker, meta):
+        seen: dict[str, tuple] = {}
+        monkeypatch.setattr(
+            NixlPushConnectorWorker,
+            "_xfer_blocks_for_req",
+            lambda self, req_id, meta: seen.update(local=meta.local_physical_block_ids),
+        )
+        worker._xfer_blocks_for_req("r0", meta)
+        return seen["local"]
+
+    def test_the_producer_tail_is_what_reaches_the_base(self, monkeypatch):
+        # The consumer kept one block: its cache covered everything before it.
+        local = self._local_reaching_base(
+            monkeypatch, self._worker(), TestPerShardWrite._meta(([5, 6, 7],), ([9],))
+        )
+
+        assert local == ([7],)
+
+    def test_an_expanded_remote_list_is_left_to_the_base(self, monkeypatch):
+        # Guard: past the identity expansion the two lengths count different
+        # things, so trimming one against the other would be arithmetic on
+        # unlike units.
+        local = self._local_reaching_base(
+            monkeypatch,
+            self._worker(blocks_per_logical=2),
+            TestPerShardWrite._meta(([5, 6, 7],), ([9],)),
+        )
+
+        assert local == ([5, 6, 7],)
+
+    def test_without_a_prefix_hit_nothing_moves(self, monkeypatch):
+        # Guard: equal lists are the ordinary case and must pass through.
+        local = self._local_reaching_base(
+            monkeypatch,
+            self._worker(),
+            TestPerShardWrite._meta(([5, 6, 7],), ([1, 2, 3],)),
+        )
+
+        assert local == ([5, 6, 7],)

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/factory.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/factory.py
@@ -27,6 +27,11 @@ KVConnectorFactory.register_connector(
     "RblnNixlPullConnector",
 )
 KVConnectorFactory.register_connector(
+    "RblnNixlPushConnector",
+    "vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl",
+    "RblnNixlPushConnector",
+)
+KVConnectorFactory.register_connector(
     "RBLNLMCacheConnectorV1",
     "vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_lmcache_connector",
     "RBLNLMCacheConnectorV1",

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/__init__.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/__init__.py
@@ -23,6 +23,7 @@ from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.base_worker imp
 from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.connector import (
     RblnNixlConnectorBase,
     RblnNixlPullConnector,
+    RblnNixlPushConnector,
 )
 from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.pull_scheduler import (
     RblnNixlPullConnectorScheduler,
@@ -30,12 +31,21 @@ from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.pull_scheduler 
 from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.pull_worker import (
     RblnNixlPullConnectorWorker,
 )
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.push_scheduler import (
+    RblnNixlPushConnectorScheduler,
+)
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.push_worker import (
+    RblnNixlPushConnectorWorker,
+)
 
 __all__ = [
     "RblnNixlConnectorBase",
     "RblnNixlPullConnector",
     "RblnNixlPullConnectorScheduler",
     "RblnNixlPullConnectorWorker",
+    "RblnNixlPushConnector",
+    "RblnNixlPushConnectorScheduler",
+    "RblnNixlPushConnectorWorker",
     "RblnNixlSchedulerBase",
     "RblnNixlWorkerBase",
 ]

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/base_worker.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/base_worker.py
@@ -14,7 +14,7 @@
 
 from collections import defaultdict
 from dataclasses import replace
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 import msgspec
 import numpy as np
@@ -104,6 +104,12 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
 
     compat_hash: str | None
     xfer_handshake_metadata: NixlHandshakePayload | None
+
+    #: Whether this side originates the bytes into the peer's memory. Two things
+    #: turn on it: a chiplet replica is a valid source to read from but not a
+    #: valid sole destination to write to (`_head_matched_desc`), and a peer
+    #: moving bytes the other way must not pass the handshake (`rbln_compat_hash`).
+    _writes_into_peer: ClassVar[bool] = False
 
     def __init__(
         self, vllm_config: VllmConfig, engine_id: str, kv_cache_config: "KVCacheConfig"
@@ -548,9 +554,15 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
         peer_areas: list[int] | None = None,
         split: int = 1,
         region_ids: list[int] | None = None,
+        replica_fanout: int = 1,
     ) -> tuple[int, list[tuple[int, int, int]]]:
         if self._sw_ratio is None:
-            if registered_layer_names is None and peer_areas is None and split == 1:
+            if (
+                registered_layer_names is None
+                and peer_areas is None
+                and split == 1
+                and replica_fanout == 1
+            ):
                 # No SWA view opt, whole-engine peer: upstream's Full-only
                 # layout, one handle covering every region.
                 return super().register_local_xfer_handler(block_size)
@@ -562,8 +574,14 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
                 peer_areas=peer_areas,
                 split=split,
                 region_ids=region_ids,
+                replica_fanout=replica_fanout,
             )
-        assert registered_layer_names is None and peer_areas is None and split == 1, (
+        assert (
+            registered_layer_names is None
+            and peer_areas is None
+            and split == 1
+            and replica_fanout == 1
+        ), (
             "RBLN NIXL: SWA view-opt is not supported with pipeline "
             "parallelism or heterogeneous tensor parallelism"
         )
@@ -751,9 +769,13 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
                         num_blocks=num_blocks,
                     )
                 )
-        # The same count `_register_shard_local_xfer_handler` builds locally
-        # and `_shard_descs_per_block` records.
-        assert len(out) == len(logical_pairs) * len(areas_iter) * num_blocks * split
+        # Per block, a region becomes one descriptor per head piece per peer
+        # copy -- the same count `_register_shard_local_xfer_handler` builds
+        # locally and `_shard_descs_per_block` records.
+        fanout = replicas_r if self._writes_into_peer else 1
+        assert len(out) == (
+            len(logical_pairs) * len(areas_iter) * num_blocks * split * fanout
+        )
         return out
 
     def _fan_in_peer_areas(
@@ -832,7 +854,9 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
         sub_len = desc_len // split
 
         # Replicas of a slice hold identical bytes, so reading any one of them
-        # answers; take the first.
+        # answers -- but writing only one leaves the peer's other chiplets on
+        # stale KV. Reading takes the first; writing takes them all.
+        fanout = replicas_r if self._writes_into_peer else 1
 
         out: list[tuple[int, int, int]] = []
         pieces: list[tuple[int, int]] = []
@@ -846,23 +870,25 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
                     f"outside the peer's range (it owns heads {base_r}.."
                     f"{base_r + per_slice_r * slices_r - 1})."
                 )
-            remote_region = logical_r * areas_r + slice_r * replicas_r
-            page = remote_lens[remote_region]
-            if page % per_slice_r != 0:
-                raise RuntimeError(
-                    f"RBLN NIXL D2D: peer region {remote_region} block length "
-                    f"{page}B does not split into {per_slice_r} heads."
-                )
-            # Heads are contiguous inside a block, so skipping `head_within` of
-            # them is a plain byte offset.
-            head_offset = head_within * (page // per_slice_r)
-            if sub_len + head_offset > page:
-                raise RuntimeError(
-                    f"RBLN NIXL D2D: local region {region_id} piece {j} wants "
-                    f"{sub_len}B at +{head_offset}B, past the end of the peer's "
-                    f"{page}B region {remote_region}."
-                )
-            pieces.append((remote_bases[remote_region] + head_offset, page))
+            for k in range(fanout):
+                remote_region = logical_r * areas_r + slice_r * replicas_r + k
+                page = remote_lens[remote_region]
+                if page % per_slice_r != 0:
+                    raise RuntimeError(
+                        f"RBLN NIXL D2D: peer region {remote_region} block "
+                        f"length {page}B does not split into {per_slice_r} "
+                        "heads."
+                    )
+                # Heads are contiguous inside a block, so skipping
+                # `head_within` of them is a plain byte offset.
+                head_offset = head_within * (page // per_slice_r)
+                if sub_len + head_offset > page:
+                    raise RuntimeError(
+                        f"RBLN NIXL D2D: local region {region_id} piece {j} "
+                        f"wants {sub_len}B at +{head_offset}B, past the end of "
+                        f"the peer's {page}B region {remote_region}."
+                    )
+                pieces.append((remote_bases[remote_region] + head_offset, page))
 
         for block_id in range(num_blocks):
             for base, page in pieces:
@@ -894,6 +920,22 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
             side="peer",
         )
         return self._head_split(per_slice_l, per_slice_r)
+
+    def _peer_replica_fanout(
+        self, nixl_agent_meta: RblnNixlAgentMetadata, remote_tp_size: int
+    ) -> int:
+        """How many of the peer's copies of a slice one transfer must touch.
+
+        The compiler duplicates a KV head across chiplet areas when a shard
+        owns fewer heads than the device has chiplets. Reading is free to pick
+        one; writing has to fill them all, or the peer's other chiplets keep
+        serving what was there before.
+        """
+        if not self._writes_into_peer:
+            return 1
+        if not self._is_head_matched_peer(remote_tp_size):
+            return 1
+        return max(1, nixl_agent_meta.kv_areas // nixl_agent_meta.kv_slices)
 
     @staticmethod
     def _head_split(per_slice_l: int, per_slice_r: int) -> int:
@@ -1213,7 +1255,9 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
         )
         base_hash = self.compat_hash
         assert base_hash is not None
-        self.compat_hash = rbln_compat_hash(base_hash)
+        self.compat_hash = rbln_compat_hash(
+            base_hash, writes_into_peer=self._writes_into_peer
+        )
         self.xfer_handshake_metadata = NixlHandshakePayload(
             compatibility_hash=self.compat_hash,
             agent_metadata_bytes=msgspec.msgpack.Encoder().encode(pp_meta),
@@ -1362,6 +1406,7 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
                     # carry, since the peer frees a request's blocks by it.
                     partial = len(overlap) < len(names)
                     split = self._peer_head_split(metadata, remote_tp_size)
+                    fanout = self._peer_replica_fanout(metadata, remote_tp_size)
                     fan_in = self._is_fan_in_peer(remote_tp_size)
 
                     if self._is_head_matched_peer(remote_tp_size):
@@ -1400,6 +1445,7 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
                         ),
                         split=split,
                         remote_tp_size=remote_tp_size,
+                        replica_fanout=fanout,
                     )
                     overlapping.append(global_rank)
         # Published once, not accumulated: a handshake that raises partway
@@ -1453,6 +1499,7 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
         peer_areas: list[int] | None = None,
         split: int = 1,
         remote_tp_size: int = 1,
+        replica_fanout: int = 1,
     ) -> None:
         # Compute the local region ids once and reuse them for the handler
         # (PP context is always the shard path: SWA + PP is rejected earlier).
@@ -1472,6 +1519,7 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
                 peer_areas=peer_areas,
                 split=split,
                 region_ids=region_ids,
+                replica_fanout=replica_fanout,
             )
         self.src_xfer_handles_by_remote[key] = handle
         n_groups = len(self.kv_cache_config.kv_cache_groups)
@@ -1480,7 +1528,7 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
             f"got {n_groups}"
         )
         self._shard_region_group_ids[(engine_id, global_rank)] = (0,) * len(region_ids)
-        self._shard_descs_per_block[(engine_id, global_rank)] = split
+        self._shard_descs_per_block[(engine_id, global_rank)] = split * replica_fanout
 
     def _cleanup_remote_engine(
         self, engine_id: str, *, log_eviction: bool = True
@@ -1605,6 +1653,7 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
         peer_areas: list[int] | None = None,
         split: int = 1,
         region_ids: list[int] | None = None,
+        replica_fanout: int = 1,
     ) -> tuple[int, list[tuple[int, int, int]]]:
         assert self.transfer_topo is not None
         assert not self.transfer_topo.is_kv_layout_blocks_first, (
@@ -1636,13 +1685,17 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
             sub_len = kv_block_len // split
             for block_id in range(num_blocks):
                 for j in range(split):
-                    blocks_data.append(
-                        (
-                            base_addr + block_id * stride + j * sub_len,
-                            sub_len,
-                            self.device_id,
+                    # One entry per peer copy this piece goes to: the same
+                    # bytes reach every replica (see _head_matched_desc), so
+                    # the source repeats while the destination advances.
+                    for _ in range(replica_fanout):
+                        blocks_data.append(
+                            (
+                                base_addr + block_id * stride + j * sub_len,
+                                sub_len,
+                                self.device_id,
+                            )
                         )
-                    )
 
         descs = self.nixl_wrapper.get_xfer_descs(blocks_data, self.nixl_memory_type)
         return (
@@ -1877,11 +1930,16 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
     ) -> bytes:
         """Notification carrying how many of our ranks pair with one peer rank.
 
-        NOTE(RBLN): upstream sends its own TP size, which the peer divides by its
-        own to learn how many of us to hear from before freeing the request's
-        blocks. A finer pipeline here multiplies that, each stage pairing with
-        the same peer rank, so send it in the unit the peer already divides by:
-        ours times the peer's TP. The two agree whenever the pipelines match.
+        NOTE(RBLN): upstream sends its own tensor-parallel size, which the peer
+        divides by its own to learn how many of us to hear from before settling
+        the request -- freeing its blocks on the read path, declaring them
+        written on the write path. A finer pipeline on our side multiplies that,
+        each stage pairing with the same peer rank for its own layers, so send
+        the count in the unit the peer already divides by: ours times the peer's
+        TP. The two agree whenever the pipelines match, which is every shape
+        upstream assumes.
+
+        Direction-free -- it only asks how much finer we are cut than the peer.
         """
         remote_pp = self._remote_pp_size.get(engine_id, 1)
         local_pp = self.vllm_config.parallel_config.pipeline_parallel_size

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/connector.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/connector.py
@@ -26,6 +26,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
     NixlBaseConnector,
     NixlPullConnector,
+    NixlPushConnector,
 )
 
 import vllm_rbln.envs as envs
@@ -40,6 +41,12 @@ from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.pull_scheduler 
 )
 from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.pull_worker import (
     RblnNixlPullConnectorWorker,
+)
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.push_scheduler import (
+    RblnNixlPushConnectorScheduler,
+)
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.push_worker import (
+    RblnNixlPushConnectorWorker,
 )
 from vllm_rbln.distributed.kv_transfer.kv_connector.v1.utils import (
     SupportsKVCacheRegistrationFinalize,
@@ -149,5 +156,25 @@ class RblnNixlPullConnector(RblnNixlConnectorBase, NixlPullConnector):
             )
         elif role == KVConnectorRole.WORKER:
             self.connector_worker = RblnNixlPullConnectorWorker(
+                vllm_config, self.engine_id, kv_cache_config
+            )
+
+
+class RblnNixlPushConnector(RblnNixlConnectorBase, NixlPushConnector):
+    """Push-based (WRITE) RBLN NIXL KV transfer connector."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        role: KVConnectorRole,
+        kv_cache_config: "KVCacheConfig",
+    ) -> None:
+        super().__init__(vllm_config, role, kv_cache_config)
+        if role == KVConnectorRole.SCHEDULER:
+            self.connector_scheduler = RblnNixlPushConnectorScheduler(
+                vllm_config, self.engine_id, kv_cache_config
+            )
+        elif role == KVConnectorRole.WORKER:
+            self.connector_worker = RblnNixlPushConnectorWorker(
                 vllm_config, self.engine_id, kv_cache_config
             )

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/metadata.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/metadata.py
@@ -30,10 +30,14 @@ from dataclasses import dataclass, field
 from vllm.config.utils import hash_factors
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl import NixlAgentMetadata
 
-# Bump on any incompatible change to the fields below. Folded into the NIXL
-# compatibility hash so a peer speaking a different schema fails the handshake
-# instead of misreading it, the way upstream uses ``NIXL_CONNECTOR_VERSION``.
-RBLN_NIXL_CONNECTOR_VERSION: int = 2
+# Bump on any incompatible change to the RBLN metadata schema or semantics.
+# Folded into the NIXL compatibility hash so an RBLN peer speaking a different
+# schema fails the handshake cleanly (both ends are RBLN). Upstream keeps its
+# own counterpart the same way (``NIXL_CONNECTOR_VERSION``).
+#   1: pp_rank / pp_size / registered_layer_names (the layer axis)
+#   2: + kv_areas / kv_slices (the head axis: chiplet geometry)
+#   3: + the transfer direction in the hash
+RBLN_NIXL_CONNECTOR_VERSION: int = 3
 
 
 @dataclass
@@ -55,12 +59,21 @@ class RblnNixlAgentMetadata(NixlAgentMetadata):
     kv_slices: int = 1
 
 
-def rbln_compat_hash(base_hash: str) -> str:
-    """Fold the RBLN schema version into the upstream NIXL compat hash.
+def rbln_compat_hash(base_hash: str, *, writes_into_peer: bool) -> str:
+    """Fold the RBLN schema version and the transfer direction into the upstream
+    NIXL compat hash.
 
     An extension rather than a change to ``compute_nixl_compatibility_hash``,
-    which stays upstream's.
+    which stays upstream's. The direction belongs in it because the read and the
+    write path move bytes by protocols that do not meet: a producer that writes
+    into a consumer expecting to read finds a peer whose every length check
+    passes. This vLLM hashes nothing that separates them -- the connector name
+    is not a factor -- so this is the only place it can be settled.
     """
     return hash_factors(
-        {"base": base_hash, "rbln_nixl_connector_version": RBLN_NIXL_CONNECTOR_VERSION}
+        {
+            "base": base_hash,
+            "rbln_nixl_connector_version": RBLN_NIXL_CONNECTOR_VERSION,
+            "rbln_writes_into_peer": writes_into_peer,
+        }
     )

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/push_scheduler.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/push_scheduler.py
@@ -1,0 +1,51 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TYPE_CHECKING, Any
+
+from vllm.distributed.kv_transfer.kv_connector.utils import BlockIds
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
+    NixlPushConnectorScheduler,
+)
+
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.base_scheduler import (
+    RblnNixlSchedulerBase,
+)
+
+if TYPE_CHECKING:
+    from vllm.v1.request import Request
+
+
+class RblnNixlPushConnectorScheduler(RblnNixlSchedulerBase, NixlPushConnectorScheduler):
+    """Scheduler side of the write path."""
+
+    def request_finished(
+        self, request: "Request", block_ids: BlockIds
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """Give a request turned away before it was scheduled the field the
+        metadata builder will read from it.
+
+        NOTE(RBLN): a request the serving layer rejects -- a prompt past the
+        context length, a client that left -- reaches upstream still flagged for
+        a remote prefill, and upstream registers an empty receive for it so the
+        producer stops holding the blocks it pinned. Building that receive reads
+        `remote_block_ids`, which on this direction is filled by
+        `update_state_after_alloc`, the one call a rejected request never makes,
+        and the engine dies on the missing key. The read path is unaffected:
+        there the field arrives with the producer's own reply.
+        """
+        params = request.kv_transfer_params
+        if params is not None and params.get("do_remote_prefill"):
+            params.setdefault("remote_block_ids", ())
+        return super().request_finished(request, block_ids)

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/push_worker.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/push_worker.py
@@ -188,7 +188,10 @@ class RblnNixlPushConnectorWorker(RblnNixlWorkerBase, NixlPushConnectorWorker):
             # identity: past that the two lengths are not the same unit.
             if remote_info.remote_physical_blocks_per_logical == 1:
                 meta.local_physical_block_ids = self._trim_to_consumer_blocks(
-                    meta.local_physical_block_ids, meta.remote.block_ids
+                    meta.local_physical_block_ids,
+                    meta.remote.block_ids,
+                    engine_id,
+                    meta.remote.request_id,
                 )
             return super()._xfer_blocks_for_req(req_id, meta)
 
@@ -211,7 +214,7 @@ class RblnNixlPushConnectorWorker(RblnNixlWorkerBase, NixlPushConnectorWorker):
         )
 
         local_block_ids = self._trim_to_consumer_blocks(
-            local_block_ids, remote_block_ids
+            local_block_ids, remote_block_ids, engine_id, meta.remote.request_id
         )
         n_write_blocks = sum(len(g) for g in local_block_ids)
         if not n_write_blocks:
@@ -277,7 +280,10 @@ class RblnNixlPushConnectorWorker(RblnNixlWorkerBase, NixlPushConnectorWorker):
 
     @staticmethod
     def _trim_to_consumer_blocks(
-        local_block_ids: BlockIds, remote_block_ids: BlockIds
+        local_block_ids: BlockIds,
+        remote_block_ids: BlockIds,
+        engine_id: str,
+        req_id: str,
     ) -> BlockIds:
         """Drop from our side the blocks the consumer already had.
 
@@ -293,10 +299,14 @@ class RblnNixlPushConnectorWorker(RblnNixlWorkerBase, NixlPushConnectorWorker):
         local = list(local_block_ids)
         for i, remote_group in enumerate(remote_block_ids):
             num_remote = len(remote_group)
-            assert num_remote <= len(local[i]), (
-                f"group {i}: consumer registered {num_remote} blocks but this "
-                f"producer holds {len(local[i])}; the pair cannot be aligned"
-            )
+            if num_remote > len(local[i]):
+                raise RuntimeError(
+                    f"RBLN NIXL: consumer {engine_id} registered {num_remote} "
+                    f"block(s) for request {req_id} in group {i}, more than the "
+                    f"{len(local[i])} this producer holds; the peer's advertised "
+                    "length crosses the handshake, so the pair is refused rather "
+                    "than trimmed to it."
+                )
             if num_remote < len(local[i]):
                 local[i] = local[i][-num_remote:]
         return tuple(local)

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/push_worker.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/push_worker.py
@@ -1,0 +1,302 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import queue
+import threading
+import time
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.utils import (
+    BlockIds,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
+    NixlPushConnectorWorker,
+)
+
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.base_worker import (
+    RblnNixlWorkerBase,
+)
+from vllm_rbln.logger import init_logger
+
+if TYPE_CHECKING:
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+        NixlConnectorMetadata,
+        ReqMeta,
+    )
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+
+logger = init_logger(__name__)
+
+
+class RblnNixlPushConnectorWorker(RblnNixlWorkerBase, NixlPushConnectorWorker):
+    """Writes a request's KV to the consumer that registered for it.
+
+    The producer drives the transfer here, so the peer this rank hands its
+    metadata to is the consumer rather than the other way round. Pairing does
+    not care -- it describes what two peers hold -- so what belongs here is the
+    write: which peers to issue it against, the writer thread that issues it,
+    and the count a consumer settles a request by.
+    """
+
+    _writes_into_peer = True
+
+    def __init__(
+        self, vllm_config: VllmConfig, engine_id: str, kv_cache_config: "KVCacheConfig"
+    ) -> None:
+        super().__init__(vllm_config, engine_id, kv_cache_config)
+
+        # Completion notifications seen per request being received, counted
+        # against the number of writers the peer put in them.
+        self._writer_counts_by_req: defaultdict[str, int] = defaultdict(int)
+
+    def start_load_kv(self, metadata: "NixlConnectorMetadata") -> None:
+        """Hand this step's work to the writer, once the KV it names is settled.
+
+        NOTE(RBLN): the writer is woken here, at the START of a step, while the
+        host copy for the same step's saves runs at its END (`wait_for_save`).
+        Today no request is in both: a producer hands its blocks over in
+        `request_finished`, which runs after this step's metadata was already
+        built, so the blocking copy always lands a step earlier. Nothing states
+        that, and if it ever stopped holding, the writer would ship a staging
+        buffer still being filled -- silently, and only under host staging.
+        """
+        if self.use_host_buffer and metadata.push_finished_blocks:
+            both = metadata.push_finished_blocks.keys() & metadata.reqs_to_save.keys()
+            assert not both, (
+                "RBLN NIXL push: request(s) staged for the host copy and handed "
+                f"to the writer in one step: {sorted(both)}. The copy runs after "
+                "this call, so the write would read an unfilled buffer."
+            )
+        super().start_load_kv(metadata)
+
+    def finalize_kv_cache_registration(self) -> None:
+        """Register the deferred D2D memory, then make sure the writer runs.
+
+        NOTE(RBLN): D2D defers registration past `register_kv_caches`, and that
+        early return skips the writer-thread start hung off it upstream -- the
+        pushes would then queue with nothing draining them. Start it here; the
+        start is guarded on the thread being unset, so host staging, which does
+        reach the upstream method, is unaffected.
+        """
+        super().finalize_kv_cache_registration()
+        self._ensure_push_writer()
+
+    def _ensure_push_writer(self) -> None:
+        # NOTE(RBLN): the writer start is inlined in the upstream
+        # `register_kv_caches`, which the D2D deferral never reaches, so it is
+        # mirrored here. Both are guarded on the thread being unset, so exactly
+        # one of them starts it whichever path ran.
+        if self._push_writer_thread is not None:
+            return
+        self._push_writer_thread: threading.Thread | None = threading.Thread(
+            target=self._push_writer_loop,
+            daemon=True,
+            name="nixl-push-writer",
+        )
+        self._push_writer_thread.start()
+        logger.info("nixl-push-writer thread started (rank=%d)", self.tp_rank)
+
+    def _get_new_notifs(self) -> set[str]:
+        """Hold a request back until every writer of it has reported.
+
+        NOTE(RBLN): upstream settles a pushed request on the FIRST completion
+        notification, which is right only while one peer rank writes the whole
+        thing. Several do as soon as either axis is cut finer on their side, and
+        the rest of them are still writing -- host staging would copy a
+        half-filled buffer to the device. Each writer's notification carries the
+        count (see `_xfer_notif_id`), so drop all but the last one and let
+        upstream settle the request on that.
+        """
+        for notif in self._drain_completion_notifs():
+            if self._writer_still_pending(notif):
+                continue
+            self._pending_completion_notifs.put(notif)
+        return super()._get_new_notifs()
+
+    def _drain_completion_notifs(self) -> list[bytes]:
+        notifs = []
+        while True:
+            try:
+                notifs.append(self._pending_completion_notifs.get_nowait())
+            except queue.Empty:
+                return notifs
+
+    def _writer_still_pending(self, notif: bytes) -> bool:
+        """Whether this notification leaves a request short of its writers.
+
+        False for anything upstream has to see itself: heartbeats, our own
+        outbound accounting, and a request we are not receiving.
+        """
+        msg = notif.decode("utf-8")
+        if msg.startswith("HB:"):
+            return False
+        req_id, count = msg.rsplit(":", 1)
+        if req_id in self._reqs_to_send or req_id in self._reqs_to_process:
+            return False
+        if req_id not in self._recving_metadata:
+            return False
+        # The peer scales the count by our tensor-parallel size, the unit
+        # upstream divides by on the other direction (see `_xfer_notif_id`).
+        writers = max(1, int(count) // self.world_size)
+        self._writer_counts_by_req[req_id] += 1
+        return self._writer_counts_by_req[req_id] < writers
+
+    def get_finished(self) -> tuple[set[str], set[str]]:
+        done_sending, done_recving = super().get_finished()
+        # Both completion and failure land here, and a retried request must not
+        # inherit a partial count.
+        for req_id in done_recving:
+            self._writer_counts_by_req.pop(req_id, None)
+        return done_sending, done_recving
+
+    def _xfer_blocks_for_req(self, req_id: str, meta: "ReqMeta") -> None:
+        """Write this request's blocks, one transfer per paired peer rank.
+
+        Runs on the writer thread, which is also where upstream writes
+        `_engine_last_active` and runs the eviction sweep on this path, so the
+        touch below needs no lock. Handles go out under the sending lock.
+        """
+        assert meta.remote is not None and self.transfer_topo is not None
+        engine_id = meta.remote.engine_id
+        # Keep the engine off the staleness sweep: a swept peer loses the state
+        # this path reads, and upstream refreshes it on the route it replaces.
+        self._engine_last_active[engine_id] = time.perf_counter()
+        remote_info = self.transfer_topo.get_engine_info(engine_id)
+        # Per-shard lists exist exactly for peers serving part of what a
+        # whole-engine handle covers; without any, upstream describes them all.
+        # Read once: a handshake replacing the entry between uses would leave the
+        # count and the loop below describing different peers.
+        peer_ranks = self._overlapping_ranks.get(engine_id)
+        if not peer_ranks:
+            # NOTE(RBLN): upstream aligns by truncating the longer list and
+            # keeping its HEAD -- the wrong end (see _trim_to_consumer_blocks)
+            # -- and the lengths match either way so nothing catches it. Trim
+            # first, only where upstream's expansion of the remote list is the
+            # identity: past that the two lengths are not the same unit.
+            if remote_info.remote_physical_blocks_per_logical == 1:
+                meta.local_physical_block_ids = self._trim_to_consumer_blocks(
+                    meta.local_physical_block_ids, meta.remote.block_ids
+                )
+            return super()._xfer_blocks_for_req(req_id, meta)
+
+        block_size_ratio = self.transfer_topo.block_size_ratio(
+            remote_info.remote_block_size
+        )
+        assert block_size_ratio == 1, (
+            "RBLN NIXL per-shard write path requires equal P/D block sizes "
+            f"(got block_size_ratio={block_size_ratio})"
+        )
+        remote_block_size = remote_info.remote_block_size
+
+        meta.remote.block_ids = self._logical_to_remote_kernel_block_ids(
+            meta.remote.block_ids, remote_info.remote_physical_blocks_per_logical
+        )
+        remote_block_ids = meta.remote.block_ids
+        local_block_ids = meta.local_physical_block_ids
+        notif_id = self._xfer_notif_id(
+            engine_id, meta.remote.request_id, remote_info.remote_tp_size
+        )
+
+        local_block_ids = self._trim_to_consumer_blocks(
+            local_block_ids, remote_block_ids
+        )
+        n_write_blocks = sum(len(g) for g in local_block_ids)
+        if not n_write_blocks:
+            logger.warning("per-shard write req %s: no blocks to push", req_id)
+            return
+
+        logger.debug(
+            "per-shard write req %s: ranks=%d write_blocks=%d",
+            req_id,
+            len(peer_ranks),
+            n_write_blocks,
+        )
+
+        # Publish once, for the reason the read path states (see
+        # `_read_blocks_for_req`); failure is per peer here, not per request.
+        handles: list[int] = []
+        for global_rank in peer_ranks:
+            remote_descs = self._get_block_descs_ids_for_shard(
+                engine_id,
+                global_rank,
+                self.dst_num_blocks[engine_id],
+                remote_block_ids,
+            )
+            local_descs = self._get_block_descs_ids_for_shard(
+                engine_id, global_rank, self.num_blocks, local_block_ids
+            )
+            assert len(local_descs) == len(remote_descs)
+            local_handle = self.src_xfer_handles_by_remote[
+                (engine_id, global_rank, remote_block_size)
+            ]
+            remote_handle = self.dst_xfer_side_handles[engine_id][global_rank]
+
+            handle = None
+            try:
+                handle = self.nixl_wrapper.make_prepped_xfer(
+                    "WRITE",
+                    local_handle,
+                    local_descs,
+                    remote_handle,
+                    remote_descs,
+                    notif_msg=notif_id,
+                )
+                self.nixl_wrapper.transfer(handle)
+                handles.append(handle)
+            except Exception as e:
+                self._log_failure(
+                    failure_type="transfer_setup_failed",
+                    req_id=req_id,
+                    msg="Push WRITE submission failed; releasing handle",
+                    error=e,
+                    dst_engine_id=engine_id,
+                    remote_pp_rank=global_rank,
+                )
+                # Outbound only: there is no local metadata to invalidate, so
+                # release this peer's handle and let the remaining peers go.
+                if handle is not None:
+                    self.nixl_wrapper.release_xfer_handle(handle)
+                self.xfer_stats.record_failed_transfer()
+
+        if handles:
+            with self._sending_transfers_lock:
+                self._sending_transfers[req_id].extend(handles)
+
+    @staticmethod
+    def _trim_to_consumer_blocks(
+        local_block_ids: BlockIds, remote_block_ids: BlockIds
+    ) -> BlockIds:
+        """Drop from our side the blocks the consumer already had.
+
+        NOTE(RBLN): the same trim the read path gets from upstream's
+        `_apply_prefix_caching`, with the roles swapped -- there the consumer is
+        local and the producer's longer list is trimmed to it, here the consumer
+        is the peer and ours is the longer one. It has to come off the END: the
+        consumer registers the uncached SUFFIX of a prompt, so dropping our tail
+        would hand it the wrong blocks under a partial prefix hit.
+
+        TODO(vllm>=0.27.2): delete -- upstream trims the write path itself there.
+        """
+        local = list(local_block_ids)
+        for i, remote_group in enumerate(remote_block_ids):
+            num_remote = len(remote_group)
+            assert num_remote <= len(local[i]), (
+                f"group {i}: consumer registered {num_remote} blocks but this "
+                f"producer holds {len(local[i])}; the pair cannot be aligned"
+            )
+            if num_remote < len(local[i]):
+                local[i] = local[i][-num_remote:]
+        return tuple(local)


### PR DESCRIPTION
### 🚀 Summary of Changes

#### Summary

The connector served only pull transfers, where the consumer reads a finished
request's KV out of the producer. Upstream offers push as a sibling, where the
producer writes into the consumer, and that is the direction it is extending.

Pairing regions describes what two peers hold, so the handshake, the descriptor
construction and the combinations a handshake refuses are already direction-free.
What a direction owns is issuing the transfer and deciding when a request is done.
Both fit in a module beside the read path's, and the shared class keeps everything
neither direction decides.

Writing turns two of the read path's assumptions around, and adds a pairing that
has to be refused. It also reaches two request states the read path never sees.

#### What changed

##### A. The direction split

`push_worker.py` and `push_scheduler.py` sit beside `pull_worker.py` and
`pull_scheduler.py`; the base worker and base scheduler keep what the direction does
not decide. The connector is selected by name, so a deployment picks a direction the
way it already picks a buffer device.

##### B. Two assumptions the write direction inverts

**1. A replica is a valid source, not a valid sole destination.** Reading from a
chiplet replica is safe because any copy answers with the same bytes. Writing one is
not: the peer's other chiplets keep serving what was there before, so a slice's
descriptors fan out over **every** copy of it. The fan-out is decided from the peer's
advertised geometry, the same input the read path uses to pick one copy.

**2. A consumer settles on the first notification, not the last.** Under pull, a
request is done when every peer has been heard from. Under push, the consumer is
told by whichever producer rank finishes, and the count that notification carries
means the opposite of what it means on the read path — so it is read the other way
round rather than reused.

##### C. Directions must refuse each other at the handshake

Two peers running opposite directions move the same bytes by protocols that do not
meet, yet they describe identical geometry to one another: every length, every band,
every regions-per-layer check passes. This vLLM hashes nothing that separates them —
the connector name is not a factor in the compatibility hash — so a mismatched pair
would proceed and stall rather than refuse. The direction now joins the schema
version in the RBLN extension of that hash, so the pair is rejected at the handshake
where it is still legible.

##### D. Two states the read path never reaches

**3. A request the serving layer turned away.** A prompt past the context length or
a client that went away still reaches the connector: the engine submits it
pre-aborted so the hooks run and the producer releases the blocks it pinned. Upstream
registers an empty receive for it and then reads `remote_block_ids`, a field the
write path fills in the one call a rejected request never reaches. It is now filled
where upstream is about to need it. Without that, the consumer's engine core dies and
takes every other request on that instance with it.

**4. A consumer under a partial prefix-cache hit.** It registers fewer blocks than
the producer holds, because its cache covered the head of the prompt and it needs
only the suffix. Where a whole-engine handle describes the peer, upstream aligns the
two lists by keeping the head of the longer one — which lands the producer's head in
the slots the consumer kept for its tail. Lengths agree, no assert fires, and the
consumer decodes against KV belonging to other tokens. The per-shard route already
trimmed to the suffix; the delegated one now trims before handing the request over,
so upstream finds the lists equal and leaves them alone. Upstream trims its own write
path from 0.27.2, which the code names as the condition for dropping this.

#### Testing

- **Unit** — the write path's transfer issue and its per-shard route, the replica
  fan-out, the notification accounting and its inverted count, the rejected-request
  field, the delegated-route trim and its equal-block-size precondition, the writer
  thread's lifecycle and handle release on failure
  (`test_rbln_nixl_push_worker.py`); the direction in the compatibility hash and the
  metadata that carries it (`test_rbln_nixl_metadata.py`); the connector and factory
  registration (`test_rbln_nixl_connector.py`, `test_factory.py`); the shared pieces
  the direction reaches into (`test_rbln_nixl_base_worker.py`,
  `test_rbln_nixl_base_scheduler.py`, `test_rbln_nixl_handshake.py`).
- Cases that cover an override enter through the upstream method that calls it rather
  than calling it directly, so an override that goes dead when upstream re-routes a
  call is caught.
- Each refusal the write direction adds has a case that fails if the guard stops
  firing — including the opposite-direction handshake, which is invisible to every
  other check.
- `pytest tests/native` green; `pre-commit` clean on every changed file.

#### Risk / compatibility

- **The read path is untouched in behaviour.** The direction is a separate connector;
  a deployment that does not name it runs exactly what it ran before.
- **A mixed-direction pair now fails fast.** Previously it would have handshaken and
  then stalled. This is a behaviour change only for a configuration that could not
  have worked.
- The delegated-route trim is scoped to the case upstream mis-aligns and carries the
  upstream version that removes the need for it.

---

### 📌 Related Issues / Tickets

* Resolves rebellions-sw/fsw-inference#493 — RBLN NIXL connector push mode.

---

### ✅ Type of Change

* [x] ✨ Feature (`feature`)

---

### 🧪 How to Test

1. `uv run --no-sync pytest tests/native/distributed/kv_connector/`
2. `uv run --no-sync pytest tests/native`
3. Expected: all green.
4. Edge cases covered: a consumer whose chiplets replicate a slice, so one write
   would leave the other copies stale; a completion notification arriving from one
   producer rank while others are still writing; a request rejected by the serving
   layer before it was ever scheduled; a consumer that registered only the suffix of
   a prompt after a partial prefix-cache hit; a peer running the opposite direction;
   a per-shard write whose peer disagrees on block size; a submission that fails
   after the handle exists.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

- Affects the **vLLM-native path** only.
- This branches from `feat/nixl-region-pairing` rather than `dev`: the write
  direction is built on the region pairing that branch introduces, and reviewing it
  against `dev` would show that work a second time.