### PR TITLE
fix(sampler): pad allowed_token_ids_mask with the rest of the batch axis

### DIFF
--- a/tests/native/v1/worker/test_rbln_model_runner.py
+++ b/tests/native/v1/worker/test_rbln_model_runner.py
@@ -88,7 +88,9 @@ def _make_runner_stub(**attrs):
     return runner
 
 
-def _sampling_metadata(n, *, no_penalties=True, spec_token_ids=None):
+def _sampling_metadata(
+    n, *, no_penalties=True, spec_token_ids=None, allowed_token_ids_mask=None
+):
     return SamplingMetadata(
         temperature=torch.ones(n),
         all_greedy=False,
@@ -103,7 +105,7 @@ def _sampling_metadata(n, *, no_penalties=True, spec_token_ids=None):
         presence_penalties=torch.zeros(n),
         repetition_penalties=torch.ones(n),
         output_token_ids=[[] for _ in range(n)],
-        allowed_token_ids_mask=None,
+        allowed_token_ids_mask=allowed_token_ids_mask,
         bad_words_token_ids={},
         logitsprocs=None,
         logprob_token_ids=None,
@@ -221,6 +223,15 @@ class TestPadDepad:
         assert p.frequency_penalties.shape[0] == 4
         assert len(p.output_token_ids) == 4
         assert p.output_token_ids[2] == []
+
+    def test_pad_sampling_metadata_pads_allowed_token_ids_mask(self):
+        mask = torch.zeros(2, 10, dtype=torch.bool)
+        mask[0, 3] = True
+        p = _pad_sampling_metadata(
+            _sampling_metadata(2, allowed_token_ids_mask=mask), 4
+        )
+        assert p.allowed_token_ids_mask.shape == (4, 10)
+        assert torch.equal(p.allowed_token_ids_mask[:2], mask)
 
     def test_depad_sampler_output_trims_to_num_reqs(self):
         out = SamplerOutput(

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -3497,9 +3497,6 @@ def _pad_sampling_metadata(md: SamplingMetadata, bucket: int) -> SamplingMetadat
         temperature=_pad_rows(md.temperature, bucket),
         top_p=_pad_rows(md.top_p, bucket),
         top_k=_pad_rows(md.top_k, bucket),
-        # Repeating the last request's mask row is safe: a real request always
-        # allows at least one token, and the padded rows' samples are discarded
-        # by _depad_sampler_output.
         allowed_token_ids_mask=_pad_rows(md.allowed_token_ids_mask, bucket),
     )
     if not md.no_penalties:

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -3497,6 +3497,10 @@ def _pad_sampling_metadata(md: SamplingMetadata, bucket: int) -> SamplingMetadat
         temperature=_pad_rows(md.temperature, bucket),
         top_p=_pad_rows(md.top_p, bucket),
         top_k=_pad_rows(md.top_k, bucket),
+        # Repeating the last request's mask row is safe: a real request always
+        # allows at least one token, and the padded rows' samples are discarded
+        # by _depad_sampler_output.
+        allowed_token_ids_mask=_pad_rows(md.allowed_token_ids_mask, bucket),
     )
     if not md.no_penalties:
         kwargs.update(


### PR DESCRIPTION
### 🚀 Summary of Changes

This was missed in #1014 
The allowed_token_ids mask tensor also needs to be padded, just like the other tensors such as top_k / top_p.

---

### 📌 Related Issues / Tickets

* Related to #1014

---

### ✅ Type of Change

* [x] 🛠 Bug fix (`fix`)

---

### 🧪 How to Test

```
uv run --no-sync pytest tests/native/v1/worker/test_rbln_model_runner.py -q \
  -k "TestPadDepad or TestSamplePadding"
```

The new `test_pad_sampling_metadata_pads_allowed_token_ids_mask` fails without the fix (the mask comes back at 2 rows instead of the bucket's 4) and passes with it; the surrounding pad/depad tests still pass (11 total).

End to end, the crash reproduces with the ngram spec-decode offline example plus `SamplingParams(..., allowed_token_ids=list(range(1000)))`, fewer prompts than `max_num_seqs`, and prompts repetitive enough for ngram to draft: before this fix the first drafted decode step raises `RuntimeError` from `masked_fill_` inside the rejection sampler's bonus path; after it, the run completes.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

Found by review of #1014, but the non-spec exposure predates it — #1014 only extended the reach to the rejection branch. Verified at unit level and by code reading of the upstream mask application; the end-to-end repro above has not been run on an NPU in this session.
