### PR TITLE
fix(moe): widen the tokens mask when the routing bias is wider

### DIFF
--- a/tests/native/model_executor/layers/fused_moe/test_moe_runner.py
+++ b/tests/native/model_executor/layers/fused_moe/test_moe_runner.py
@@ -23,12 +23,10 @@ from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner
 
 from vllm_rbln.model_executor.layers.fused_moe.runner.moe_runner import (
     RBLNMoERunner,
+    _routing_mask_dtype,
 )
 from vllm_rbln.model_executor.layers.fused_moe.runner.moe_runner import (
     _apply_grouped_topk_torch as grouped_topk,
-)
-from vllm_rbln.model_executor.layers.fused_moe.runner.moe_runner import (
-    _routing_mask_dtype,
 )
 
 

--- a/tests/native/model_executor/layers/fused_moe/test_moe_runner.py
+++ b/tests/native/model_executor/layers/fused_moe/test_moe_runner.py
@@ -17,14 +17,15 @@
 # expert without one), keep the top `topk_group` groups, then pick `top_k`
 # within them. Pure torch, hand-verifiable inputs.
 
+from types import SimpleNamespace
+
 import torch
 from vllm.model_executor.custom_op import maybe_get_oot_by_class
 from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner
 
-from vllm_rbln.model_executor.layers.fused_moe.runner.moe_runner import (
-    RBLNMoERunner,
-    _routing_mask_dtype,
-)
+import vllm_rbln.model_executor.layers.fused_moe.utils as fused_moe_utils
+from vllm_rbln.model_executor.layers.fused_moe.runner import moe_runner
+from vllm_rbln.model_executor.layers.fused_moe.runner.moe_runner import RBLNMoERunner
 from vllm_rbln.model_executor.layers.fused_moe.runner.moe_runner import (
     _apply_grouped_topk_torch as grouped_topk,
 )
@@ -228,37 +229,74 @@ class TestApplyGroupedTopkTorch:
         assert pre.sum().item() < 1.0
 
 
+def _routed_logits_dtype(monkeypatch, *, logits_dtype, bias_dtype):
+    """Dtype of the weights ``forward`` hands the quant method, mask included.
+
+    Building a real RBLNMoERunner needs a MoEConfig, a quant method and an
+    initialized DP group, so the instance is assembled by hand -- but ``forward``
+    itself is the real one, which is what the mask dtype has to come out of.
+    """
+    monkeypatch.setattr(moe_runner.envs, "VLLM_RBLN_USE_MOE_TOKENS_MASK", True)
+    monkeypatch.setattr(
+        fused_moe_utils,
+        "get_forward_context",
+        lambda: SimpleNamespace(
+            dp_metadata=SimpleNamespace(
+                num_tokens_across_dp_cpu=torch.tensor([3]),
+                max_pads_across_dp=None,  # DP=1
+            )
+        ),
+    )
+
+    routed: dict[str, torch.dtype] = {}
+
+    class _CaptureQuantMethod:
+        def apply(self, layer, x, router_logits):
+            routed["dtype"] = router_logits.dtype
+            return x
+
+    runner = object.__new__(RBLNMoERunner)
+    torch.nn.Module.__init__(runner)
+    runner.routed_experts = SimpleNamespace(quant_method=_CaptureQuantMethod())
+    runner.top_k = 2
+    runner.moe_parallel_config = SimpleNamespace(dp_size=1, dp_rank=0)
+    runner.router = SimpleNamespace(
+        scoring_func="sigmoid",
+        renormalize=False,
+        e_score_correction_bias=torch.zeros(4, dtype=bias_dtype),
+        num_expert_group=2,
+        topk_group=2,
+    )
+
+    logits = torch.randn(1, 3, 4, dtype=logits_dtype)
+    RBLNMoERunner.forward(
+        runner, torch.zeros(1, 3, 8, dtype=logits_dtype), lambda _: logits
+    )
+    return routed["dtype"]
+
+
 class TestRoutingMaskDtype:
     # The mask multiplies the routing weights AFTER the compiler has folded the
