### PR TITLE
fix: make prompt logprobs survive the RBLN prefill path

### DIFF
--- a/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
@@ -321,7 +321,11 @@ def _recording_model_executable(calls, hidden_states, logits):
             token_indices=token_indices,
             kwargs=kwargs,
         )
-        return hidden_states, None, logits
+        # The wrapper returns the narrowed tensor alongside the whole one.
+        # The fake hands back the same tensor in both slots -- the fixtures
+        # here are not staged-shaped, and this is exactly what the previous
+        # contract gave the caller.
+        return hidden_states, hidden_states, None, logits
 
     return fake_model_executable
 
@@ -1976,12 +1980,10 @@ def test_get_prompt_logprobs_dict_chunked_and_final(
     monkeypatch.setattr(rbln_model_runner, "model", FakeModel(), raising=False)
     monkeypatch.setattr(rbln_model_runner, "sampler", FakeSampler())
 
-    rbln_model_runner.query_start_loc[0] = 0
-
     # First chunk: create and keep in-progress prompt logprobs.
     req_state.num_computed_tokens = 0
     hidden_states = torch.empty(
-        (2, hidden_size),
+        (1, 2, hidden_size),
         dtype=rbln_model_runner.dtype,
         device=rbln_model_runner.device,
     )
@@ -2001,7 +2003,7 @@ def test_get_prompt_logprobs_dict_chunked_and_final(
     # Final step: return accumulated logprobs and clear request-local in-progress state.
     req_state.num_computed_tokens = 2
     hidden_states = torch.empty(
-        (1, hidden_size),
+        (1, 1, hidden_size),
         dtype=rbln_model_runner.dtype,
         device=rbln_model_runner.device,
     )
@@ -2022,6 +2024,126 @@ def test_get_prompt_logprobs_dict_chunked_and_final(
 
     assert req_id not in rbln_model_runner.num_prompt_logprobs
     assert req_state.in_progress_prompt_logprobs_cpu is None
+
+
+def test_get_prompt_logprobs_dict_indexes_the_request_and_token_axes(
+    rbln_model_runner, dist_init, monkeypatch
+):
+    """The staged prefill layout is (num_reqs, query_len, hidden), so a
+    request's prompt rows live in its own row -- not at a query_start_loc
+    offset into a flat, concatenated batch. The flat offset reads other
+    requests' rows for req_idx 0 and an empty slice beyond it; the row markers
+    below are what make either visible."""
+    req_id = "req_axes"
+    prompt_token_ids = [10, 11, 12, 13]
+    vocab = 32
+    num_logits = len(prompt_token_ids) - 1
+
+    rbln_model_runner._update_states(
+        _schedule_new_request(
+            req_id,
+            prompt_token_ids=[prompt_token_ids],
+            sampling_params=[SamplingParams(prompt_logprobs=2)],
+        )
+    )
+
+    req_state = rbln_model_runner.requests[req_id]
+    hidden_size = rbln_model_runner.model_config.get_hidden_size()
+
+    class FakeModel:
+        def compute_logits(self, hidden_states):
+            # The upstream contract: (num_tokens, hidden) in, (num_tokens,
+            # vocab) out. A 3D input means the caller sliced the wrong axis.
+            assert hidden_states.dim() == 2, tuple(hidden_states.shape)
+            return hidden_states[:, :1].expand(-1, vocab).contiguous()
+
+    class FakeSampler:
+        def compute_logprobs(self, logits):
+            return logits
+
+        def gather_logprobs(self, logprobs, num_logprobs, tgt_token_ids):
+            assert logprobs.shape == (tgt_token_ids.numel(), vocab), (
+                f"expected ({tgt_token_ids.numel()}, {vocab}), got "
+                f"{tuple(logprobs.shape)}"
+            )
+            # Derived from the logits, not the targets, so a wrong row reaches
+            # the assertions instead of being masked.
+            marks = logprobs[:, 0].to(torch.int32)
+            token_ids = torch.stack([marks, marks + 100, marks + 200], dim=1)
+            out = torch.zeros_like(token_ids, dtype=torch.float32)
+            ranks = torch.arange(
+                1, marks.numel() + 1, dtype=torch.int32, device=marks.device
+            )
+            return token_ids, out, ranks, None
+
+    monkeypatch.setattr(rbln_model_runner, "model", FakeModel(), raising=False)
+    monkeypatch.setattr(rbln_model_runner, "sampler", FakeSampler())
+
+    # Three request rows, each token row tagged 1000*req + token, so reading
+    # the request axis lands on 0/1000/2000 rather than 0/1/2.
+    hidden_states = torch.zeros(
+        (3, len(prompt_token_ids), hidden_size),
+        dtype=torch.float32,
+        device=rbln_model_runner.device,
+    )
+    for r in range(3):
+        for j in range(len(prompt_token_ids)):
+            hidden_states[r, j, :] = 1000 * r + j
+
+    req_state.num_computed_tokens = 0
+
+    out = rbln_model_runner._get_prompt_logprobs_dict(
+        hidden_states=hidden_states,
+        num_scheduled_tokens={req_id: len(prompt_token_ids)},
+    )
+
+    assert list(out) == [req_id]
+    assert out[req_id].logprob_token_ids[:num_logits].tolist() == [
+        [j, j + 100, j + 200] for j in range(num_logits)
+    ]
+
+
+def test_get_prompt_logprobs_dict_refuses_collapsed_hidden_states(
+    rbln_model_runner, dist_init, monkeypatch
+):
+    """If the prefill collapse is not skipped, what arrives here holds one row
+    per request instead of one per token. That has to fail loudly rather than
+    read the last prompt position for every target."""
+    req_id = "req_collapsed"
+    rbln_model_runner._update_states(
+        _schedule_new_request(
+            req_id,
+            prompt_token_ids=[[10, 11, 12, 13]],
+            sampling_params=[SamplingParams(prompt_logprobs=2)],
+        )
+    )
+    rbln_model_runner.requests[req_id].num_computed_tokens = 0
+    hidden_size = rbln_model_runner.model_config.get_hidden_size()
+
+    collapsed = torch.zeros(
+        (1, hidden_size),
+        dtype=torch.float32,
+        device=rbln_model_runner.device,
+    )
+    with pytest.raises(AssertionError, match="un-collapsed"):
+        rbln_model_runner._get_prompt_logprobs_dict(
+            hidden_states=collapsed,
+            num_scheduled_tokens={req_id: 4},
+        )
+
+    # Rank 3 with the token axis narrowed to 1 is what the collapse actually
+    # produces, and it must fail too -- otherwise the last position is handed
+    # back for every target.
+    narrowed = torch.zeros(
+        (1, 1, hidden_size),
+        dtype=torch.float32,
+        device=rbln_model_runner.device,
+    )
+    with pytest.raises(AssertionError, match="token rows"):
+        rbln_model_runner._get_prompt_logprobs_dict(
+            hidden_states=narrowed,
+            num_scheduled_tokens={req_id: 4},
+        )
 
 
 def test_get_nans_in_logits_when_enabled(rbln_model_runner, dist_init, monkeypatch):

--- a/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
@@ -51,7 +51,10 @@ from vllm.v1.worker.gpu_input_batch import InputBatch
 
 import vllm_rbln.v1.worker.rbln_model_runner as rbln_model_runner_module
 from vllm_rbln.v1.core.rbln_scheduler import RBLNSchedulerOutput
-from vllm_rbln.v1.worker.rbln_model_runner import RBLNModelRunner
+from vllm_rbln.v1.worker.rbln_model_runner import (
+    RBLNModelRunner,
+    _prompt_logprobs_row_bucket,
+)
 from vllm_rbln.v1.worker.utils import reorder_input_batch
 
 BLOCK_SIZE = 1024
@@ -2101,6 +2104,99 @@ def test_get_prompt_logprobs_dict_indexes_the_request_and_token_axes(
     assert out[req_id].logprob_token_ids[:num_logits].tolist() == [
         [j, j + 100, j + 200] for j in range(num_logits)
     ]
+
+
+def test_prompt_logprobs_row_bucket_collapses_lengths_to_a_short_ladder():
+    """Each distinct row count costs one dynamo cache entry on the RBLN op
+    wrappers, and the recompile past the limit dies in create_runtime. The
+    ladder has to stay short no matter how many prompt lengths are served."""
+    cap = 512
+    lengths = range(1, cap + 1)
+    assert {_prompt_logprobs_row_bucket(n, cap) for n in lengths} == {
+        1,
+        2,
+        4,
+        8,
+        16,
+        32,
+        64,
+        128,
+        256,
+        512,
+    }
+    assert all(_prompt_logprobs_row_bucket(n, cap) >= n for n in lengths)
+    # Capped by the staged token axis -- never ask for rows that do not exist.
+    assert _prompt_logprobs_row_bucket(300, 400) == 400
+
+
+def test_get_prompt_logprobs_dict_pads_the_row_count_to_a_bucket(
+    rbln_model_runner, dist_init, monkeypatch
+):
+    """Padding must not move the answers: the recorded rows are still the
+    unpadded ones, and what reaches compute_logits is a bucket."""
+    vocab = 32
+    query_len = 16
+    prompt_lens = [3, 6, 10, 13]
+    req_ids = [f"req_bucket_{n}" for n in prompt_lens]
+    seen_rows: list[int] = []
+
+    class FakeModel:
+        def compute_logits(self, hidden_states):
+            seen_rows.append(hidden_states.shape[0])
+            return hidden_states[:, :1].expand(-1, vocab).contiguous()
+
+    class FakeSampler:
+        def compute_logprobs(self, logits):
+            return logits
+
+        def gather_logprobs(self, logprobs, num_logprobs, tgt_token_ids):
+            assert logprobs.shape[0] == tgt_token_ids.numel(), (
+                f"{logprobs.shape[0]} rows vs {tgt_token_ids.numel()} targets"
+            )
+            marks = logprobs[:, 0].to(torch.int32)
+            token_ids = torch.stack([marks, marks + 100], dim=1)
+            out = torch.zeros_like(token_ids, dtype=torch.float32)
+            ranks = torch.arange(
+                1, marks.numel() + 1, dtype=torch.int32, device=marks.device
+            )
+            return token_ids, out, ranks, None
+
+    monkeypatch.setattr(rbln_model_runner, "model", FakeModel(), raising=False)
+    monkeypatch.setattr(rbln_model_runner, "sampler", FakeSampler())
+
+    rbln_model_runner._update_states(
+        _schedule_new_request(
+            *req_ids,
+            prompt_token_ids=[list(range(10, 10 + n)) for n in prompt_lens],
+            sampling_params=[SamplingParams(prompt_logprobs=1)] * len(prompt_lens),
+        )
+    )
+    for req_id in req_ids:
+        rbln_model_runner.requests[req_id].num_computed_tokens = 0
+
+    hidden_size = rbln_model_runner.model_config.get_hidden_size()
+    # Every request row carries the same per-token marker, so a correct read
+    # is j regardless of which row the request landed on.
+    hidden_states = torch.zeros(
+        (len(prompt_lens), query_len, hidden_size),
+        dtype=torch.float32,
+        device=rbln_model_runner.device,
+    )
+    for j in range(query_len):
+        hidden_states[:, j, :] = j
+
+    out = rbln_model_runner._get_prompt_logprobs_dict(
+        hidden_states=hidden_states,
+        num_scheduled_tokens=dict(zip(req_ids, prompt_lens)),
+    )
+
+    for req_id, prompt_len in zip(req_ids, prompt_lens):
+        num_logits = prompt_len - 1
+        assert out[req_id].logprob_token_ids.tolist() == [
+            [j, j + 100] for j in range(num_logits)
+        ], req_id
+    # 2, 5, 9, 12 rows unpadded -> the ladder, capped at the token axis.
+    assert seen_rows == [2, 8, 16, 16], seen_rows
 
 
 def test_get_prompt_logprobs_dict_refuses_collapsed_hidden_states(

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1318,7 +1318,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
 
         # Compute prompt logprobs if needed.
         prompt_logprobs_dict = self._get_prompt_logprobs_dict(
-            hidden_states[:num_scheduled_tokens],
+            hidden_states,
             scheduler_output.num_scheduled_tokens,
         )
 
@@ -1444,7 +1444,9 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             )
 
         with record_function_or_nullcontext("rbln_model_runner: postprocess"):
-            hidden_states, aux_hidden_states, logits = model_output
+            hidden_states, sample_hidden_states, aux_hidden_states, logits = (
+                model_output
+            )
 
             if not get_pp_group().is_last_rank:
                 # Return the intermediate tensors; carry the connector output
@@ -1463,8 +1465,11 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                     kv_connector_output,
                 )
 
-            sample_hidden_states = hidden_states
             assert self.use_wrapped_compute_logits
+            # The wrapper narrows it; re-deriving it from hidden_states here
+            # would hand the drafters every prefill position instead of the
+            # sampling ones.
+            assert sample_hidden_states is not None
             if not self.is_prefill and spec_decode_metadata is not None:
                 logits = logits[logits_indices]
 
@@ -1784,6 +1789,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             )
 
             logits = None
+            sample_hidden_states = None
             if self.use_aux_hidden_state_outputs:
                 hidden_states, aux_hidden_states = model_output
             else:
@@ -1796,20 +1802,22 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 and self.logits_processor is not None
             ):
                 if token_indices is not None:
+                    # NOTE(RBLN): token_indices points to the last-token
+                    # positions used for sampling. Both tensors are returned
+                    # rather than collapsing one into the other: the narrow
+                    # one is what compute_logits and the drafters want, and
+                    # EAGLE and prompt logprobs need every prefill position.
+                    # Choosing between them here is not an option either --
+                    # this function is torch.compiled with
+                    # keep_tensor_guards_unsafe, so a per-request condition
+                    # would be traced once and baked in for good.
                     sample_hidden_states = hidden_states[:, token_indices]
-                    # NOTE(RBLN): token_indices points to the last-token positions used
-                    # for sampling. EAGLE needs the full hidden_states during prefill,
-                    # so do not slice them here.
-                    if not (
-                        self.speculative_config and self.speculative_config.use_eagle()
-                    ):
-                        hidden_states = sample_hidden_states
                 else:
                     sample_hidden_states = hidden_states
                 logits = self.model.compute_logits(sample_hidden_states)
                 logits = logits.view(-1, logits.size(-1))
 
-            return hidden_states, aux_hidden_states, logits
+            return hidden_states, sample_hidden_states, aux_hidden_states, logits
 
         if self.model_config.enforce_eager or not envs.VLLM_RBLN_COMPILE_MODEL:
             self.model_executable = model_wrapper
@@ -1882,7 +1890,9 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 continue
 
             num_prompt_tokens = len(request.prompt_token_ids)
-            prompt_token_ids = torch.tensor(request.prompt_token_ids)
+            prompt_token_ids = torch.tensor(request.prompt_token_ids).to(
+                self.device, non_blocking=True
+            )
 
             # Set up target LogprobsTensors object.
             logprobs_tensors = request.in_progress_prompt_logprobs_cpu
@@ -1920,8 +1930,19 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             # If this is a partial request (i.e. chunked prefill),
             # then there is prompt logprob generated for each index.
             req_idx = self.input_batch.req_id_to_index[req_id]
-            offset = self.query_start_loc.cpu[req_idx].item()
-            prompt_hidden_states = hidden_states[offset : offset + num_logits]
+            # The staged prefill layout gives every request its own row, so this
+            # chunk's tokens start at local index 0. Upstream's query_start_loc
+            # offset exists only to find a request inside a flat, concatenated
+            # batch, and applying it here would index the request axis.
+            # The rank alone proves nothing: collapsing narrows the token axis
+            # to 1 and keeps three dims, which would silently hand back the
+            # last position for every target.
+            assert hidden_states.dim() == 3 and hidden_states.shape[1] >= num_logits, (
+                "prompt logprobs need the un-collapsed prefill hidden states; "
+                f"want >= {num_logits} token rows, got "
+                f"{tuple(hidden_states.shape)}"
+            )
+            prompt_hidden_states = hidden_states[req_idx, :num_logits]
             logits = self.model.compute_logits(prompt_hidden_states)
 
             # Get the "target" tokens for each index. For prompt at index i,
@@ -1935,15 +1956,14 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 logprobs, num_prompt_logprobs, tgt_token_ids
             )
 
