### PR TITLE
fix(metrics): keep MODEL+SAMPLE meaningful under spec decode

### DIFF
--- a/tests/native/patches/test_metrics.py
+++ b/tests/native/patches/test_metrics.py
@@ -496,6 +496,19 @@ class TestSamplerTiming:
         assert ctx._graph_latency is None
 
 
+class TestDrafterTiming:
+    def test_drafter_call_adds_graph_time(self, monkeypatch):
+        monkeypatch.setattr(
+            pm, "_propose_draft_token_ids", lambda self, *a, **k: "drafts"
+        )
+        runner = _Runner()
+        ctx = pm._ctx(runner)
+        ctx.start_pass()
+
+        assert pm.propose_draft_token_ids(runner) == "drafts"
+        assert ctx._graph_latency is not None
+
+
 class TestModelExecutable:
     def test_the_executable_is_timed_only_inside_a_pass(self, monkeypatch):
         calls: list[dict] = []
@@ -522,20 +535,17 @@ class TestModelExecutable:
 
 
 class TestTimedRegion:
-    """Spec decode's device wait sits in the postprocess gather and the drafter,
-    which are inline regions: timed_region must fold exactly those two into the
-    graph sum, and only while a pass is open."""
+    """Spec decode's device wait sits in the postprocess gather, an inline region:
+    timed_region must fold exactly that one into the graph sum, and only while a
+    pass is open."""
 
     def _in_pass(self, ctx, clock, monkeypatch):
         monkeypatch.setattr(pm, "_ACTIVE_CTX", ctx)
         ctx.start_pass()
 
-    @pytest.mark.parametrize(
-        "region", ["rbln_model_runner: postprocess", "rbln_model_runner: draft"]
-    )
-    def test_graph_regions_add_graph_time(self, ctx, clock, monkeypatch, region):
+    def test_graph_region_adds_graph_time(self, ctx, clock, monkeypatch):
         self._in_pass(ctx, clock, monkeypatch)
-        with pm.timed_region(region):
+        with pm.timed_region("rbln_model_runner: postprocess"):
             clock.advance(3 * MS)
         assert ctx._graph_latency == pytest.approx(3 * MS)
 
@@ -593,7 +603,7 @@ class TestDescriptors:
             for d in registry.get_registered_patch_descriptors()
             if d.owner_module == "vllm_rbln.patches.metrics"
         ]
-        assert len(ours) == 8
+        assert len(ours) == 9
         for descriptor in ours:
             owner, attr = registry._resolve_patch_target_owner(descriptor.target)
             assert hasattr(owner, attr), descriptor.target

--- a/tests/native/patches/test_metrics.py
+++ b/tests/native/patches/test_metrics.py
@@ -521,6 +521,42 @@ class TestModelExecutable:
         assert calls == [{"step": 1}, {"step": 2}]
 
 
+class TestTimedRegion:
+    """Spec decode's device wait sits in the postprocess gather and the drafter,
+    which are inline regions: timed_region must fold exactly those two into the
+    graph sum, and only while a pass is open."""
+
+    def _in_pass(self, ctx, clock, monkeypatch):
+        monkeypatch.setattr(pm, "_ACTIVE_CTX", ctx)
+        ctx.start_pass()
+
+    @pytest.mark.parametrize(
+        "region", ["rbln_model_runner: postprocess", "rbln_model_runner: draft"]
+    )
+    def test_graph_regions_add_graph_time(self, ctx, clock, monkeypatch, region):
+        self._in_pass(ctx, clock, monkeypatch)
+        with pm.timed_region(region):
+            clock.advance(3 * MS)
+        assert ctx._graph_latency == pytest.approx(3 * MS)
+
+    def test_other_regions_do_not_touch_graph_time(self, ctx, clock, monkeypatch):
+        self._in_pass(ctx, clock, monkeypatch)
+        with pm.timed_region("rbln_model_runner: preprocess"):
+            clock.advance(3 * MS)
+        assert ctx._graph_latency is None
+
+    def test_no_pass_open_is_a_no_op(self, ctx, clock, monkeypatch):
+        monkeypatch.setattr(pm, "_ACTIVE_CTX", ctx)
+        with pm.timed_region("rbln_model_runner: postprocess"):
+            clock.advance(3 * MS)
+        assert ctx._graph_latency is None
+
+    def test_no_active_ctx_is_a_no_op(self, clock, monkeypatch):
+        monkeypatch.setattr(pm, "_ACTIVE_CTX", None)
+        with pm.timed_region("rbln_model_runner: postprocess"):
+            clock.advance(3 * MS)
+
+
 class TestShutdown:
     def test_stats_are_reported_before_teardown(self, monkeypatch):
         order: list[str] = []
@@ -557,7 +593,7 @@ class TestDescriptors:
             for d in registry.get_registered_patch_descriptors()
             if d.owner_module == "vllm_rbln.patches.metrics"
         ]
