### PR TITLE
perf(moe): build the tokens mask in the routing weights' dtype

### DIFF
--- a/tests/native/model_executor/layers/fused_moe/test_utils.py
+++ b/tests/native/model_executor/layers/fused_moe/test_utils.py
@@ -40,7 +40,8 @@ class TestGetTokensMask:
         # DP=2, max_pad=4: rank 0 has 3 real tokens, rank 1 has 2. Flattened over
         # both ranks' 4-slot windows (the docstring's worked example).
         _fake_forward_context(monkeypatch, num_tokens_across_dp=[3, 2], max_pad_len=4)
-        mask = utils.get_tokens_mask(999)  # num_tokens ignored when DP>1
+        # num_tokens is ignored when DP>1
+        mask = utils.get_tokens_mask(999, dtype=torch.float32)
         assert mask.shape == (8, 1)
         assert mask.flatten().tolist() == [1, 1, 1, 0, 1, 1, 0, 0]
 
@@ -48,7 +49,7 @@ class TestGetTokensMask:
         # DP=1 has no padding: num_tokens is the window length and every position
         # is a real token, so the mask is all `left`.
         _fake_forward_context(monkeypatch, num_tokens_across_dp=[3], max_pad_len=0)
-        mask = utils.get_tokens_mask(3)
+        mask = utils.get_tokens_mask(3, dtype=torch.float32)
         assert mask.shape == (3, 1)
         assert mask.flatten().tolist() == [1, 1, 1]
 
@@ -56,15 +57,13 @@ class TestGetTokensMask:
         # (left=0, right=-inf) turns the mask into an additive logit mask that
         # drives padded positions to -inf before softmax.
         _fake_forward_context(monkeypatch, num_tokens_across_dp=[3, 2], max_pad_len=4)
-        mask = utils.get_tokens_mask(999, left=0.0, right=float("-inf"))
+        mask = utils.get_tokens_mask(
+            999, left=0.0, right=float("-inf"), dtype=torch.float32
+        )
         vals = mask.flatten().tolist()
         assert vals[:3] == [0.0, 0.0, 0.0]
         assert vals[3] == float("-inf")
         assert vals[6:] == [float("-inf"), float("-inf")]
-
-    def test_dtype_defaults_to_torch_default(self, monkeypatch):
-        _fake_forward_context(monkeypatch, num_tokens_across_dp=[3, 2], max_pad_len=4)
-        assert utils.get_tokens_mask(999).dtype == torch.get_default_dtype()
 
     def test_dtype_is_honored_so_the_product_stays_narrow(self, monkeypatch):
         # An fp32 mask would promote the bf16 routing weights it multiplies,
@@ -88,9 +87,14 @@ class TestGetTokensMask:
         assert vals[:3] == [0.0, 0.0, 0.0]
         assert vals[3] == float("-inf")
 
+    def test_dtype_is_required(self, monkeypatch):
+        _fake_forward_context(monkeypatch, num_tokens_across_dp=[3, 2], max_pad_len=4)
+        with pytest.raises(TypeError):
+            utils.get_tokens_mask(999)
+
     def test_missing_dp_metadata_is_rejected(self, monkeypatch):
         monkeypatch.setattr(
             utils, "get_forward_context", lambda: SimpleNamespace(dp_metadata=None)
         )
         with pytest.raises(AssertionError):
-            utils.get_tokens_mask(4)
+            utils.get_tokens_mask(4, dtype=torch.float32)

--- a/tests/native/model_executor/layers/fused_moe/test_utils.py
+++ b/tests/native/model_executor/layers/fused_moe/test_utils.py
@@ -62,6 +62,32 @@ class TestGetTokensMask:
         assert vals[3] == float("-inf")
         assert vals[6:] == [float("-inf"), float("-inf")]
 