-    # routing chain into `contrib_top_k_routing`, whose output follows the wider
-    # of (scores, e_score_correction_bias). The mask has to follow the same rule
-    # or the fused multiply is a relay dtype mismatch.
-    def test_wider_bias_widens_the_mask(self):
-        weights = torch.zeros(4, 2, dtype=torch.bfloat16)
-        bias = torch.zeros(4, dtype=torch.float32)
-        assert _routing_mask_dtype(weights, bias) is torch.float32
+    # routing chain into one fused routing op, whose output follows the wider of
+    # (scores, e_score_correction_bias). The mask has to follow the same rule or
+    # the fused multiply is a dtype mismatch the compiler rejects.
+    def test_an_fp32_bias_widens_the_masked_weights(self, monkeypatch):
+        # A bf16 mask here is the reported failure: the multiply stays bf16 while
+        # the fused routing it feeds is fp32.
+        assert (
+            _routed_logits_dtype(
+                monkeypatch, logits_dtype=torch.bfloat16, bias_dtype=torch.float32
+            )
+            is torch.float32
+        )
 
-    def test_no_bias_keeps_the_weights_dtype(self):
-        weights = torch.zeros(4, 2, dtype=torch.bfloat16)
-        assert _routing_mask_dtype(weights, None) is torch.bfloat16
-
-    def test_bias_of_equal_width_keeps_the_weights_dtype(self):
-        weights = torch.zeros(4, 2, dtype=torch.bfloat16)
-        bias = torch.zeros(4, dtype=torch.bfloat16)
-        assert _routing_mask_dtype(weights, bias) is torch.bfloat16
-
-    def test_narrower_bias_does_not_narrow_the_mask(self):
-        weights = torch.zeros(4, 2, dtype=torch.float32)
-        bias = torch.zeros(4, dtype=torch.bfloat16)
-        assert _routing_mask_dtype(weights, bias) is torch.float32
-
-    def test_the_product_is_the_mask_dtype(self):
-        # What the relay type checker sees: the multiply comes out fp32, so a
-        # cast lands on the (fused, fp32) routing side and nothing mismatches.
-        weights = torch.ones(4, 2, dtype=torch.bfloat16)
-        bias = torch.zeros(4, dtype=torch.float32)
-        mask = torch.ones(1, 2, dtype=_routing_mask_dtype(weights, bias))
-        assert (weights * mask).dtype is torch.float32
+    def test_a_bias_of_equal_width_keeps_the_narrow_weights(self, monkeypatch):
+        assert (
+            _routed_logits_dtype(
+                monkeypatch, logits_dtype=torch.bfloat16, bias_dtype=torch.bfloat16
+            )
+            is torch.bfloat16
+        )
 
 
 class TestRegistration:

--- a/tests/native/model_executor/layers/fused_moe/test_moe_runner.py
+++ b/tests/native/model_executor/layers/fused_moe/test_moe_runner.py
@@ -229,7 +229,14 @@ class TestApplyGroupedTopkTorch:
         assert pre.sum().item() < 1.0
 
 
