### PR TITLE
fix(metrics): fold the PP hand-off into the pass on non-last ranks

### DIFF
--- a/tests/native/patches/test_metrics.py
+++ b/tests/native/patches/test_metrics.py
@@ -416,6 +416,28 @@ class TestPassBoundary:
         assert ctx._graph[pm._Phase.DECODE].latencies == pytest.approx([5 * MS])
         assert ctx._e2e[pm._Phase.DECODE].latencies == pytest.approx([5 * MS])
 
+    def test_raising_hand_off_records_nothing(self, monkeypatch, clock):
+        def fake_forward(self, *a, **k):
+            ctx = pm._ctx(self)
+            ctx.mark_phase(pm._Phase.DECODE)
+            ctx.add_graph_time(1 * MS)
+            return IntermediateTensors({})
+
+        def boom(self, *a, **k):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(pm, "_execute_model", fake_forward)
+        monkeypatch.setattr(pm, "_send_handoff", boom)
+        runner = _Runner()
+
+        pm.execute_model(runner)
+        with pytest.raises(RuntimeError, match="boom"):
+            pm.send_handoff(types.SimpleNamespace(model_runner=runner), {})
+
+        ctx = pm._ctx(runner)
+        assert ctx.in_pass  # left open, like any raising pass
+        assert not ctx._e2e and not ctx._graph
+
     def test_whole_pass_records_one_sample_per_section(self, monkeypatch):
         monkeypatch.setattr(pm, "_execute_model", lambda self, *a, **k: None)
         monkeypatch.setattr(pm, "_sample_tokens", lambda self, *a, **k: "out")

--- a/tests/native/patches/test_metrics.py
+++ b/tests/native/patches/test_metrics.py
@@ -18,6 +18,7 @@ import types
 from typing import Any
 
 import pytest
+from vllm.sequence import IntermediateTensors
 
 import vllm_rbln.envs as envs
 import vllm_rbln.patches.metrics as pm
@@ -380,6 +381,41 @@ class TestPassBoundary:
         assert pm.execute_model(runner) == "output"
         assert not pm._ctx(runner).in_pass
 
+    def test_hand_off_output_leaves_the_pass_open(self, monkeypatch):
+        # The hand-off follows, so the pass stays open for its wall.
+        monkeypatch.setattr(
+            pm, "_execute_model", lambda self, *a, **k: IntermediateTensors({})
+        )
+        runner = _Runner()
+
+        out = pm.execute_model(runner)
+
+        assert isinstance(out, IntermediateTensors)
+        assert pm._ctx(runner).in_pass
+
+    def test_hand_off_folds_the_send_into_the_pass(self, monkeypatch, clock):
+        def fake_forward(self, *a, **k):
+            ctx = pm._ctx(self)
+            ctx.mark_phase(pm._Phase.DECODE)
+            clock.advance(1 * MS)  # dispatch cost
+            ctx.add_graph_time(1 * MS)
+            return IntermediateTensors({})
+
+        monkeypatch.setattr(pm, "_execute_model", fake_forward)
+        monkeypatch.setattr(
+            pm, "_send_handoff", lambda self, *a, **k: clock.advance(4 * MS)
+        )
+        runner = _Runner()
+        worker = types.SimpleNamespace(model_runner=runner)
+
+        pm.execute_model(runner)
+        pm.send_handoff(worker, {})
+
+        ctx = pm._ctx(runner)
+        assert not ctx.in_pass
+        assert ctx._graph[pm._Phase.DECODE].latencies == pytest.approx([5 * MS])
+        assert ctx._e2e[pm._Phase.DECODE].latencies == pytest.approx([5 * MS])
+
     def test_whole_pass_records_one_sample_per_section(self, monkeypatch):
         monkeypatch.setattr(pm, "_execute_model", lambda self, *a, **k: None)
         monkeypatch.setattr(pm, "_sample_tokens", lambda self, *a, **k: "out")
@@ -598,7 +634,7 @@ class TestDescriptors:
             for d in registry.get_registered_patch_descriptors()
             if d.owner_module == "vllm_rbln.patches.metrics"
         ]
-        assert len(ours) == 8
+        assert len(ours) == 9
         for descriptor in ours:
             owner, attr = registry._resolve_patch_target_owner(descriptor.target)
             assert hasattr(owner, attr), descriptor.target

--- a/vllm_rbln/patches/metrics.py
+++ b/vllm_rbln/patches/metrics.py
@@ -49,6 +49,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 
 import numpy as np
+from vllm.sequence import IntermediateTensors
 from vllm.v1.utils import record_function_or_nullcontext
 
 from vllm_rbln import envs
@@ -282,9 +283,9 @@ def execute_model(self, *args, **kwargs):
     _ACTIVE_CTX = ctx
     ctx.start_pass()
     output = _execute_model(self, *args, **kwargs)
-    # The engine calls sample_tokens() only if execute_model() returned None, so a
-    # non-None return means nobody else will end this pass.
-    if output is not None:
+    # A None pass is closed by sample_tokens, an IntermediateTensors pass by
+    # send_handoff below; anything else nobody would end.
+    if output is not None and not isinstance(output, IntermediateTensors):
         ctx.end_pass()
     return output
 