+    def test_dtype_defaults_to_torch_default(self, monkeypatch):
+        _fake_forward_context(monkeypatch, num_tokens_across_dp=[3, 2], max_pad_len=4)
+        assert utils.get_tokens_mask(999).dtype == torch.get_default_dtype()
+
+    def test_dtype_is_honored_so_the_product_stays_narrow(self, monkeypatch):
+        # An fp32 mask would promote the bf16 routing weights it multiplies,
+        # turning the whole [E, T] tensor into a precision island the compiler
+        # runs in dlfp16. The mask must come back in the caller's dtype.
+        _fake_forward_context(monkeypatch, num_tokens_across_dp=[3, 2], max_pad_len=4)
+        mask = utils.get_tokens_mask(999, dtype=torch.bfloat16)
+        assert mask.dtype == torch.bfloat16
+        assert mask.flatten().tolist() == [1, 1, 1, 0, 1, 1, 0, 0]
+        weights = torch.ones(2, 8, dtype=torch.bfloat16)
+        assert (weights * mask.transpose(1, 0)).dtype == torch.bfloat16
+
+    def test_dtype_is_honored_for_the_additive_logit_mask(self, monkeypatch):
+        # -inf is representable in bf16, so the (0, -inf) form narrows too.
+        _fake_forward_context(monkeypatch, num_tokens_across_dp=[3, 2], max_pad_len=4)
+        mask = utils.get_tokens_mask(
+            999, left=0.0, right=float("-inf"), dtype=torch.bfloat16
+        )
+        assert mask.dtype == torch.bfloat16
+        vals = mask.flatten().tolist()
+        assert vals[:3] == [0.0, 0.0, 0.0]
+        assert vals[3] == float("-inf")
+
     def test_missing_dp_metadata_is_rejected(self, monkeypatch):
         monkeypatch.setattr(
             utils, "get_forward_context", lambda: SimpleNamespace(dp_metadata=None)

--- a/vllm_rbln/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm_rbln/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -285,6 +285,11 @@ class RBLNMoERunner(MoERunner):
                     e, R * max_pad
                 )  # (e, T)
 
+                # send_mask is registered as float32, but the ccl kernels
+                # matmul it against these routing slices (send_mask @ send_rl
+                # in ccl_dispatch_send
+                send_mask = self.send_mask.to(masked_routing_weights.dtype)
+
             # --- Step 4: Dispatch tokens across DP ranks ---
             if envs.VLLM_RBLN_DISPATCH_ALL2ALL:
                 # --- all2all dispatch path ---
@@ -294,7 +299,7 @@ class RBLNMoERunner(MoERunner):
                 send_buffer, send_sizes = torch.ops.rbln_custom_ops.ccl_dispatch_send(
                     hidden_flat,
                     send_rl,
-                    self.send_mask,
+                    send_mask,
                     self.moe_parallel_config.dp_rank,
                 )
 
@@ -351,11 +356,11 @@ class RBLNMoERunner(MoERunner):
 
                 # ccl_combine_receive: unpack + sum-reduce → (max_pad, H)
                 # send_rl (E, max_pad): this rank's full expert routing
-                # self.send_mask: reused as expert_map (same matrix)
+                # send_mask: reused as expert_map (same matrix)
                 final_hidden_states = torch.ops.rbln_custom_ops.ccl_combine_receive(
                     combine_recv_buf,
                     send_rl,
-                    self.send_mask,
+                    send_mask,
                     combine_3d[
                         self.moe_parallel_config.dp_rank
                     ],  # local rank's own contribution

--- a/vllm_rbln/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm_rbln/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -262,7 +262,9 @@ class RBLNMoERunner(MoERunner):
             use_moe_tokens_mask = envs.VLLM_RBLN_USE_MOE_TOKENS_MASK
             if use_moe_tokens_mask:
                 tokens_mask = get_tokens_mask(
-                    max_pad, device=masked_routing_weights.device
+                    max_pad,
+                    device=masked_routing_weights.device,
+                    dtype=masked_routing_weights.dtype,
                 ).transpose(1, 0)  # [1, R*max_pad]
                 masked_routing_weights = masked_routing_weights * tokens_mask
 
@@ -480,7 +482,9 @@ class RBLNMoERunner(MoERunner):
         use_moe_tokens_mask = envs.VLLM_RBLN_USE_MOE_TOKENS_MASK
         if use_moe_tokens_mask:
             tokens_mask = get_tokens_mask(
-                num_tokens, device=masked_routing_weights.device
+                num_tokens,
+                device=masked_routing_weights.device,
+                dtype=masked_routing_weights.dtype,
             ).transpose(1, 0)  # [1, t]
 
             # [t, E] * [t, 1] (broadcast)

--- a/vllm_rbln/model_executor/layers/fused_moe/utils.py
+++ b/vllm_rbln/model_executor/layers/fused_moe/utils.py
@@ -21,7 +21,8 @@ def get_tokens_mask(
     left=1.0,
     right=0.0,
     device=None,
-    dtype: torch.dtype | None = None,
+    *,
+    dtype: torch.dtype,
 ) -> torch.Tensor:
     """Real-vs-padding mask aligned with the DP multicast output layout.
 
@@ -49,9 +50,11 @@ def get_tokens_mask(
             ``max_pads_across_dp`` is ``None``); ignored otherwise
         left: Value for real-token positions.
         right: Value for padded positions.
-        dtype: Dtype of the returned mask. Pass the dtype of the tensor the
-            mask is combined with; leaving it unset falls back to the torch
-            default (fp32), which promotes that tensor. See below.
+        dtype: Dtype of the returned mask. Required, and keyword-only: pass
+            the dtype of the tensor the mask is combined with. There is no
+            default because the only sensible fallback (the torch default,
+            fp32) is the very thing this argument exists to avoid -- see the
+            comment at the ``torch.where`` below.
 
     Returns:
         Tensor of shape ``[dp_size * max_pad, 1]``.
@@ -66,17 +69,11 @@ def get_tokens_mask(
     )
     pos = torch.arange(max_pad, dtype=torch.int32).unsqueeze(0)
 
-    # `left`/`right` as Python floats make torch.where fall back to the torch
-    # default dtype (fp32). Multiplying an fp32 mask into bf16 routing weights
-    # promotes the whole [E, T] tensor to fp32, and the compiler reads that as a
-    # precision island and runs it in dlfp16 -- two full-tensor device casts per
-    # layer to carry a mask of ones and zeros. Materializing the branches in the
-    # caller's dtype keeps the product in bf16.
-    if dtype is not None:
-        left = torch.tensor(left, dtype=dtype)
-        right = torch.tensor(right, dtype=dtype)
-
-    tokens_mask = torch.where(pos < num_tokens_across_dp, left, right)
+    tokens_mask = torch.where(
+        pos < num_tokens_across_dp,
+        torch.tensor(left, dtype=dtype),
+        torch.tensor(right, dtype=dtype),
+    )
     tokens_mask = tokens_mask.reshape(-1, 1)  # [dp_size * max_pad, 1]
     if device is not None:
         tokens_mask = tokens_mask.to(device)

--- a/vllm_rbln/model_executor/layers/fused_moe/utils.py
+++ b/vllm_rbln/model_executor/layers/fused_moe/utils.py
@@ -16,7 +16,13 @@ import torch
 from vllm.forward_context import get_forward_context
 
 
-def get_tokens_mask(num_tokens: int, left=1.0, right=0.0, device=None) -> torch.Tensor:
+def get_tokens_mask(
+    num_tokens: int,
+    left=1.0,
+    right=0.0,
+    device=None,
+    dtype: torch.dtype | None = None,
+) -> torch.Tensor:
     """Real-vs-padding mask aligned with the DP multicast output layout.
 
     For every DP rank's slot in the multicast buffer, positions before
@@ -43,6 +49,9 @@ def get_tokens_mask(num_tokens: int, left=1.0, right=0.0, device=None) -> torch.
             ``max_pads_across_dp`` is ``None``); ignored otherwise
         left: Value for real-token positions.
         right: Value for padded positions.
