### PR TITLE
other: update torch-rbln to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "torchvision",
     "torchaudio",
     "torchcodec",
-    "torch-rbln~=0.4.0rc0 ; platform_machine == 'x86_64'",
+    "torch-rbln>=0.4.0 ; platform_machine == 'x86_64'",
     "optimum-rbln>=0.11.2",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2586,8 +2586,8 @@ wheels = [
 
 [[package]]
 name = "torch-rbln"
-version = "0.4.0rc0"
-source = { registry = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/simple/" }
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "libcst" },
     { name = "pyyaml" },
@@ -2597,10 +2597,10 @@ dependencies = [
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/torch-rbln/0.4.0rc0/torch_rbln-0.4.0rc0-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:7687f86a22bc75ee5c86182facbbdbb8a7a34914a0bd4a2e48d6eb873fdae785" },
-    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/torch-rbln/0.4.0rc0/torch_rbln-0.4.0rc0-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:60fc4a9f9b744414c010b8f5e5184c35194e0c722f811fb74f0ac117b6995a6e" },
-    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/torch-rbln/0.4.0rc0/torch_rbln-0.4.0rc0-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:e1f0ce90935b314f7cccc20964ad0c79516620d40f0c7c8a09a2e17a7c926637" },
-    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/torch-rbln/0.4.0rc0/torch_rbln-0.4.0rc0-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:1bd2aa1e263b59a8b0b214bb79ededd7efa4a64b479da5fb89cf37a2a7ed5a39" },
+    { url = "https://files.pythonhosted.org/packages/b9/4b/7d10b0f9c5e229d535ead980e876caa9cf9e3ab7b80c60d67c5d17a1897a/torch_rbln-0.4.0-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:f26d5579641d316572524d9ed368b52d22fea2c118f682e6b1bc3eaa6bc8abe3", size = 1314698, upload-time = "2026-08-28T06:59:00.101Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/5d/4cc838a0ed3db927ffbeae33553432cb00d6779a32d8958ca073ffbefc1b/torch_rbln-0.4.0-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:3b6ea9b82a21a9b7d992560dc8d76d08f192f8846632ba334fa8a4b7af5e7fd5", size = 1317442, upload-time = "2026-08-28T06:59:02.318Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/01/e9382e0c035569ff61c8ae45adbbed821bb5154972d0fa33e67b131a57e5/torch_rbln-0.4.0-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:31e62a4ba8770541cdac8b8536198cf0e38df9da4c77da8258d2bb9841051953", size = 1321995, upload-time = "2026-08-28T06:59:04.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/e7/93182c8222d14237ca564b7176ad8f68295b4d28388d94b29e1723252ca8/torch_rbln-0.4.0-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:4dafaafaa5c948f348a7649ccbae2e2df4ee5c1722fce4c684d0263517ab56ab", size = 1321726, upload-time = "2026-08-28T06:59:06.352Z" },
 ]
 
 [[package]]
@@ -2946,7 +2946,7 @@ requires-dist = [
     { name = "setuptools-scm", marker = "extra == 'build'" },
     { name = "simphile", marker = "extra == 'dev'" },
     { name = "torch", index = "https://download.pytorch.org/whl/cpu" },
-    { name = "torch-rbln", marker = "platform_machine == 'x86_64'", specifier = "~=0.4.0rc0" },
+    { name = "torch-rbln", marker = "platform_machine == 'x86_64'", specifier = ">=0.4.0" },
     { name = "torchaudio", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torchcodec", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torchvision", index = "https://download.pytorch.org/whl/cpu" },


### PR DESCRIPTION
## What

Backport of #1021 to `release-v0.11.2` — squashed cherry-pick of its commits (`f0007517`, `fcec81bd`, `5a87d473`), applied cleanly.

```diff
- "torch-rbln~=0.4.0rc0 ; platform_machine == 'x86_64'",
+ "torch-rbln>=0.4.0 ; platform_machine == 'x86_64'",
```

`uv.lock`: `torch-rbln` 0.4.0rc0 → **0.4.0** (published to PyPI on 2026-08-28). The specifier follows the `optimum-rbln>=0.11.2` style in the same list.

## Notes

- **Prereleases no longer satisfy the range.** `~=0.4.0rc0` accepted the nightly `0.4.0rc1.dev*` builds; `>=0.4.0` does not.
- The lock's `source` / wheel URLs for this package move from the nightly Nexus index to `pypi.org` / `files.pythonhosted.org`, since that is where the final release is published — no index configuration was needed for this. Wheels cover cp310–cp313 (`requires_python >=3.10,<3.14`), same as the previous rc.

## Verification

- Cherry-pick applied cleanly on top of `release-v0.11.2` (`bbd2355e`).
- `uv lock --check` passes on this branch, so CI's `uv sync --locked` stays green.
- Lock diff is 14 lines, **all torch-rbln** — no other package resolution changed.

Companion PR on `dev`: #1021.