-            # Transfer
+            # Transfer device->CPU. Blocking on purpose: upstream follows its
+            # non-blocking copies with a device synchronize, and this runner
+            # has no _sync_device -- an async copy here would let the CPU
+            # tensors be serialized before the data lands.
             chunk_slice = slice(start_idx, start_idx + num_logits)
-            logprobs_tensors.logprob_token_ids[chunk_slice].copy_(
-                token_ids, non_blocking=True
-            )
-            logprobs_tensors.logprobs[chunk_slice].copy_(logprobs, non_blocking=True)
-            logprobs_tensors.selected_token_ranks[chunk_slice].copy_(
-                ranks, non_blocking=True
-            )
+            logprobs_tensors.logprob_token_ids[chunk_slice].copy_(token_ids)
+            logprobs_tensors.logprobs[chunk_slice].copy_(logprobs)
+            logprobs_tensors.selected_token_ranks[chunk_slice].copy_(ranks)
 
         # Remove requests that have completed prefill from the batch
         # num_prompt_logprobs_dict.

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1890,9 +1890,6 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 continue
 
             num_prompt_tokens = len(request.prompt_token_ids)
-            prompt_token_ids = torch.tensor(request.prompt_token_ids).to(
-                self.device, non_blocking=True
-            )
 
             # Set up target LogprobsTensors object.
             logprobs_tensors = request.in_progress_prompt_logprobs_cpu