+        dtype: Dtype of the returned mask. Pass the dtype of the tensor the
+            mask is combined with; leaving it unset falls back to the torch
+            default (fp32), which promotes that tensor. See below.
 
     Returns:
         Tensor of shape ``[dp_size * max_pad, 1]``.
@@ -56,6 +65,16 @@ def get_tokens_mask(num_tokens: int, left=1.0, right=0.0, device=None) -> torch.
         else dp_metadata.max_pads_across_dp.shape[0]
     )
     pos = torch.arange(max_pad, dtype=torch.int32).unsqueeze(0)
+
+    # `left`/`right` as Python floats make torch.where fall back to the torch
+    # default dtype (fp32). Multiplying an fp32 mask into bf16 routing weights
+    # promotes the whole [E, T] tensor to fp32, and the compiler reads that as a
+    # precision island and runs it in dlfp16 -- two full-tensor device casts per
+    # layer to carry a mask of ones and zeros. Materializing the branches in the
+    # caller's dtype keeps the product in bf16.
+    if dtype is not None:
+        left = torch.tensor(left, dtype=dtype)
+        right = torch.tensor(right, dtype=dtype)
 
     tokens_mask = torch.where(pos < num_tokens_across_dp, left, right)
     tokens_mask = tokens_mask.reshape(-1, 1)  # [dp_size * max_pad, 1]


### PR DESCRIPTION
### 🚀 Summary of Changes

- **Problem**: the MoE tokens mask is built in fp32, so it promotes the routing weights it multiplies.
  - `get_tokens_mask` hands Python floats to `torch.where`, so the result takes the torch default dtype (fp32).
  - `masked_routing_weights * tokens_mask` then promotes the whole `[E, T]` tensor from bf16 to fp32.
  - The compiler reads that fp32 region as a deliberate precision island and runs it in dlfp16.
  - Cost: device casts in and out over `[E, T]`, per layer, to carry a mask of ones and zeros.
- **Solution**: build the mask in the dtype of the tensor it is combined with.
  - `get_tokens_mask` takes a `dtype` and materializes `left`/`right` as tensors of that dtype.
  - Both call sites in `RBLNMoERunner.forward` (DP>1 and DP=1) pass `masked_routing_weights.dtype`.
  - It follows the caller instead of being pinned to bf16.
    - A model whose routing weights are fp32 gets an fp32 mask and is equally cast-free.
  - `dtype=None` keeps the previous behavior, so other callers are unaffected.