@@ -357,6 +358,21 @@ def determine_batch_execution_and_padding(self, *args, **kwargs):
     # A no-op on the dummy run, which reaches this with no pass open.
     _ctx(self).mark_phase(phase)
     return result
+
+
+_send_handoff = RBLNWorker._send_handoff
+
+
+@functools.wraps(_send_handoff)
+def send_handoff(self, *args, **kwargs):
+    # The send waits on this stage's compute, so its wall carries the stage's time.
+    ctx = _ctx(self.model_runner)
+    start = time.perf_counter()
+    try:
+        return _send_handoff(self, *args, **kwargs)
+    finally:
+        ctx.add_graph_time(time.perf_counter() - start)
+        ctx.end_pass()
 
 
 @functools.wraps(_shutdown)
@@ -433,6 +449,12 @@ def _register_patches() -> None:
             determine_batch_execution_and_padding,
             "Reads the pass phase where it is decided. The padded token dimension is a "
             "local of execute_model and is not observable from any wrapped callable.",
+        ),
+        (
+            f"{_WORKER}._send_handoff",
+            send_handoff,
+            "Times the hand-off and closes its pass; left outside the pass, "
+            "the send hides a non-last rank's stage time.",
         ),
         (
             f"{_WORKER}.shutdown",

--- a/vllm_rbln/patches/metrics.py
+++ b/vllm_rbln/patches/metrics.py
@@ -366,13 +366,13 @@ _send_handoff = RBLNWorker._send_handoff
 @functools.wraps(_send_handoff)
 def send_handoff(self, *args, **kwargs):
     # The send waits on this stage's compute, so its wall carries the stage's time.
+    # No try/finally: a raising hand-off leaves the pass open, like any raising pass.
     ctx = _ctx(self.model_runner)
     start = time.perf_counter()
-    try:
-        return _send_handoff(self, *args, **kwargs)
-    finally:
-        ctx.add_graph_time(time.perf_counter() - start)
-        ctx.end_pass()
+    output = _send_handoff(self, *args, **kwargs)
+    ctx.add_graph_time(time.perf_counter() - start)
+    ctx.end_pass()
+    return output
 
 
 @functools.wraps(_shutdown)

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -1172,6 +1172,11 @@ class RBLNWorker(WorkerBase):
     ) -> ModelRunnerOutput | AsyncModelRunnerOutput:
         return self.model_runner.sample_tokens(grammar_output)
 
+    def _send_handoff(self, tensors: dict) -> None:
+        """Hand this stage's output on; a seam the metrics patch wraps."""
+        # NOTE(RBLN): DO NOT all_gather_group for RBLN pp
+        get_pp_group().send_tensor_dict(tensors)
+
     @torch.inference_mode()
     def execute_model(
         self,
@@ -1197,8 +1202,7 @@ class RBLNWorker(WorkerBase):
             and not get_pp_group().is_last_rank
         )
 
-        # NOTE(RBLN): DO NOT all_gather_group for RBLN pp
-        get_pp_group().send_tensor_dict(output.tensors)
+        self._send_handoff(output.tensors)
 
         # Non-last PP rank: the model runner already surfaces this rank's
         # KV-connector output through the two-phase sample_tokens() path


### PR DESCRIPTION
### 🚀 Summary of Changes

On a non-last PP rank the metrics pass ends right after the asynchronous
dispatch, so `MODEL + SAMPLE` (and `E2E`) reported the dispatch cost only —
the stage's actual time stayed hidden from the report. The last rank never
had this problem because its pass contains the sampled-token read.

This change surfaces that hidden part. The hand-off is where a non-last
rank's stage time becomes observable: the send completes only after the
stage's compute has produced the tensors. So the worker's send becomes a
named seam (`RBLNWorker._send_handoff`), and the metrics patch keeps the pass
open until it and folds its wall into the graph sum — the same shape as the
existing spec-decode postprocess region. The metrics module stays a pure
observer: it times what the worker already does and never adds device work
of its own, so runs behave identically with the metric on or off.

Everything is registry-gated on `VLLM_RBLN_METRICS`; without it the worker
seam is the plain send it replaced.

**Model path**: vLLM-native only.

---

### 📌 Related Issues / Tickets

* Related to # <!-- TODO: link the tracking issue -->

---

### ✅ Type of Change

* [x] 🛠 Bug fix (`fix`)

---

### 🧪 How to Test

1. Run `uv run --no-sync pytest tests/native/patches/test_metrics.py` — the
   new `TestPassBoundary` hand-off tests fail without the change.
2. Run any `pp > 1` case with `VLLM_RBLN_METRICS=1` and read the per-rank
   report: on non-last ranks `MODEL + SAMPLE` now carries the pass through
   the hand-off instead of stopping at dispatch; the last rank's sections are
   unchanged, and `E2E − MODEL + SAMPLE` keeps its meaning (host overhead
   around the graphs).
3. Edge cases: a pass that does not return `IntermediateTensors` (last rank,
   `pp == 1`, empty steps) closes where it always did; a hand-off that raises
   leaves the pass open, like any raising pass.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

On a loaded pipeline the hand-off wall also contains the wait for the next
rank to arrive, so on non-last ranks the section reads as "what this rank's
step actually spent" rather than device time alone; with an idle downstream
the two coincide. Reviewers may also want to eye `_send_handoff`: it exists
so the metrics patch has a wrappable seam, the same reason the postprocess
profiler region exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
