### PR TITLE
fix: honor skip_reading_prefix_cache in the connector branch

### DIFF
--- a/tests/torch_compile/unit/v1/core/test_pd_disaggregation.py
+++ b/tests/torch_compile/unit/v1/core/test_pd_disaggregation.py
@@ -349,6 +349,42 @@ class TestPDDisaggregationScheduler:
         for d in decodes:
             assert d.request_id in ns
 
+    def test_prompt_logprobs_request_does_not_consult_the_connector(self):
+        """A restored span is never recomputed, so a request that needs every
+        prompt position must skip the connector the way it already skips the
+        local prefix cache and the sub-block match."""
+        matched = _BLOCK_SIZE
+        num_tokens = 3 * _BLOCK_SIZE
+
+        def make_scheduler():
+            return create_scheduler(
+                block_size=_BLOCK_SIZE,
+                num_blocks=_NUM_BLOCKS,
+                max_num_seqs=_MAX_NUM_SEQS,
+                use_kv_connector=MockKVConfig(matched_tokens=matched, is_async=False),
+            )
+
+        # Control: the same offer reduces a plain request's prefill, proving
+        # the connector wiring is live and the assertion below is not vacuous.
+        scheduler = make_scheduler()
+        control = _create_pd_request(num_tokens, "control")
+        scheduler.add_request(control)
+        out = scheduler.schedule()
+        assert out.num_scheduled_tokens["control"] == num_tokens - matched
+
+        scheduler = make_scheduler()
+        wants = create_requests(
+            num_requests=1,
+            num_tokens=num_tokens,
+            block_size=_BLOCK_SIZE,
+            req_ids=["wants-logprobs"],
+            prompt_logprobs=1,
+        )[0]
+        wants.kv_transfer_params = {"do_remote_prefill": True}
+        scheduler.add_request(wants)
+        out = scheduler.schedule()
+        assert out.num_scheduled_tokens["wants-logprobs"] == num_tokens
+
 
 # ===========================================================================
 # NIXL connector tests

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -475,8 +475,14 @@ class RBLNScheduler(Scheduler):
                         self.kv_cache_manager.get_computed_blocks(request)
                     )
 
-                    # Get externally-cached tokens if using a KVConnector.
-                    if self.connector is not None:
+                    # Get externally-cached tokens if using a KVConnector —
+                    # unless the request must see every prompt position (prompt
+                    # logprobs): a restored span is never recomputed. Local APC
+                    # and the sub-block match already honor this flag.
+                    if (
+                        self.connector is not None
+                        and not request.skip_reading_prefix_cache
+                    ):
                         ext_tokens, load_kv_async = (
                             self.connector.get_num_new_matched_tokens(
                                 request, num_new_local_computed_tokens
@@ -498,6 +504,16 @@ class RBLNScheduler(Scheduler):
                             request.num_tokens - num_new_local_computed_tokens
                         )
                         connector_prefix_cache_hits = num_external_computed_tokens
+                    elif self.connector is not None:
+                        # Loud on purpose: on a disaggregated deployment the
+                        # prefill instance's work for this request is discarded
+                        # and the prompt is recomputed here.
+                        logger.warning_once(
+                            "prompt-logprobs requests bypass the KV connector "
+                            "(a restored span can never produce prompt "
+                            "logprobs); each such request recomputes its full "
+                            "prompt locally."
+                        )
 
                     # NOTE(RBLN): Arbitrate between sub-block match and KV connector.
                     sub_block_match, num_sub_block_tokens = self._try_sub_block_match(


### PR DESCRIPTION
## What

A request that asks for prompt logprobs must have every prompt position computed —
the engine already encodes this: `SamplingParams` sets `skip_reading_prefix_cache`
for such requests, the local prefix cache honors it (`rbln_kv_cache_manager`), and
so does the sub-block match. The KV-connector branch of the scheduler did not, and
a connector-restored span is never recomputed.

Measured effect (KV connector enabled, second identical ~23k-token request with
`echo=true, logprobs=1`): the connector restores the cached span, the engine
computes only the residual tokens, and the restored span's rows of the
preallocated prompt-logprobs buffer reach the response uninitialized — the API
layer then 500s with a `KeyError` while resolving a prompt token in a garbage row.
The first (cold) request returns correct values, bit-identical to a run with the
connector disabled.

## Fix

Gate the connector consultation on the same flag the other two reuse paths already
honor. Such a request computes its full prompt — correct, at the price of forgoing
the cache for that one request, exactly the trade the local prefix cache already
makes. Upstream vLLM's scheduler has the same unguarded branch; this mirrors what
its own local path does.

The bypass is loud: the scheduler logs a `warning_once` when it skips the
connector for such a request — on a disaggregated deployment the prefill
instance's work for that request is discarded and the prompt is recomputed
locally, which an operator should know about.

## What this does and does not buy

Verified on hardware three times, on an aggregated deployment with the LMCache
CPU-offload connector: both attempts of a repeated ~23k-token
`echo=true, logprobs=1` request now return 23,231 token logprobs with a total
that is bit-identical to the connector-disabled arm (-278248.138425827), where
before the fix the second (warm) attempt 500'd.

Two consequences worth stating plainly, because they bound what a
connector-enabled deployment can measure with these requests:

- **Accuracy with a connector is identical to without one, by construction.**
  The request bypasses the cache, so there is nothing left for the connector to
  change. Three runs agree to the last bit. A prompt-logprobs workload
  therefore cannot be used to measure a KV-cache axis.
- **These requests have no decode phase.** `lm-evaluation-harness` sends
  `max_tokens=1`, and that one token is sampled from the final prefill step, so
  the request finishes there — in a full task run not a single decode batch was
  scheduled. On a disaggregated deployment there is consequently nothing to
  disaggregate: the prompt logprobs are computed where the prompt hidden states
  live (the prefill instance) while the client is answered by the decode
  instance, which is why that instance must recompute the prompt locally.

Note also that a disaggregated deployment always has a connector, whatever the
cache configuration, because cross-instance KV transfer is the premise of the
topology. So this guard is on the path for every prompt-logprobs request there,
not only when an offload tier is enabled. That path is untested: the hardware
verification above covers the LMCache connector on an aggregated deployment
only. A NIXL transfer whose pull the decode side never registers may leave the
prefill side's blocks held until its own timeout — worth a probe before anyone
runs such a workload on a disaggregated topology.

## Tests

The new scheduler test pins both sides: the same connector offer still reduces a
plain request's prefill (proving the wiring is live), and a prompt-logprobs
request schedules every prompt token.

Related: #1030 (the prompt-logprobs path itself; this gap was found while
verifying it on hardware).