@@ -1942,13 +1939,20 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 f"want >= {num_logits} token rows, got "
                 f"{tuple(hidden_states.shape)}"
             )
-            prompt_hidden_states = hidden_states[req_idx, :num_logits]
+            # Row count padded to a ladder: every distinct one costs a dynamo
+            # cache entry on the RBLN op wrappers, and the recompile past the
+            # limit dies in create_runtime and takes the engine with it.
+            num_rows = _prompt_logprobs_row_bucket(num_logits, hidden_states.shape[1])
+            prompt_hidden_states = hidden_states[req_idx, :num_rows]
             logits = self.model.compute_logits(prompt_hidden_states)
 
             # Get the "target" tokens for each index. For prompt at index i,
             # the token at prompt index i+1 is the "sampled" token we want
-            # to gather the logprob for.
-            tgt_token_ids = prompt_token_ids[start_tok : start_tok + num_logits]
+            # to gather the logprob for. Padded on the host -- a device-side
+            # pad would be one more shape that varies with the prompt.
+            tgt = list(request.prompt_token_ids[start_tok : start_tok + num_logits])
+            tgt.extend([tgt[-1]] * (num_rows - num_logits))
+            tgt_token_ids = torch.tensor(tgt, dtype=torch.int64, device=self.device)
 
             # Compute prompt logprobs.
             logprobs = self.sampler.compute_logprobs(logits)
