### PR TITLE
docs(agent): keep agent-written changes small enough to review

### DIFF
--- a/.claude/skills/finishing-a-change/SKILL.md
+++ b/.claude/skills/finishing-a-change/SKILL.md
@@ -50,7 +50,11 @@ Repository-specific checks:
 - No `test_*.py` under `tests/optimum/optimum_correctness/` — those are `fire` scripts.
 - No test that is skipped as a placeholder.
 
-## 4. Report what you did not do
+## 4. State the size
+
+Report the diff as source lines and test lines. If the test diff dwarfs the source, or the source dwarfs what your one-line summary describes, cut scope before opening the PR.
+
+## 5. Report what you did not do
 
 State it explicitly, every time:
 
@@ -61,7 +65,7 @@ State it explicitly, every time:
 
 An empty list is a claim. Only write it if it is true.
 
-## 5. Write the commit and PR
+## 6. Write the commit and PR
 
 - `type(scope): summary`, matching the existing history
 - Summarise what changed in a line or two, then explain what the diff cannot show. That explanation goes in the PR description; the squash merge discards the commit body

--- a/.claude/skills/finishing-a-change/SKILL.md
+++ b/.claude/skills/finishing-a-change/SKILL.md
@@ -35,6 +35,7 @@ Look for each of these:
 - **Abstractions** built for one call site
 - **Comments that narrate the code**, describe your changes, or address the reader
 - **Comments added to code you did not otherwise change**
+- **Comment blocks over 5 lines, a `reason=` over 400 characters, docstring prose over 15 lines** — the surplus belongs in the PR description, not the file, and not the commit message
 - **Swallowed failures** — `except Exception`, bare `except`, `except: pass`, an unrequested fallback or default
 - **`else` branches for cases that cannot happen** — should be `assert` or `raise`
 - **Dead leftovers** — renamed `_var`, unused re-exports, `# removed` comments
@@ -63,7 +64,7 @@ An empty list is a claim. Only write it if it is true.
 ## 5. Write the commit and PR
 
 - `type(scope): summary`, matching the existing history
-- Summarise what changed in a line or two, then explain what the diff cannot show
+- Summarise what changed in a line or two, then explain what the diff cannot show. That explanation goes in the PR description; the squash merge discards the commit body
 - Say which model path or paths the change affects
 - English
 - A perf change may give a relative change, never an absolute measurement

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,10 +97,13 @@ Upstream vLLM asks for eval results in the PR description. That convention does 
 - Look for an existing utility or mechanism before writing a significant amount of new code.
 - Do not create a helper that is called once. Inline it.
 - Do not build an abstraction for a single use. Three similar lines beat a premature abstraction.
+- Do not create a module to hold a single function. A `patches/` module is the exception: it exists for its registrations, and being imported from `patches/__init__.py` is the whole contract.
 - Do not add error handling for states that cannot occur.
 - Do not create files nobody asked for — docs, examples, scripts, changelogs.
 - Delete the scratch files you made while iterating.
+- The diff is the smallest one that fixes the stated problem. If it grew past that, say why in the PR, in one line.
 - Prefer fixing the underlying problem over a local workaround, even when that means a larger refactor. If the refactor is out of scope, say so and ask.
+- Do not restructure code you are not fixing. A refactor that is not the fix is its own PR.
 
 ## Failure handling
 
@@ -117,8 +120,11 @@ Code either succeeds or fails with a clear error.
 - Do not restate what the code says. If a comment narrates the next line, delete it and let the name carry the meaning.
 - Do not describe your changes or address the reader in a comment. The commit message and the PR body are for that.
 - Do not add or edit comments in code you did not otherwise change.
-- Comments are for invariants, non-obvious constraints, and why an unusual approach was taken. These may be long; explain them properly. The module comments in `vllm_rbln/__init__.py` and `vllm_rbln/envs.py` are the intended level.
-- Assume the reader knows vLLM and RBLN hardware.
+- Comments are for invariants, non-obvious constraints, and why an unusual approach was taken.
+- **One place per fact.** The file carries what a reader must know to change this code safely. The PR description carries how we found out and why the shape is what it is. Do not put the second in the first.
+- **A comment block stays at or under 5 lines, a `reason=` at or under 400 characters, and a docstring's prose at or under 15 lines; `Args:` and `Returns:` blocks do not count.** Nearly all of the repository is already inside these. When you need more, the surplus belongs in the PR description: leave only the lines a future reader cannot re-derive. The squash merge stamps `(#1234)` on the subject line, so `git blame` reaches the rest on its own. Splitting one long block into two shorter ones is not a fix.
+- Do not move the surplus into the commit message instead. The squash merge keeps the subject line and discards the body, so a commit message does not survive the merge.
+- Assume the reader knows vLLM and RBLN hardware. The module comments in `vllm_rbln/__init__.py` and `vllm_rbln/envs.py` are the intended level.
 
 ## Tests
 
@@ -146,6 +152,8 @@ Some of the rules above cost something to follow. When you believe a case is a r
 Follow the existing convention: `type(scope): summary`, for example `fix(mega-cache): key the bundle on the warm-up graph set`.
 
 Explain intent. Summarise what changed in a line or two, then spend the space on what the diff cannot show — the reason behind an unusual approach, a constraint that forced the shape, a tradeoff that was weighed. Do not walk through the diff file by file; that is the part a reader can already see.
