### PR TITLE
fix(worker): skip the discard offset rewind for CPU generators

### DIFF
--- a/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
@@ -1847,6 +1847,74 @@ def test_bookkeeping_sync_discards_chunked_prefill_samples(
     assert rbln_model_runner.requests["req_1"].output_token_ids == [202]
 
 
+def test_bookkeeping_sync_discard_keeps_seeded_cpu_generator(
+    rbln_model_runner, dist_init
+):
+    """A request that carries a seed gets a per-request generator, and this
+    backend creates it on CPU. When such a request is in the discard set,
+    _bookkeeping_sync must not rewind the generator offset: a CPU generator has
+    no offset and raises RuntimeError on get_offset()/set_offset()."""
+    req_id = "req_seeded"
+
+    rbln_model_runner._update_states(
+        _schedule_new_request(req_id, sampling_params=[SamplingParams(seed=1234)])
+    )
+
+    ib = rbln_model_runner.input_batch
+    assert ib.req_id_to_index == {req_id: 0}
+
+    # The seed is what puts a generator into input_batch.generators, which is
+    # the dict the discard path reaches into.
+    generator = ib.generators[0]
+    assert generator.device.type == "cpu"
+    state_before = generator.get_state()
+
+    # Default prompt is [1, 2, 3]; the row is an intermediate chunked prefill
+    # and must discard its sample.
+    ib.num_tokens_no_spec[:1] = [3]
+    rbln_model_runner.discard_request_mask[0] = True
+
+    sampler_output = _sampler_output([[101]], device=rbln_model_runner.device)
+
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={req_id: 1},
+        total_num_scheduled_tokens=1,
+        scheduled_spec_decode_tokens={},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+
+    hidden_states = torch.empty(
+        (1, rbln_model_runner.model_config.get_hidden_size()),
+        dtype=rbln_model_runner.dtype,
+        device=rbln_model_runner.device,
+    )
+
+    (
+        _num_nans_in_logits,
+        _logprobs_lists,
+        valid_sampled_token_ids,
+        _prompt_logprobs_dict,
+        _req_ids_output_copy,
+        _req_id_to_index_output_copy,
+    ) = rbln_model_runner._bookkeeping_sync(
+        scheduler_output=scheduler_output,
+        sampler_output=sampler_output,
+        logits=None,
+        hidden_states=hidden_states,
+        num_scheduled_tokens=1,
+    )
+
+    # The sample is still dropped, and the generator is left untouched.
+    assert valid_sampled_token_ids == [[]]
+    assert rbln_model_runner.requests[req_id].output_token_ids == []
+    assert torch.equal(generator.get_state(), state_before)
+
+
 def test_bookkeeping_sync_parses_spec_decode_output(rbln_model_runner, dist_init):
     """Speculative sampler output is parsed into accepted tokens and only those
     accepted tokens are cached in the request state."""

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1255,7 +1255,9 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         )[0]
         for i in discard_sampled_tokens_req_indices:
             gen = self.input_batch.generators.get(int(i))
-            if gen is not None:
+            # The rewind undoes a Philox counter advance, which only device
+            # generators have; a CPU generator raises on get/set_offset().
+            if gen is not None and gen.device.type != "cpu":
                 gen.set_offset(gen.get_offset() - 4)
 
         # Copy some objects so they don't get modified after returning.


### PR DESCRIPTION
### 🚀 Summary of Changes

`_bookkeeping_sync` rewinds a discarded request's sampling generator by 4 offsets, to undo the counter advance of the sampled token that is being dropped:

```python
for i in discard_sampled_tokens_req_indices:
    gen = self.input_batch.generators.get(int(i))
    if gen is not None:
        gen.set_offset(gen.get_offset() - 4)
```

That rewind is adapted from the CUDA model runner, where per-request generators are Philox-based and therefore have an offset. On this backend the generator is created explicitly on CPU (`RBLNModelRunner._update_states`, `torch.Generator(device="cpu")`), and a CPU generator has no offset — both `get_offset()` and `set_offset()` raise:

```
RuntimeError: CPU Generator does not use offset
```

The exception propagates out of `execute_model`, so the engine core process dies and the server answers 500 for every in-flight request.

**Why it was latent.** A per-request generator only exists when the request carries a seed: `_update_states` builds one for `SamplingType.RANDOM_SEED`, and `InputBatch.add_request` keys it into `input_batch.generators` only when it is not `None`. Unseeded traffic never has an entry there, so the loop body never runs. It fires the first time a client sends the OpenAI-compatible `seed` field — which evaluation harnesses set by default — on a request whose sampled token is also discarded (for example an intermediate chunked-prefill step).

**Fix.** Skip the rewind for a CPU generator, and leave it in place for device generators that do have an offset. Upstream does not guard the statement, because on the CUDA path the dict can only hold CUDA generators.

This is the only `get_offset()`/`set_offset()` call site in the tree; the discard logic itself is untouched.

---

### 📌 Related Issues / Tickets

* Related to #

<!-- No issue is linked yet; this PR is in draft until one is filed. -->

---

### ✅ Type of Change

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

Unit test (added in this PR):

```bash
pytest tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py \
  -k discard_keeps_seeded_cpu_generator -vv
```

`test_bookkeeping_sync_discard_keeps_seeded_cpu_generator` schedules one request with `SamplingParams(seed=1234)`, asserts the generator that lands in `input_batch.generators` is on CPU, marks the row in `discard_request_mask`, and calls `_bookkeeping_sync`. It then checks that the sample is still dropped and that the generator state is byte-identical afterwards.

The test is a real regression guard, not a smoke test: reverting the guard to `if gen is not None:` makes exactly this test fail, with the production error and nothing else changing.

End to end, the same condition is reachable by sending a chat/completions request with `"seed": 1234` and a prompt long enough to be chunk-prefilled; before this change the engine core exits on the first discarded step.

---

### 📸 Screenshots / Logs (if applicable)

With the guard removed:

```
tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py:1904: in test_bookkeeping_sync_discard_keeps_seeded_cpu_generator
    ) = rbln_model_runner._bookkeeping_sync(
vllm_rbln/v1/worker/rbln_model_runner.py:1259: in _bookkeeping_sync
    gen.set_offset(gen.get_offset() - 4)
                   ^^^^^^^^^^^^^^^^
E   RuntimeError: CPU Generator does not use offset
1 failed, 53 deselected
```

With the guard in place:

```
3 passed, 51 deselected   # -k discard
```

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

The optimum model runner builds its per-request generators with `torch.Generator(device=self.device)` but has no equivalent rewind, so it is unaffected.