@@ -1956,14 +1960,18 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 logprobs, num_prompt_logprobs, tgt_token_ids
             )
 
-            # Transfer device->CPU. Blocking on purpose: upstream follows its
-            # non-blocking copies with a device synchronize, and this runner
-            # has no _sync_device -- an async copy here would let the CPU
-            # tensors be serialized before the data lands.
+            # Transfer device->CPU, then drop the padding rows. Blocking on
+            # purpose: upstream follows its non-blocking copies with a device
+            # synchronize, and this runner has no _sync_device. Trimming after
+            # the copy keeps the varying shape off the device.
             chunk_slice = slice(start_idx, start_idx + num_logits)
-            logprobs_tensors.logprob_token_ids[chunk_slice].copy_(token_ids)
-            logprobs_tensors.logprobs[chunk_slice].copy_(logprobs)
-            logprobs_tensors.selected_token_ranks[chunk_slice].copy_(ranks)
+            logprobs_tensors.logprob_token_ids[chunk_slice].copy_(
+                token_ids.cpu()[:num_logits]
+            )
+            logprobs_tensors.logprobs[chunk_slice].copy_(logprobs.cpu()[:num_logits])
+            logprobs_tensors.selected_token_ranks[chunk_slice].copy_(
+                ranks.cpu()[:num_logits]
+            )
 
         # Remove requests that have completed prefill from the batch
         # num_prompt_logprobs_dict.