-        assert len(ours) == 7
+        assert len(ours) == 8
         for descriptor in ours:
             owner, attr = registry._resolve_patch_target_owner(descriptor.target)
             assert hasattr(owner, attr), descriptor.target

--- a/tests/native/patches/test_metrics.py
+++ b/tests/native/patches/test_metrics.py
@@ -497,19 +497,6 @@ class TestSamplerTiming:
         assert ctx._graph_latency is None
 
 
-class TestDrafterTiming:
-    def test_drafter_call_adds_graph_time(self, monkeypatch):
-        monkeypatch.setattr(
-            pm, "_propose_draft_token_ids", lambda self, *a, **k: "drafts"
-        )
-        runner = _Runner()
-        ctx = pm._ctx(runner)
-        ctx.start_pass()
-
-        assert pm.propose_draft_token_ids(runner) == "drafts"
-        assert ctx._graph_latency is not None
-
-
 class TestModelExecutable:
     def test_the_executable_is_timed_only_inside_a_pass(self, monkeypatch):
         calls: list[dict] = []
@@ -611,7 +598,7 @@ class TestDescriptors:
             for d in registry.get_registered_patch_descriptors()
             if d.owner_module == "vllm_rbln.patches.metrics"
         ]
-        assert len(ours) == 9
+        assert len(ours) == 8
         for descriptor in ours:
             owner, attr = registry._resolve_patch_target_owner(descriptor.target)
             assert hasattr(owner, attr), descriptor.target

--- a/tests/native/patches/test_metrics.py
+++ b/tests/native/patches/test_metrics.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import json
 import types
 from typing import Any
@@ -565,6 +566,13 @@ class TestTimedRegion:
         monkeypatch.setattr(pm, "_ACTIVE_CTX", None)
         with pm.timed_region("rbln_model_runner: postprocess"):
             clock.advance(3 * MS)
+
+    def test_the_region_literal_matches_the_runner_source(self):
+        # timed_region matches execute_model's region by its literal name, so a
+        # rename in the runner would silently drop the spec-decode device wait
+        # from the graph sum. Pin the string to the source it must match.
+        source = inspect.getsource(pm._execute_model)
+        assert f'"{pm._GRAPH_REGION}"' in source
 
 
 class TestShutdown:

--- a/vllm_rbln/patches/metrics.py
+++ b/vllm_rbln/patches/metrics.py
@@ -24,12 +24,19 @@ absorbs the wait. Async defers that read out of the pass, so there it is dispatc
 A pass is recorded only once its phase and its graph time are both known, which is
 what keeps those counts equal.
 