Device IR for one MoE layer, before and after (DP=2 shown; DP=1 is the same shape):

```mlir
// before: the mask drags the [128, 1024] routing weights through dlfp16
%655 = "cast"(%654) <{dtype = dlf16}> : (tensor<128x1024xbf16>) -> tensor<128x1024xdlf16>
%662 = "cast"(%659) <{dtype = dlf16}> : (tensor<2x512xbf16>) -> tensor<2x512xdlf16>
%663 = "where"(%662, %660, %661) : (tensor<2x512xdlf16>, tensor<dlf16>, tensor<dlf16>) -> tensor<2x512xdlf16>
%664 = "reshape"(%663) : (tensor<2x512xdlf16>) -> tensor<1x1024xdlf16>
%665 = "multiply"(%655, %664) : (tensor<128x1024xdlf16>, tensor<1x1024xdlf16>) -> tensor<128x1024xdlf16>
%667 = "contrib_gather_1d"(%665, %666) : (tensor<128x1024xdlf16>, tensor<64x64xi32>) -> tensor<64x1024xdlf16>

// after: straight bf16, no casts
%655 = "where"(%652, %653, %654) : (tensor<2x512xbf16>, tensor<bf16>, tensor<bf16>) -> tensor<2x512xbf16>
%656 = "reshape"(%655) : (tensor<2x512xbf16>) -> tensor<1x1024xbf16>
%657 = "multiply"(%648, %656) : (tensor<128x1024xbf16>, tensor<1x1024xbf16>) -> tensor<128x1024xbf16>
%659 = "contrib_gather_1d"(%657, %658) : (tensor<128x1024xbf16>, tensor<64x64xi32>) -> tensor<64x1024xbf16>
```

- Results are bit-identical.
  - `1.0`/`0.0` (and `-inf`, for the additive-logit form) are exact in bf16.
  - Multiplying by them is exact in any float format.
- The fp32 residual add in `fused_add_rms_norm` is untouched.
  - That one is a real precision request, and it still lowers to dlfp16.

---

### 📌 Related Issues / Tickets

* No tracked issue. Found while reading the compiled graph of an MoE model: the
  routing-weight multiply was running in dlfp16, and the only reason was the mask's
  dtype. Filing an issue after the fact did not seem to add anything, so this PR is
  the record. Happy to open one if the process requires it.

---

### ✅ Type of Change

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [x] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Unit tests: `pytest tests/native/model_executor/layers/fused_moe/`
   - Three cases added: the default stays at the torch default dtype, a bf16 request keeps the product bf16, and the `(0.0, -inf)` additive form narrows too.
2. Compile an MoE model and inspect the routing region of `rank_0/rbln_tensor_debug.log`.
   - e.g. `vllm-rbln-exec vllm-decoderonly gpt-oss -m gpt-oss-120b c -l 4 -ep -dp 1 -bs 8192 -b 1 -nblk 30 --cache-ignore`
   - The `multiply` that applies the mask must be `bf16`, with no `cast` to `dlf16` around it.
3. Edge case: a model whose routing weights are fp32 (e.g. minimax) must still produce an fp32 mask and no cast.

---

### 📸 Screenshots / Logs (if applicable)

Same compile run with and without the change, counting op result dtypes in `rank_0/rbln_tensor_debug.log` (gpt-oss-120b, 4 layers, prefill + decode). Both DP paths were compiled.

| op / dtype | DP=1 before | DP=1 after | DP=2 before | DP=2 after |
| --- | ---: | ---: | ---: | ---: |
| `multiply` dlf16 | 8 | 0 | 8 | 0 |
| `multiply` bf16 | 0 | 8 | 0 | 8 |
| `where` dlf16 / f32 | 1 / 1 | 0 / 0 | 2 / 1 | 0 / 0 |
| `cast` dlf16 | 32 | 22 | 51 | 33 |
| `cast` bf16 | 28 | 20 | 42 | 30 |
| **all dlf16 values** | **96** | **65** | **175** | **107** |
| all f32 values | 10 | 4 | 18 | 6 |

- `add` dlf16 is unchanged in both, i.e. the `fused_add_rms_norm` residual add still lowers to dlfp16.
- DP=2 also narrows the ops downstream of the mask that the promotion had dragged along.
  - `contrib_gather_1d`, `contrib_aligned_pad`, `pad_last_dim` and 4 host/device `transfer`s move from dlf16 to bf16.
- The saved mega-cache bundle shrinks from 924.1 MiB to 923.6 MiB at DP=2.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

- The `dtype=None` default is intentionally the old fp32 behavior rather than a narrowing one, so nothing changes for a caller that has not opted in.
- Only compilation was verified, not end-to-end accuracy. The mask values are exact in bf16, so no numerical difference is expected.