@@ -2950,6 +2958,12 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                     dst = op.dst_block_id
                     nt = op.num_tokens
                     kv_cache[:, dst, :, :, :nt, :] = kv_cache[:, src, :, :, :nt, :]
+
+
+def _prompt_logprobs_row_bucket(num_logits: int, cap: int) -> int:
+    """Round a prompt-logprobs row count up to a power of two, capped by the
+    staged token axis so the slice stays in bounds."""
+    return min(cap, 1 << (num_logits - 1).bit_length())
 
 
 def _pad_rows(t: torch.Tensor | None, bucket: int) -> torch.Tensor | None:


### PR DESCRIPTION
## What

Any `/v1/completions` request with `echo=true, logprobs=N` (the payload
`lm-evaluation-harness` sends for every loglikelihood task) kills EngineCore,
so the server returns 500 and the deployment goes down. Four separate
divergences from upstream stack up on the prompt-logprobs path; each was
found by fixing the previous one and measuring again on hardware.

### 1. The prefill collapse discards the hidden states this path needs

During prefill the compiled model wrapper replaced `hidden_states` with the
sampling slice — one row per request — so the per-token prompt positions were
gone before `_get_prompt_logprobs_dict` ran:

```
RuntimeError: Size does not match at dimension 0
              expected index [512, 1] to be no larger than self [1, 151936]
```

