### PR TITLE
fix(test): compile-context signature and DP e2e near-tie flips

### DIFF
--- a/tests/native/compilation/test_compiler.py
+++ b/tests/native/compilation/test_compiler.py
@@ -265,4 +265,4 @@ class TestCompilerConformance:
 
         params = inspect.signature(CompileContext).parameters
         assert "use_weight_sharing" in params
-        assert "use_global_ctx" in params
+        assert "use_global_ctx" not in params  # deprecated kwargs

--- a/tests/native/distributed/test_dp_e2e.py
+++ b/tests/native/distributed/test_dp_e2e.py
@@ -23,10 +23,10 @@ import pytest
 from tests.native.model_specs import CompileModelSpec, apply_spec_envs, spec_params
 from tests.native.runners import DPRequest
 from tests.native.utils import (
-    TokensText,
+    ALMOST_EQUAL_MAX_LOGPROB_GAP,
+    ALMOST_EQUAL_MAX_RANK,
     TokensTextLogprobs,
     check_logprobs_close,
-    check_outputs_equal,
     devices_needed,
     rbln_device_count,
 )
@@ -69,9 +69,6 @@ class DPLane:
     def dp_size(self) -> int:
         return self.spec.engine_kwargs["data_parallel_size"]
 
-    def generate_greedy(self, requests: list[DPRequest]) -> list[TokensText]:
-        return self.runner.generate_greedy(requests)
-
     def generate_greedy_logprobs(
         self, requests: list[DPRequest]
     ) -> list[TokensTextLogprobs]:
@@ -104,8 +101,7 @@ def dp_lane(request, async_vllm_runner):
 @pytest.fixture(scope="module")
 def symmetric_outputs(dp_lane):
     """Every rank busy with the same prompt -- the reference for the asymmetric
-    runs, and the only run here with no idle rank. Carries logprobs because the
-    rank-to-rank comparison needs them; the asymmetric runs compare ids only."""
+    runs, and the only run here with no idle rank."""
     return dp_lane.generate_greedy_logprobs(
         [DPRequest(PROMPT, MAX_TOKENS, dp_rank=rank) for rank in range(dp_lane.dp_size)]
     )
@@ -128,42 +124,50 @@ def test_every_rank_produces_the_same_output(symmetric_outputs) -> None:
 
 def test_output_survives_idle_peers(dp_lane, symmetric_outputs) -> None:
     # Every other rank dummy-runs for the whole of rank 0's decode.
-    outputs = dp_lane.generate_greedy([DPRequest(PROMPT, MAX_TOKENS, dp_rank=0)])
+    outputs = dp_lane.generate_greedy_logprobs(
+        [DPRequest(PROMPT, MAX_TOKENS, dp_rank=0)]
+    )
 
-    ref_ids, ref_text, _ = symmetric_outputs[0]
-    check_outputs_equal(
-        outputs_0_lst=[(ref_ids, ref_text)],
+    check_logprobs_close(
+        outputs_0_lst=[symmetric_outputs[0]],
         outputs_1_lst=outputs,
         name_0="rank0 with every rank busy",
         name_1=f"rank0 with {dp_lane.dp_size - 1} idle peers",
+        max_logprob_gap=ALMOST_EQUAL_MAX_LOGPROB_GAP,
+        max_rank=ALMOST_EQUAL_MAX_RANK,
     )
 
 
 def test_output_survives_a_peer_finishing_early(dp_lane, symmetric_outputs) -> None:
     # rank0 drops out mid-flight, so the group's shape changes under the survivor.
     last = dp_lane.dp_size - 1
-    outputs = dp_lane.generate_greedy(
+    short, long = dp_lane.generate_greedy_logprobs(
         [
             DPRequest(PROMPT, SHORT_MAX_TOKENS, dp_rank=0),
             DPRequest(PROMPT, MAX_TOKENS, dp_rank=last),
         ]
     )
-    short, long = outputs
 
-    ref_ids, ref_text, _ = symmetric_outputs[last]
-    check_outputs_equal(
-        outputs_0_lst=[(ref_ids, ref_text)],
+    check_logprobs_close(
+        outputs_0_lst=[symmetric_outputs[last]],
         outputs_1_lst=[long],
         name_0=f"rank{last} with every rank busy",
         name_1=f"rank{last} outliving rank0",
+        max_logprob_gap=ALMOST_EQUAL_MAX_LOGPROB_GAP,
+        max_rank=ALMOST_EQUAL_MAX_RANK,
     )
     # Bounded, not fixed: an earlier EOS still leaves the rank idle early.
-    short_ids = short[0]
-    assert 0 < len(short_ids) <= SHORT_MAX_TOKENS, (
-        f"rank0 asked for at most {SHORT_MAX_TOKENS} tokens, got {len(short_ids)}"
+    assert 0 < len(short[0]) <= SHORT_MAX_TOKENS, (
+        f"rank0 asked for at most {SHORT_MAX_TOKENS} tokens, got {len(short[0])}"
     )
-    assert short_ids == symmetric_outputs[0][0][: len(short_ids)], (
-        "rank0's tokens changed when it shared the group with a longer request"
+    # check_logprobs_close stops at the shorter run, so this compares the prefix.
+    check_logprobs_close(
+        outputs_0_lst=[symmetric_outputs[0]],
+        outputs_1_lst=[short],
+        name_0="rank0 with every rank busy",
+        name_1="rank0 sharing the group with a longer request",
+        max_logprob_gap=ALMOST_EQUAL_MAX_LOGPROB_GAP,
+        max_rank=ALMOST_EQUAL_MAX_RANK,
     )
 
 
@@ -173,7 +177,7 @@ def test_output_survives_a_peer_at_a_bigger_bucket(dp_lane) -> None:
     # #894 that mismatch was a shape error, so completing at all is the signal;
     # the batch-2 graph differs from symmetric_outputs' batch-1 one, so those are
     # not compared.
-    first, second = dp_lane.generate_greedy(
+    first, second = dp_lane.generate_greedy_logprobs(
         [
             DPRequest(PROMPT, MAX_TOKENS, dp_rank=0),
             DPRequest(PROMPT, MAX_TOKENS, dp_rank=0),
@@ -181,9 +185,11 @@ def test_output_survives_a_peer_at_a_bigger_bucket(dp_lane) -> None:
     )
 
     assert len(first[0]) == len(second[0]) == MAX_TOKENS
-    check_outputs_equal(
+    check_logprobs_close(
         outputs_0_lst=[first],
         outputs_1_lst=[second],
         name_0="rank0 request 0",
         name_1="rank0 request 1",
+        max_logprob_gap=ALMOST_EQUAL_MAX_LOGPROB_GAP,
+        max_rank=ALMOST_EQUAL_MAX_RANK,
     )


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

Follow-up to #1037. This PR is based on that branch, so please merge #1037 first.

Two test fixes:

- `test_rebel_compile_context_signature` — on the new compiler, `use_global_ctx` is no longer in `CompileContext`'s signature, so the test now checks that it is gone.
- `test_dp_e2e` — three tests compared token ids exactly. The DP e2e lane builds only 4 layers, and that model rates its top two tokens almost the same, so the greedy pick flips between runs. They now use `check_logprobs_close`, like the rank-to-rank test in the same file already does.

The flips are not new. I ran the same tests on the old compiler (`0.11.3.dev4`) and got the same failure, at the same token, with the same two candidates. With the whole model there are no flips at all. So this is not a fix for the version bump (it is a test that was too strict from the start).

The 0.125 nats bound has no room to spare: one run landed exactly on it. If this gets flaky again, the next step is `max_rank` with the default 0.5 gap, not a bigger number.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [x] 🛠 Bug fix (`fix`)

---

### 🧪 How to Test

1. The compiler signature test:
```bash
uv run --no-sync pytest tests/native/compilation/test_compiler.py::TestCompilerConformance -q
```

Expected: 2 passed.

2. The DP e2e lane:
```bash
uv run --no-sync pytest \
  tests/native/distributed/test_dp_e2e.py --model-compile -rw
```

Expected: 4 passed. Some runs print a `NearTieWarning` and that is fine.

3. Optional, the whole model instead of 4 layers:
```
uv run --no-sync pytest \
  tests/native/distributed/test_dp_e2e.py --model-compile --num-hidden-layers 0 -rw
```

Expected: 4 passed with no `NearTieWarning` at all.

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