-def _routed_logits_dtype(monkeypatch, *, logits_dtype, bias_dtype):
+def _routed_logits_dtype(
+    monkeypatch,
+    *,
+    logits_dtype,
+    bias_dtype,
+    scoring_func="sigmoid",
+    num_expert_group=2,
+):
     """Dtype of the weights ``forward`` hands the quant method, mask included.
 
     Building a real RBLNMoERunner needs a MoEConfig, a quant method and an
@@ -261,11 +268,11 @@ def _routed_logits_dtype(monkeypatch, *, logits_dtype, bias_dtype):
     runner.top_k = 2
     runner.moe_parallel_config = SimpleNamespace(dp_size=1, dp_rank=0)
     runner.router = SimpleNamespace(
-        scoring_func="sigmoid",
+        scoring_func=scoring_func,
         renormalize=False,
         e_score_correction_bias=torch.zeros(4, dtype=bias_dtype),
-        num_expert_group=2,
-        topk_group=2,
+        num_expert_group=num_expert_group,
+        topk_group=num_expert_group,
     )
 
     logits = torch.randn(1, 3, 4, dtype=logits_dtype)
@@ -294,6 +301,20 @@ class TestRoutingMaskDtype:
         assert (
             _routed_logits_dtype(
                 monkeypatch, logits_dtype=torch.bfloat16, bias_dtype=torch.bfloat16
+            )
+            is torch.bfloat16
+        )
+
+    def test_a_bias_the_routing_never_adds_does_not_widen(self, monkeypatch):
+        # Non-grouped softmax scores without the bias, so the fused routing stays
+        # bf16 and widening the mask would promote the table for nothing.
+        assert (
+            _routed_logits_dtype(
+                monkeypatch,
+                logits_dtype=torch.bfloat16,
+                bias_dtype=torch.float32,
+                scoring_func="softmax",
+                num_expert_group=None,
             )
             is torch.bfloat16
         )

--- a/tests/native/model_executor/layers/fused_moe/test_moe_runner.py
+++ b/tests/native/model_executor/layers/fused_moe/test_moe_runner.py
@@ -27,6 +27,9 @@ from vllm_rbln.model_executor.layers.fused_moe.runner.moe_runner import (
 from vllm_rbln.model_executor.layers.fused_moe.runner.moe_runner import (
     _apply_grouped_topk_torch as grouped_topk,
 )
+from vllm_rbln.model_executor.layers.fused_moe.runner.moe_runner import (
+    _routing_mask_dtype,
+)
 
 
 class TestApplyGroupedTopkTorch:
@@ -225,6 +228,39 @@ class TestApplyGroupedTopkTorch:
         )
         assert post.sum().item() == torch.tensor(1.0).item()
         assert pre.sum().item() < 1.0
+
+
+class TestRoutingMaskDtype:
+    # The mask multiplies the routing weights AFTER the compiler has folded the
+    # routing chain into `contrib_top_k_routing`, whose output follows the wider
+    # of (scores, e_score_correction_bias). The mask has to follow the same rule
+    # or the fused multiply is a relay dtype mismatch.
+    def test_wider_bias_widens_the_mask(self):
+        weights = torch.zeros(4, 2, dtype=torch.bfloat16)
+        bias = torch.zeros(4, dtype=torch.float32)
+        assert _routing_mask_dtype(weights, bias) is torch.float32
+
+    def test_no_bias_keeps_the_weights_dtype(self):
+        weights = torch.zeros(4, 2, dtype=torch.bfloat16)
+        assert _routing_mask_dtype(weights, None) is torch.bfloat16
+
+    def test_bias_of_equal_width_keeps_the_weights_dtype(self):
+        weights = torch.zeros(4, 2, dtype=torch.bfloat16)
+        bias = torch.zeros(4, dtype=torch.bfloat16)
+        assert _routing_mask_dtype(weights, bias) is torch.bfloat16
+
+    def test_narrower_bias_does_not_narrow_the_mask(self):
+        weights = torch.zeros(4, 2, dtype=torch.float32)
+        bias = torch.zeros(4, dtype=torch.bfloat16)
+        assert _routing_mask_dtype(weights, bias) is torch.float32
+
+    def test_the_product_is_the_mask_dtype(self):
+        # What the relay type checker sees: the multiply comes out fp32, so a
+        # cast lands on the (fused, fp32) routing side and nothing mismatches.
+        weights = torch.ones(4, 2, dtype=torch.bfloat16)
+        bias = torch.zeros(4, dtype=torch.float32)
+        mask = torch.ones(1, 2, dtype=_routing_mask_dtype(weights, bias))
+        assert (weights * mask).dtype is torch.float32
 
 
 class TestRegistration:

--- a/vllm_rbln/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm_rbln/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -28,7 +28,9 @@ from vllm_rbln.model_executor.layers.fused_moe.utils import get_tokens_mask
 logger = init_logger(__name__)
 
 
-def _routing_mask_dtype(routing_weights, e_score_correction_bias):
+def _routing_mask_dtype(
+    routing_weights, e_score_correction_bias, *, scoring_func, use_grouped_topk
+):
     # The compiler folds the routing chain built below into a single fused
     # routing op, and that op's output follows the wider of (scores,
     # e_score_correction_bias) -- bf16 scores with an fp32 bias come back fp32.
@@ -36,8 +38,14 @@ def _routing_mask_dtype(routing_weights, e_score_correction_bias):
     # narrower mask makes the fused multiply a dtype mismatch the compiler
     # rejects, while a wider one is always safe because torch promotes the
     # product.
+    #
+    # Only the branches that add the bias to the scores put it in that chain.
+    # The non-grouped softmax and plain-topk branches score without it, so the
+    # fused op keeps the weights' own dtype there and a widened mask would just
+    # promote the whole [E, t] table for nothing.
     dtype = routing_weights.dtype
-    if e_score_correction_bias is None:
+    bias_is_routed = use_grouped_topk or scoring_func == "sigmoid"
+    if e_score_correction_bias is None or not bias_is_routed:
         return dtype
     if e_score_correction_bias.dtype.itemsize > dtype.itemsize:
         return e_score_correction_bias.dtype
@@ -281,7 +289,10 @@ class RBLNMoERunner(MoERunner):
                     max_pad,
                     device=masked_routing_weights.device,
                     dtype=_routing_mask_dtype(
-                        masked_routing_weights, e_score_correction_bias
+                        masked_routing_weights,
+                        e_score_correction_bias,
+                        scoring_func=scoring_func,
+                        use_grouped_topk=use_grouped_topk,
                     ),
                 ).transpose(1, 0)  # [1, R*max_pad]
                 masked_routing_weights = masked_routing_weights * tokens_mask
@@ -508,7 +519,10 @@ class RBLNMoERunner(MoERunner):
                 num_tokens,
                 device=masked_routing_weights.device,
                 dtype=_routing_mask_dtype(
-                    masked_routing_weights, e_score_correction_bias
+                    masked_routing_weights,
+                    e_score_correction_bias,
+                    scoring_func=scoring_func,
+                    use_grouped_topk=use_grouped_topk,
                 ),
             ).transpose(1, 0)  # [1, t]
 

--- a/vllm_rbln/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm_rbln/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -29,25 +29,13 @@ logger = init_logger(__name__)
 
 
 def _routing_mask_dtype(routing_weights, e_score_correction_bias):
-    """The dtype the routing weights carry once the COMPILER fuses the routing.
-
-    `EarlyCanonicalizeOpsRebel` folds the topk/gather/normalize/scatter chain
-    built below into one `contrib_top_k_routing`, and that op's type relation
-    (`ContribTopKRoutingRel`, rebel_compiler `src/relay/op/rbln/transform.cc`)
-    widens its output to `e_score_correction_bias`'s dtype whenever the bias is
-    the wider of the two -- bf16 scores with an fp32 bias come back fp32, which
-    the `scatter_elements` it replaced was not.
-
-    So the mask multiplied into those weights has to be that same wider dtype.
-    Narrower is the bug this exists to avoid: the fused multiply then has an fp32
-    left operand and a bf16 right one, and relay's type checker refuses it
-    ("data types float32 and bfloat16 do not match in BroadcastRel"). Wider is
-    always safe -- torch promotes the product and the relay frontend inserts the
-    cast -- and it is also what the mask was before it took a dtype at all.
-
-    Everything else keeps the narrow mask #1027 asked for: with no bias, or a
-    bias no wider than the weights, this is the weights' own dtype.
-    """
+    # The compiler folds the routing chain built below into a single fused
+    # routing op, and that op's output follows the wider of (scores,
+    # e_score_correction_bias) -- bf16 scores with an fp32 bias come back fp32.
+    # The mask multiplied into those weights has to follow the same rule: a
+    # narrower mask makes the fused multiply a dtype mismatch the compiler
+    # rejects, while a wider one is always safe because torch promotes the
+    # product.
     dtype = routing_weights.dtype
     if e_score_correction_bias is None:
         return dtype

--- a/vllm_rbln/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm_rbln/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -28,6 +28,34 @@ from vllm_rbln.model_executor.layers.fused_moe.utils import get_tokens_mask
 logger = init_logger(__name__)
 
 
+def _routing_mask_dtype(routing_weights, e_score_correction_bias):
+    """The dtype the routing weights carry once the COMPILER fuses the routing.
+
+    `EarlyCanonicalizeOpsRebel` folds the topk/gather/normalize/scatter chain
+    built below into one `contrib_top_k_routing`, and that op's type relation
+    (`ContribTopKRoutingRel`, rebel_compiler `src/relay/op/rbln/transform.cc`)
+    widens its output to `e_score_correction_bias`'s dtype whenever the bias is
+    the wider of the two -- bf16 scores with an fp32 bias come back fp32, which
+    the `scatter_elements` it replaced was not.
+
+    So the mask multiplied into those weights has to be that same wider dtype.
+    Narrower is the bug this exists to avoid: the fused multiply then has an fp32
+    left operand and a bf16 right one, and relay's type checker refuses it
+    ("data types float32 and bfloat16 do not match in BroadcastRel"). Wider is
+    always safe -- torch promotes the product and the relay frontend inserts the
+    cast -- and it is also what the mask was before it took a dtype at all.
+
+    Everything else keeps the narrow mask #1027 asked for: with no bias, or a
+    bias no wider than the weights, this is the weights' own dtype.
+    """
+    dtype = routing_weights.dtype
+    if e_score_correction_bias is None:
+        return dtype
+    if e_score_correction_bias.dtype.itemsize > dtype.itemsize:
+        return e_score_correction_bias.dtype
+    return dtype
+
+
 class RBLNMoERunner(MoERunner):
     """RBLN out-of-tree MoERunner.
     (See [#41184](https://github.com/vllm-project/vllm/pull/41184).)
@@ -264,7 +292,9 @@ class RBLNMoERunner(MoERunner):
                 tokens_mask = get_tokens_mask(
                     max_pad,
                     device=masked_routing_weights.device,
-                    dtype=masked_routing_weights.dtype,
+                    dtype=_routing_mask_dtype(
+                        masked_routing_weights, e_score_correction_bias
+                    ),
                 ).transpose(1, 0)  # [1, R*max_pad]
                 masked_routing_weights = masked_routing_weights * tokens_mask
 
@@ -489,7 +519,9 @@ class RBLNMoERunner(MoERunner):
             tokens_mask = get_tokens_mask(
                 num_tokens,
                 device=masked_routing_weights.device,
-                dtype=masked_routing_weights.dtype,
+                dtype=_routing_mask_dtype(
+                    masked_routing_weights, e_score_correction_bias
+                ),
             ).transpose(1, 0)  # [1, t]
 
             # [t, E] * [t, 1] (broadcast)


### PR DESCRIPTION
### 🚀 Summary of Changes

#1027 built the MoE tokens mask in the routing weights' dtype. That is too narrow when the router has an fp32 `e_score_correction_bias` over bf16 scores (A.X-K2): the compiler folds the topk/gather/normalize/scatter routing chain into one fused routing op, and that op's output follows the wider of (scores, bias). The mask multiply then has an fp32 left operand and a bf16 right one, and the type checker refuses it:

```
data types float32 and bfloat16 do not match in BroadcastRel
```

`_routing_mask_dtype` mirrors that widening rule when choosing the mask dtype. A wider mask is always safe — torch promotes the product and the cast is inserted for us — and models with no bias, or a bias no wider than the weights, keep the narrow mask #1027 asked for.

---

### ✅ Type of Change

* [x] 🛠 Bug fix (`fix`)

---

### 🧪 How to Test

1. `uv run --no-sync pytest tests/native/model_executor/layers/fused_moe/` → 30 passed. `TestRoutingMaskDtype` drives the real `RBLNMoERunner.forward` on the DP=1 path and asserts the dtype of the weights that reach the quant method; it is red with the helper reverted to #1027's rule.
2. Compile `skt/A.X-K2-NVFP4`: the `BroadcastRel` failure is gone and the build reaches codegen.

---

### 💬 Notes

The dtype rule is duplicated from the compiler's type relation for the fused routing op; the comment states the invariant so the coupling is findable. Fixing it on the compiler side instead — having the routing rewrite cast back to the dtype of the `scatter_elements` it replaces — would let this be reverted.

Affects the vLLM-native path only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)