The collapse arrived with the EAGLE work, which excepted only itself. The
condition cannot become per-request: the wrapper is compiled with
`guard_filter_fn=torch.compiler.keep_tensor_guards_unsafe`, so a Python-value
test is traced once — during warm-up, when nothing has asked for prompt
logprobs — and baked in for good. The collapse is dropped and the wrapper
returns the narrowed tensor alongside the whole one: the narrow one is what
`compute_logits` and the medusa drafter consume, the whole one is what EAGLE
and prompt logprobs need. EAGLE behavior is unchanged (it already received
the whole tensor); the medusa drafter receives exactly the tensor it received
before.

The indexing changes with it: upstream's `query_start_loc` offset locates a
request inside a flat concatenated batch, but the staged layout gives every
request its own row, so the slice is `hidden_states[req_idx, :num_logits]`.
A guard asserts the token extent (not the rank — the collapsed tensor is
still 3-D, so a rank check would silently return the last position for every
target).

### 2. `tgt_token_ids` never moved to the device

With the hidden states arriving, `gather_logprobs` dies on

```
RuntimeError: cat_out_rbln: inputs must be on RBLN device, got cpu
```

Upstream moves `prompt_token_ids` to `self.device` where the tensor is
created (`gpu_model_runner.py`, both 0.22.0 and 0.24.0); this port dropped
that call. Restored.

### 3. The device→CPU transfers lost their synchronize