+
+The two have different lifetimes. The squash merge keeps the subject line and discards the body, so a commit message is read during review and then gone, while the PR description is what `git log`'s `(#1234)` still points at. Write commit messages for the reviewer. Where both would carry the same explanation, it goes in the PR description and the commit message stays short.
 
 ## Skills
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,10 @@ Two documents own their subjects; read them rather than duplicating them here:
 - Environment setup, dependency and lockfile policy: `DEVELOPMENT.md`
 - PR process and issue labels: `CONTRIBUTING.md`
 
+## Accountability
+
+A pure agent-authored change is not acceptable. Upstream vLLM states the same rule in its own `AGENTS.md`. The submitting human reads every changed line, runs the tests, and can defend the change without the agent. If you cannot say why a line is there, delete it rather than ship it.
+
 ## Commands
 
 Run everything through `uv`. Never use the system `python3` or a bare `pip`.
@@ -98,12 +102,12 @@ Upstream vLLM asks for eval results in the PR description. That convention does 
 - Do not create a helper that is called once. Inline it.
 - Do not build an abstraction for a single use. Three similar lines beat a premature abstraction.
 - Do not create a module to hold a single function. A `patches/` module is the exception: it exists for its registrations, and being imported from `patches/__init__.py` is the whole contract.
+- Before adding a file, a class, or a layer of indirection, name the second caller. If there is none, put the code where the one caller already lives.
 - Do not add error handling for states that cannot occur.
 - Do not create files nobody asked for — docs, examples, scripts, changelogs.
 - Delete the scratch files you made while iterating.
-- The diff is the smallest one that fixes the stated problem. If it grew past that, say why in the PR, in one line.
 - Prefer fixing the underlying problem over a local workaround, even when that means a larger refactor. If the refactor is out of scope, say so and ask.
-- Do not restructure code you are not fixing. A refactor that is not the fix is its own PR.
+- Do not refactor, rename, or reformat code that is not part of the fix. A refactor is its own PR.
 
 ## Failure handling
 
@@ -122,7 +126,7 @@ Code either succeeds or fails with a clear error.
 - Do not add or edit comments in code you did not otherwise change.
 - Comments are for invariants, non-obvious constraints, and why an unusual approach was taken.
 - **One place per fact.** The file carries what a reader must know to change this code safely. The PR description carries how we found out and why the shape is what it is. Do not put the second in the first.
-- **A comment block stays at or under 5 lines, a `reason=` at or under 400 characters, and a docstring's prose at or under 15 lines; `Args:` and `Returns:` blocks do not count.** Nearly all of the repository is already inside these. When you need more, the surplus belongs in the PR description: leave only the lines a future reader cannot re-derive. The squash merge stamps `(#1234)` on the subject line, so `git blame` reaches the rest on its own. Splitting one long block into two shorter ones is not a fix.
+- **A comment block stays at or under 5 lines, a `reason=` at or under 400 characters, and a docstring's text at or under 15 lines; `Args:` and `Returns:` blocks do not count.** Nearly all of the repository is already inside these. When you need more, the surplus belongs in the PR description: leave only the lines a future reader cannot re-derive. The squash merge stamps `(#1234)` on the subject line, so `git blame` reaches the rest on its own. Splitting one long block into two shorter ones is not a fix.
 - Do not move the surplus into the commit message instead. The squash merge keeps the subject line and discards the body, so a commit message does not survive the merge.
 - Assume the reader knows vLLM and RBLN hardware. The module comments in `vllm_rbln/__init__.py` and `vllm_rbln/envs.py` are the intended level.
 


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

When a coding agent writes a whole change by itself, the result is often too large to review. Recent examples in this repository, measured on `dev`:

- A `reason=` string of 1816 characters. The median in this repository is 194.
- A new file where more than half of the lines are comments and docstrings. The usual amount here is one such line for every 4 lines of code.
- A helper function with its own docstring that is called from only one place.

Each of these looks reasonable by itself. But when they happen together, a human reviewer cannot check every line. Checking every line is what a review needs.

`AGENTS.md` did not prevent this. The Comments section said that comments "may be long", and it did not say where the extra text should go instead. The Scope section set limits for helper functions and for abstractions, but it said nothing about new modules, about unrelated cleanup, or about who is responsible for the result.

This PR has two commits:
1. Set limits on comment length, and state that long explanations belong in the PR description.
2. State who is responsible for a change, and limit what it may add on top of the fix. This adds an accountability rule, a check before a new file or layer is created, a rule that keeps unrelated refactoring out, and a size report in `finishing-a-change`.

#### Why these numbers

Each limit is what the repository already does. Measured on `dev`, not chosen.

| Rule | Already inside it | Worst case |
| --- | --- | --- |
| Comment block 5 lines or fewer | 92%, or 96% ignoring the 13-line licence header | about 94 blocks at 6 or more |
| Docstring text 15 lines or fewer | 97% | 73 lines |
| `reason=` 400 chars or fewer | 81%, median 194 | 1816 chars in 30 lines |
| Comments and docstrings per file | median 0.25 | 0.61 |

These limits do not require a new style, They only stop the recent outliers.

Our rule says not to move the extra text into the commit message instead. The commit body does not last here. None of the last 40 commits on `dev` has a body beyond trailers, because the squash merge keeps only the subject line.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [x] 📄 Documentation (`docs`)

---

### 🧪 How to Test

N/A

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