+Spec decode moves that first blocking read again -- into the spec-only logits gather
+in execute_model's postprocess block, and runs the drafter between _sample and
+_bookkeeping_sync. Neither is a wrappable method, so timed_region folds the runner's
+"postprocess" and "draft" profiler regions into the same graph sum; both are empty
+without spec decode.
+
 The whole feature lives in this module so the runner carries no metrics code at all. A
 range that is not a whole method -- the model call sits mid-way through execute_model --
 is reached by wrapping the callable the runner holds, and the phase, which is a local of
 execute_model, is read where the runner computes it.
 """
 
+import contextlib
 import functools
 import json
 import os
@@ -39,6 +46,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 
 import numpy as np
+from vllm.v1.utils import record_function_or_nullcontext
 
 from vllm_rbln import envs
 from vllm_rbln.logger import init_logger
@@ -266,7 +274,9 @@ _shutdown = RBLNWorker.shutdown
 
 @functools.wraps(_execute_model)
 def execute_model(self, *args, **kwargs):
+    global _ACTIVE_CTX
     ctx = _ctx(self)
+    _ACTIVE_CTX = ctx
     ctx.start_pass()
     output = _execute_model(self, *args, **kwargs)
     # The engine calls sample_tokens() only if execute_model() returned None, so a
@@ -357,6 +367,30 @@ def shutdown(self):
     _shutdown(self)
 
 
+_ACTIVE_CTX: _PerformanceContext | None = None
+
+# The regions that hold device wait under spec decode (see the module docstring);
+# they belong to the graph sum, and are empty without spec decode.
+_GRAPH_REGIONS = frozenset(
+    {"rbln_model_runner: postprocess", "rbln_model_runner: draft"}
+)
+
+
+@contextlib.contextmanager
+def timed_region(name: str):
+    ctx = _ACTIVE_CTX
+    if name not in _GRAPH_REGIONS or ctx is None or not ctx.in_pass:
+        with record_function_or_nullcontext(name):
+            yield
+        return
+    start = time.perf_counter()
+    try:
+        with record_function_or_nullcontext(name):
+            yield
+    finally:
+        ctx.add_graph_time(time.perf_counter() - start)
+
+
 _RUNNER = "vllm_rbln.v1.worker.rbln_model_runner.RBLNModelRunner"
 _WORKER = "vllm_rbln.v1.worker.rbln_worker.RBLNWorker"
 
@@ -404,6 +438,12 @@ def _register_patches() -> None:
             shutdown,
             "Reports the collected metrics before teardown; the worker holds the only "
             "shutdown hook that still has the runner.",
+        ),
+        (
+            "vllm_rbln.v1.worker.rbln_model_runner.record_function_or_nullcontext",
+            timed_region,
+            "Spec decode holds its device wait in the postprocess and draft "
+            "regions, which are inline blocks with no method to wrap.",
         ),
     ):
         register_patch(

--- a/vllm_rbln/patches/metrics.py
+++ b/vllm_rbln/patches/metrics.py
@@ -26,9 +26,10 @@ what keeps those counts equal.
 
 Spec decode moves that first blocking read again -- into the spec-only logits gather
 in execute_model's postprocess block, and runs the drafter between _sample and
-_bookkeeping_sync. Neither is a wrappable method, so timed_region folds the runner's
-"postprocess" and "draft" profiler regions into the same graph sum; both are empty
-without spec decode.
+_bookkeeping_sync. The drafter is a method (propose_draft_token_ids) and is wrapped
+like the sampler; the gather is an inline block with no method to wrap, so
+timed_region folds the runner's "postprocess" profiler region into the same graph
+sum. Both are empty without spec decode.
 
 The whole feature lives in this module so the runner carries no metrics code at all. A
 range that is not a whole method -- the model call sits mid-way through execute_model --
@@ -269,6 +270,7 @@ _determine_batch_execution_and_padding = (
     RBLNModelRunner._determine_batch_execution_and_padding
 )
 _bookkeeping_sync = RBLNModelRunner._bookkeeping_sync
+_propose_draft_token_ids = RBLNModelRunner.propose_draft_token_ids
 _shutdown = RBLNWorker.shutdown
 
 
@@ -310,6 +312,14 @@ def sample(self, *args, **kwargs):
         return _sample(self, *args, **kwargs)
     start = time.perf_counter()
     output = _sample(self, *args, **kwargs)
+    _ctx(self).add_graph_time(time.perf_counter() - start)
+    return output
+
+
+@functools.wraps(_propose_draft_token_ids)
+def propose_draft_token_ids(self, *args, **kwargs):
+    start = time.perf_counter()
+    output = _propose_draft_token_ids(self, *args, **kwargs)
     _ctx(self).add_graph_time(time.perf_counter() - start)
     return output
 
@@ -369,17 +379,15 @@ def shutdown(self):
 
 _ACTIVE_CTX: _PerformanceContext | None = None
 
-# The regions that hold device wait under spec decode (see the module docstring);
-# they belong to the graph sum, and are empty without spec decode.
-_GRAPH_REGIONS = frozenset(
-    {"rbln_model_runner: postprocess", "rbln_model_runner: draft"}
-)
+# The region that holds the spec-only logits gather (see the module docstring); it
+# belongs to the graph sum, and is empty without spec decode.
+_GRAPH_REGION = "rbln_model_runner: postprocess"
 
 
 @contextlib.contextmanager
 def timed_region(name: str):
     ctx = _ACTIVE_CTX
-    if name not in _GRAPH_REGIONS or ctx is None or not ctx.in_pass:
+    if name != _GRAPH_REGION or ctx is None or not ctx.in_pass:
         with record_function_or_nullcontext(name):
             yield
         return
@@ -422,6 +430,12 @@ def _register_patches() -> None:
             "attribute, so it cannot be replaced through the registry.",
         ),
         (
+            f"{_RUNNER}.propose_draft_token_ids",
+            propose_draft_token_ids,
+            "Times the drafter, which runs between _sample and _bookkeeping_sync "
+            "and holds device wait under MTP/EAGLE spec decode.",
+        ),
+        (
             f"{_RUNNER}._bookkeeping_sync",
             bookkeeping_sync,
             "Holds the step's first blocking read of the sampler output, which the "
@@ -442,8 +456,8 @@ def _register_patches() -> None:
         (
             "vllm_rbln.v1.worker.rbln_model_runner.record_function_or_nullcontext",
             timed_region,
-            "Spec decode holds its device wait in the postprocess and draft "
-            "regions, which are inline blocks with no method to wrap.",
+            "Spec decode syncs on the forward in the spec-only logits gather, "
+            "an inline block of execute_model with no method to wrap.",
         ),
     ):
         register_patch(

--- a/vllm_rbln/patches/metrics.py
+++ b/vllm_rbln/patches/metrics.py
@@ -25,11 +25,13 @@ A pass is recorded only once its phase and its graph time are both known, which 
 what keeps those counts equal.
 
 Spec decode moves that first blocking read again -- into the spec-only logits gather
-in execute_model's postprocess block, and runs the drafter between _sample and
-_bookkeeping_sync. The drafter is a method (propose_draft_token_ids) and is wrapped
-like the sampler; the gather is an inline block with no method to wrap, so
-timed_region folds the runner's "postprocess" profiler region into the same graph
-sum. Both are empty without spec decode.
+in execute_model's postprocess block, which syncs on the target forward. The gather
+is an inline block with no method to wrap, so timed_region folds the runner's
+"postprocess" profiler region into the graph sum; it is empty without spec decode.
+The drafter, which runs between _sample and _bookkeeping_sync, is deliberately not
+folded: MODEL + SAMPLE stays the main-graph number, and the drafter's time -- under
+EAGLE/MTP a draft-model forward, plus any sampler wait its first read absorbs --
+shows up in the E2E residual.
 
 The whole feature lives in this module so the runner carries no metrics code at all. A
 range that is not a whole method -- the model call sits mid-way through execute_model --
@@ -270,7 +272,6 @@ _determine_batch_execution_and_padding = (
     RBLNModelRunner._determine_batch_execution_and_padding
 )
 _bookkeeping_sync = RBLNModelRunner._bookkeeping_sync
-_propose_draft_token_ids = RBLNModelRunner.propose_draft_token_ids
 _shutdown = RBLNWorker.shutdown
 
 
@@ -312,14 +313,6 @@ def sample(self, *args, **kwargs):
         return _sample(self, *args, **kwargs)
     start = time.perf_counter()
     output = _sample(self, *args, **kwargs)
-    _ctx(self).add_graph_time(time.perf_counter() - start)
-    return output
-
-
-@functools.wraps(_propose_draft_token_ids)
-def propose_draft_token_ids(self, *args, **kwargs):
-    start = time.perf_counter()
-    output = _propose_draft_token_ids(self, *args, **kwargs)
     _ctx(self).add_graph_time(time.perf_counter() - start)
     return output
 
@@ -428,12 +421,6 @@ def _register_patches() -> None:
             load_model,
             "Wraps the compiled model_executable once it exists; it is an instance "
             "attribute, so it cannot be replaced through the registry.",
-        ),
-        (
-            f"{_RUNNER}.propose_draft_token_ids",
-            propose_draft_token_ids,
-            "Times the drafter, which runs between _sample and _bookkeeping_sync "
-            "and holds device wait under MTP/EAGLE spec decode.",
         ),
         (
             f"{_RUNNER}._bookkeeping_sync",


### PR DESCRIPTION
## Problem

With `VLLM_RBLN_METRICS`, the `MODEL + SAMPLE` section approximates device time by relying on where the step's first blocking device read happens: the model call and `_sample` are async dispatches, and the wait for the device lands inside `_bookkeeping_sync` (the `tolist()` of the sampled tokens), which is one of the three timed callables.

Spec decode breaks that premise. On the spec-decode path the first blocking read moves out of every timed callable:

- the spec-only logits gather (`logits = logits[logits_indices]`) in `execute_model`'s postprocess block syncs on the forward **before** `_sample` runs, and
- the drafter executes between `_sample` and `_bookkeeping_sync` (for MTP/EAGLE it runs a draft-model forward there).

`MODEL + SAMPLE` then collapses to dispatch cost while the E2E residual absorbs the whole device wait, so every mtp/ngram config in the perf CI reports a huge "host overhead" gap that is actually device time. Non-spec configs are unaffected and report normal gaps.

Verified with a per-region breakdown on a small config: enabling ngram spec decode moved the decode-step device wait from the `bookkeep` region into the `postprocess` region while `bookkeep` collapsed to dispatch cost, and the region times summed to E2E.

## Fix

Fold the runner's `postprocess` region into the graph sum: the spec-only gather is a hard sync on the target forward, so MODEL + SAMPLE keeps reading as the time the step was bound to the target graph and the sampler. The block is inline with no method to wrap, so the patch registers a `timed_region` wrapper over the module's `record_function_or_nullcontext` symbol; it adds `add_graph_time` only for that region name and passes every other region through untouched. A test pins the region literal to `execute_model`'s source, so renaming the region fails the suite instead of silently degrading the report.

The drafter is deliberately not folded: MODEL + SAMPLE stays the main-graph number, and the drafter's time -- under MTP/EAGLE a draft-model forward, plus any sampler wait its first read absorbs -- shows up in the E2E residual, which is therefore not pure host overhead in spec-decode configs. Verified on a spec-decode perf CI config: folding the drafter inflated the section's mean and tail with draft time, while excluding it leaves a tight distribution that tracks the target graph. The report format does not change.

Non-spec configs are unaffected: the postprocess block does no spec gather there and the draft region never runs.