Upstream pairs its non-blocking copies with `_sync_device()` ("Must
synchronize the non-blocking GPU->CPU transfers"). This runner has no
`_sync_device`, and the port kept the async copies while dropping the sync —
not a crash but a race: the CPU tensors can be serialized before the data
lands, silently returning wrong logprobs. The copies are now blocking; this
is the rare-feature path where upstream itself trades performance for
simplicity.

### 4. The row count leaks the prompt length into a compiled shape

With parts 1-3 in, single requests work and a short loglikelihood task
completes -- but a longer run dies after a few dozen prompts, at a point that
looks arbitrary. It is not. Two independent runs left the same fingerprint,
nine seconds before the engine died:

```
torch._dynamo hit config.recompile_limit (64)
   function: 'forward' (torch_rbln/_internal/ops_utils.py:1624)
   last reason: tensor 'fwd_args[0]' size mismatch at index 0.
                expected 76, actual 75
```

`num_logits` comes straight from the prompt length, and it was passed through
unpadded. There is no eager execution on the NPU, so every op goes through
`torch_rbln`'s per-op wrapper -- which, compiled with static shapes, spends
one dynamo cache entry per distinct row count. Past the limit (64, set in
`vllm_rbln/compilation/compiler.py`) a compile runs mid-serve, and
`create_runtime` on a device that already holds its runtimes fails with
`RuntimeError: INIT_INTERNAL`, taking EngineCore down.

The count is cumulative over the process, which is why the death point looks
random: in both runs the number of distinct prefill `query_len` values seen
before the warning was exactly 64. The RBLN sampler graph that appears to
recompile at the crash (`bf16[1,151936]`) is a downstream symptom -- that
signature was already compiled during warm-up.

The fix pads the row count up to a power-of-two ladder, capped by the staged
token axis, so a 512-token chunk size yields ten distinct shapes instead of
thousands. Target token ids are padded on the host (a device-side pad would
be one more prompt-shaped op), and the padding rows are dropped after the
device-to-CPU copy for the same reason. The whole-prompt host-to-device copy
is gone with them: it was prompt-shaped too, and only the padded target slice
is needed.

Padding rows cannot move the answers -- every op on this path is row-wise:
`log_softmax(-1)`, `topk(-1)`, `gather(-1)`, `cat(1)`, and the rank's
`(x >= values).sum(-1)`.

Raising the limit is not a fix: a real evaluation sends thousands of distinct
prompt lengths, so it only moves the failure later, at one compile and one
device allocation each.

Upstream does not have this problem. `@support_torch_compile` swaps
`cls.__call__`, so `compute_logits` runs outside the compiled region; and
even compiled, `automatic_dynamic_shapes` (on by default) promotes the
dimension to symbolic on the second distinct size. This runner compiles with
`dynamic=False`, which disables that promotion. For reference the torch
default limit is 8 -- the 64 here is already higher, so the limit is not the
problem; letting the prompt length become a shape axis is.

## Measured on hardware (RBLN-CR03, tiny 0.6B model)

- Before: the request 500s and EngineCore dies, on every attempt.
- After parts 1-3: `echo=true, logprobs=1` over a ~23k-token prompt returns
  23,231 token logprobs, zero unexpected nulls, `logprobs[0] == null` as
  upstream defines, and the total logprob is bit-identical across two
  identical requests. Repeated across three runs.
- Part 4 was found by running `lm-evaluation-harness` loglikelihood tasks
  against the deployment: the engine died after 64 distinct prompt lengths,
  twice, with the fingerprint above. After the fix both tasks complete and the
  deployment shuts down cleanly:

  | | before | after |
  |---|---|---|
  | `wikitext` (62 docs, `loglikelihood_rolling`) | completed, 1128.8 s | completed, 555.7 s |
  | `arc_challenge` (200 docs, `loglikelihood`) | died at request 30/799 | completed, 197.9 s |

  The scores are unchanged where they existed before: `wikitext` reports
  `word_perplexity 1396653.0933726637`, `byte_perplexity 14.098154838229165`,
  `bits_per_byte 3.8174344504241953` — identical to the last float digit
  across the two runs, so the padding demonstrably does not move the answers.
  `arc_challenge` returns `acc 0.200 ± 0.028` / `acc_norm 0.270 ± 0.031`,
  which brackets chance (0.25) for the random-weight stand-in model this ran
  against — the expected result, and evidence the path is correct rather than
  a claim about the model.

- Unexpected second effect: **the tasks got 2-13x faster.** `arc_challenge`
  went from 3.27 s/req to 0.247 s/req. The old cost was almost entirely
  compilation — nearly every request introduced a new shape, so nearly every
  request paid for a compile. With ten shapes total only the first few do.

## Out of scope, observed while verifying

With a KV-cache connector enabled, a second identical request restores the
cached prompt span and the engine computes only the residual tokens, so the
restored span's prompt logprobs are never produced — the preallocated
buffer's uninitialized rows reach the response and the API layer 500s
(`KeyError` while resolving a prompt token in a garbage logprob row). Local
prefix caching is already guarded for this (`skip_reading_prefix_cache`);
the connector branch has no such guard, in upstream vLLM as well. That is a
scheduler-side gap independent of this fix, and is addressed separately in
#1038.

## Tests

`tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py`:

- New: rows are tagged per (request, token) so the assertions check which
  rows were read (request-axis vs token-axis vs flat offset), and the shape
  reaching `gather_logprobs` is pinned.
- New: both failure modes of the guard (2-D input, collapsed 3-D input).
- The pre-existing chunked-prefill test carried flat 2-D fixtures — the
  upstream layout this runner never sees, which is how the collapse survived
  it — and now uses the staged 3-D layout.
- New: the ladder itself -- every length from 1 to the cap maps into ten
  buckets, each bucket is at least the length it covers, and the cap wins so
  the slice stays in bounds.
- New: padding does not move the answers -- four requests of different prompt
  lengths record exactly their unpadded rows while what reaches
  `compute_logits` is the bucket. Observed failing with the call site
  unpadded (`[2, 5, 9, 12]` instead of `[2, 8, 16, 16]`), with the other
  tests still passing, so the assertion discriminates.
- Parts 2 and 3 are not observable in CPU-only unit tests; they are covered
  by the hardware verification above.

The full unit suite was run against this commit and against its parent under
the same environment: the failure set is identical (56 failures either way,
both directions of the set difference empty — they are environment drift, the
public 0.22 wheels against 0.24-era code), with the two new tests accounting
for the difference in passes.


