### PR TITLE
fix(sampler): keep the rejection-sample op out of the mega-cache bundle

### DIFF
--- a/vllm_rbln/v1/sample/rbln_rejection_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_rejection_sampler.py
@@ -334,6 +334,9 @@ class RBLNRejectionSamplerImpl(RejectionSamplerImpl):
             mode="strict" if envs.VLLM_RBLN_COMPILE_STRICT_MODE else "",
             use_global_ctx=True if HAS_TORCH_RBLN and not USE_DEVICE_TENSOR else None,
             global_device_id=0 if HAS_TORCH_RBLN and not USE_DEVICE_TENSOR else None,
+            # Built only under VLLM_RBLN_SAMPLER, so a bundle saved with the
+            # sampler off misses this op and forces a partial compile.
+            use_cache=False,
         )
 
     def rejection_sample(


### PR DESCRIPTION
### 🚀 Summary of Changes

The rejection-sample op compiled in `RBLNRejectionSamplerImpl` now uses `use_cache=False`, so it no longer enters the mega-cache bundle.

That op is built only when `VLLM_RBLN_SAMPLER` is on and warm-up calls it, but `VLLM_RBLN_SAMPLER` lives in `RBLN_NON_COMPILE_ENV`, so a bundle saved with the sampler off keys to the same `config_signature` as a run with the sampler on. Restoring such a bundle then compiles this one op fresh beside the restored model programs. A restored program never reaches `add_module`, so the compile session does not know it holds weights or const-buffer indices — the fresh compile loses weight reuse and shares the const-buffer pool with programs the session cannot see.

The plain sampler already compiles with `use_cache=False`. Both ops are gated by the same flag and warmed up together, so they belong on the same side of the bundle: cached together or not at all. This puts the rejection sampler back with the sampler.

**Relationship to #1026.** This PR only brings the two ops back in sync, and changes no default: the plain sampler already compiles with `use_cache=False`, the rejection sampler did not, so one of the pair could enter the bundle alone. #1026 is the separate question of turning bundle caching on for the sampler by default. Landing this first means that switch flips one pair instead of one of two ops — and when it flips, the bundle key has to move with it: `VLLM_RBLN_SAMPLER` into `RBLN_COMPILE_ENV`, or the compile stage stops forcing the sampler off. Without that, a sampler-off bundle is still reused by a sampler-on run, for both ops.

---

### 📌 Related Issues / Tickets

* Resolves #
* Related to #1026
* Related to rebellions-sw/rebel_compiler#13244 — turns this partial compile into a hard error instead of a silent one, which is how it surfaced

---

### ✅ Type of Change

* [x] 🛠 Bug fix (`fix`)

---

### 🧪 How to Test

Reproduced in Compiler PR CI, `Inference - Minimax2.7-b1-dp4-ngram-k-1-l4-CR13` (a spec-decode config, the only one that builds the rejection-sample op):

1. Compile stage runs with `VLLM_RBLN_SAMPLER=0` (forced for the dummy device), so the bundle it saves holds the model programs only — no rejection-sample op.
2. Inference stage runs the same config with `VLLM_RBLN_SAMPLER=1`, loads that bundle (same `config_signature`), restores the model programs, then compiles the rejection-sample op fresh.
3. With rebellions-sw/rebel_compiler#13244 in place, step 2 fails at `warmup_model` → `_warmup_sampler_decode_batches` → `rejection_sample` with `RuntimeError: rbln mega-cache is stale: <hash> missed after N program(s) were restored`. Without it, the run continues on a partially compiled session.

Reduced locally to a script that plants one restored program in the bundle (a real `note_hit` through `load_compiled`), then drives `impl.rejection_sample(...)` once:

- Without this change: the op is looked up in the bundle and raises through the same stack as CI — `_rbln_backend` → `rebel/core/torch_compile.py` → `mega_cache.load_compiled` → `note_miss` → `RuntimeError: rbln mega-cache is stale: ... missed after 1 program(s) were restored`.
- With this change: no bundle lookup happens for the op at all, and the compile proceeds normally.

Test runs, all green:

```
pytest tests/native/test_envs.py tests/torch_compile/unit/v1/sample   ->  185 passed
```

---

### 💬 Notes

Draft — opened to settle the direction with #1026 before adding tests. No issue filed yet.

No test added yet: the change's only observable effect is the option set handed to `torch.compile`, and asserting that back is the kind of static-value test the repo's test guide rejects. If this direction is the one we take, the coverage worth adding is on the invariant — every graph that can enter the bundle is also built during the compile stage — which is a different test from this one line.

Not verified: whether the CI job goes green with only this change (it needs the compiler-side PR in the image), and whether anything else relies on the rejection-sample op being restorable from a bundle. The local repro ran with `RBLN_DUMMY_DEVICE=1` and no NPU, so it exercises the bundle lookup, not the compiled op's behavior.
