### PR TITLE
fix(spec-decode): keep the post-step draft fetch off the prefill path

### DIFF
--- a/tests/native/patches/test_engine_core.py
+++ b/tests/native/patches/test_engine_core.py
@@ -1,0 +1,160 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The post-step draft fetch stays off the prefill path.
+
+A stub engine only -- the guard reads `scheduler.running` and the three flags
+`post_step` already branches on, so no config, checkpoint or device is needed.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from vllm.v1.engine.core import EngineCore
+
+from vllm_rbln.patches.engine_core import patched_post_step
+
+
+class _Executor:
+    def __init__(self, drafts="drafts"):
+        self.drafts = drafts
+        self.calls = 0
+
+    def take_draft_token_ids(self):
+        self.calls += 1
+        return self.drafts
+
+
+class _Scheduler:
+    def __init__(self, prefill_flags):
+        self.running = [
+            SimpleNamespace(is_prefill_chunk=flag) for flag in prefill_flags
+        ]
+        self.updated = []
+
+    def update_draft_token_ids(self, draft_token_ids):
+        self.updated.append(draft_token_ids)
+
+
+def _engine(prefill_flags, *, spec=True, async_scheduling=False, drafts="drafts"):
+    return SimpleNamespace(
+        check_for_draft_tokens=spec,
+        async_scheduling=async_scheduling,
+        model_executor=_Executor(drafts),
+        scheduler=_Scheduler(prefill_flags),
+    )
+
+
+def test_the_patch_is_the_one_installed():
+    assert EngineCore.post_step is patched_post_step
+
+
+@pytest.mark.parametrize("prefill_flags", [[True], [True, True], [True] * 4])
+def test_all_prefill_skips_the_fetch(prefill_flags):
+    engine = _engine(prefill_flags)
+
+    patched_post_step(engine, model_executed=True)
+
+    assert engine.model_executor.calls == 0
+    assert engine.scheduler.updated == []
+
+
+@pytest.mark.parametrize(
+    "prefill_flags",
+    [
+        [False],  # a decode request
+        [True, False],  # the step that scheduled a request's last chunk
+        [False, True],
+    ],
+)
+def test_any_non_prefill_request_still_fetches(prefill_flags):
+    engine = _engine(prefill_flags)
+
+    patched_post_step(engine, model_executed=True)
+
+    assert engine.model_executor.calls == 1
+    assert engine.scheduler.updated == ["drafts"]
+
+
+def test_an_empty_running_queue_still_fetches():
+    # The guard must not turn a no-op queue into a skip: `all()` is True on an
+    # empty list, so the emptiness check is what keeps this path unchanged.
+    engine = _engine([])
+
+    patched_post_step(engine, model_executed=True)
+
+    assert engine.model_executor.calls == 1
+
+
+@pytest.mark.parametrize(
+    ("spec", "async_scheduling", "model_executed"),
+    [
+        (False, False, True),  # no spec decode
+        (True, True, True),  # async scheduling updates in the worker
+        (True, False, False),  # nothing ran
+    ],
+)
+def test_the_upstream_conditions_are_untouched(spec, async_scheduling, model_executed):
+    engine = _engine([False], spec=spec, async_scheduling=async_scheduling)
+
+    patched_post_step(engine, model_executed=model_executed)
+
+    assert engine.model_executor.calls == 0
+
+
+def test_a_none_result_is_not_forwarded():
+    engine = _engine([False], drafts=None)
+
+    patched_post_step(engine, model_executed=True)
+
+    assert engine.model_executor.calls == 1
+    assert engine.scheduler.updated == []
+
+
+def test_a_chunked_prefill_run_fetches_once_instead_of_every_step():
+    """The regression this guard exists for, in miniature.
+
+    A long prompt under chunked prefill is many intermediate chunks and one
+    that finishes it. Only the last one produces an anchor token, so only its
+    drafts are ever verified -- yet unpatched `post_step` pays for the
+    round-trip on every step. Under PP that round-trip is a wait on the last
+    stage, which is what stops `batch_queue` from refilling.
+    """
+    engine = _engine([])
+    n_chunks = 101
+
+    for step in range(n_chunks):
+        last = step == n_chunks - 1
+        # `_update_after_schedule` advances num_computed_tokens before the step
+        # runs, so the request already reads as non-prefill on its last chunk.
+        engine.scheduler.running = [SimpleNamespace(is_prefill_chunk=not last)]
+        patched_post_step(engine, model_executed=True)
+
+    assert engine.model_executor.calls == 1
+    assert engine.scheduler.updated == ["drafts"]
+
+
+def test_the_guard_is_per_step_not_sticky():
+    # A prefilling request must not suppress the fetch for a decode request
+    # that joins the batch later in the same run.
+    engine = _engine([True])
+
+    patched_post_step(engine, model_executed=True)
+    assert engine.model_executor.calls == 0
+
+    engine.scheduler.running.append(SimpleNamespace(is_prefill_chunk=False))
+    patched_post_step(engine, model_executed=True)
+    assert engine.model_executor.calls == 1

--- a/vllm_rbln/patches/__init__.py
+++ b/vllm_rbln/patches/__init__.py
@@ -31,6 +31,7 @@ from . import (
     deepseek_v2,
     distributed_utils,
     dynamic_kv,
+    engine_core,
     fp8_moe_method,
     gpt_oss,
     gpt_oss_mxfp4_config,

--- a/vllm_rbln/patches/engine_core.py
+++ b/vllm_rbln/patches/engine_core.py
@@ -1,0 +1,67 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Keep the post-step draft fetch out of the prefill path.
+
+``EngineCore.post_step`` pulls the drafts out of the worker that produced them so
+the scheduler can size and allocate the next verification step. It runs whenever
+spec decode is on and async scheduling is off -- on RBLN that is every PP run,
+since PP under async scheduling is not supported yet (see ``platform.py``).
+
+Between decode steps the fetch is a true dependence: step N's drafts are what
+step N+1 verifies. Between prefill chunks there is none, and upstream's own
+consumer says so -- ``Scheduler.update_draft_token_ids`` drops the value on
+arrival ("Ignore draft tokens for prefill chunks"). ``post_step`` only receives
+``model_executed``, so it cannot tell the two apart.
+
+At ``pipeline_parallel_size == 1`` that costs nothing: the engine has one batch
+in flight and already blocks each step. Under PP it costs the pipeline. The
+fetch is a synchronous round-trip to ``output_rank``, the last stage, issued
+right after ``step_with_batch_queue`` returns early to refill ``batch_queue`` --
+so the engine cannot get back to ``schedule()`` until the chunk has traversed
+every stage, and the pipeline runs about one microbatch deep.
+
+The guard is the consumer's own condition moved ahead of the round-trip. The
+step that schedules a request's last chunk already reports ``is_prefill_chunk ==
+False`` (``_update_after_schedule`` advances ``num_computed_tokens`` first), so
+the fetch resumes on exactly the step whose drafts the next one will verify.
+
+Self-disabling: with async scheduling the ``not async_scheduling`` term is false
+and the guard is never reached.
+"""
+
+from vllm.v1.engine.core import EngineCore
+
+from vllm_rbln.patches import register_patch
+
+
+@register_patch(
+    target="vllm.v1.engine.core.EngineCore.post_step",
+    reason=(
+        "Skip the post-step draft fetch while every running request is still "
+        "mid-prefill. The scheduler discards drafts for prefill chunks, but "
+        "under PP the fetch is a synchronous round-trip to the last stage that "
+        "stops the engine from refilling batch_queue, so the pipeline runs one "
+        "microbatch deep instead of pipeline_parallel_size."
+    ),
+    key="vllm_rbln.patches.engine_core.post_step",
+    owner_module="vllm_rbln.patches.engine_core",
+)
+def patched_post_step(self: EngineCore, model_executed: bool) -> None:
+    if self.check_for_draft_tokens and not self.async_scheduling and model_executed:
+        running = self.scheduler.running
+        if running and all(request.is_prefill_chunk for request in running):
+            return
+        draft_token_ids = self.model_executor.take_draft_token_ids()
+        if draft_token_ids is not None:
+            self.scheduler.update_draft_token_ids(draft_token_ids)


### PR DESCRIPTION
`EngineCore.post_step` fetches the drafts from the worker that produced them so the scheduler can size and allocate the next verification step. It runs whenever spec decode is on and async scheduling is off — and on RBLN async scheduling is off for **every** PP run, because PP under async scheduling is not supported yet (`platform.py`).

Between **decode** steps that fetch is a true dependence: step N's drafts are what step N+1 verifies. Between **prefill** chunks there is none, and upstream's own consumer says so — `update_draft_token_ids` drops the value on arrival with `# Ignore draft tokens for prefill chunks`, because a chunk with no anchor token has nothing to verify. `post_step` only receives `model_executed`, so it cannot tell the two apart.

At `pipeline_parallel_size == 1` paying for it anyway is invisible: the engine has one batch in flight and already blocks each step. Under PP it is not. The fetch is a synchronous round-trip to `output_rank` — the last stage — so the reply cannot come until the chunk has traversed the whole pipeline, and it is issued right after `step_with_batch_queue` returns early to refill `batch_queue`. The engine never gets back to `schedule()`, `batch_queue` never reaches `pp_size`, and the pipeline runs about **one microbatch deep instead of `pipeline_parallel_size`** — every stage but one idle, waiting for a chunk that the engine is not allowed to schedule yet.

The cost is the round-trip, not the drafting: an ngram drafter, whose own work across a prefill-only run is negligible, regresses prefill TTFT several-fold on PP4 purely by being configured. Stage times are unchanged — only the interval between chunks moves. eagle3 cannot avoid this by configuration at all, since its drafter fills its KV in the prefill forward and therefore requires a speculative config on the prefill instance.

```
expected — the period is one stage, so pp_size chunks are in flight

  pp0  |[ c0 ][ c1 ][ c2 ][ c3 ][ c4 ]
  pp1  |      [ c0 ][ c1 ][ c2 ][ c3 ][ c4 ]
  pp2  |            [ c0 ][ c1 ][ c2 ][ c3 ][ c4 ]
  pp3  |                  [ c0 ][ c1 ][ c2 ][ c3 ][ c4 ]
        pp0 takes the next chunk as soon as it has handed one on


actual — the period is a whole traversal, so one chunk is in flight

  pp0  |[ c0 ]                  [ c1 ]                  [ c2 ]
  pp1  |      [ c0 ]                  [ c1 ]                  [ c2 ]
  pp2  |            [ c0 ]                  [ c1 ]                  [ c2 ]
  pp3  |                  [ c0 ]                  [ c1 ]
  eng  |>>>>>>>>>>>>>>>>>>>>>>>|                 |
        take_draft_token_ids() reply ───────────┘  c1 scheduled
        stage times are the same in both -- the next chunk just does not arrive
```

### The change

Skip the fetch while every running request is still mid-prefill:

```python
running = self.scheduler.running
if running and all(request.is_prefill_chunk for request in running):
    return
```

That is the condition the consumer already applies, moved ahead of the round-trip, so **not fetching and fetching-then-discarding are the same**. The step that schedules a request's last chunk already reports `is_prefill_chunk == False` (`_update_after_schedule` advances `num_computed_tokens` first), so the fetch resumes on exactly the step whose drafts the next one will verify. The decode path is untouched.

With the guard the pipeline fills to `pp_size` again and prefill TTFT returns to parity with a run that carries no speculative config at all — for both ngram and eagle3. Sanity generations (short greedy, and long-context needle retrieval) are unchanged.

Self-disabling: once PP is supported under async scheduling the `not async_scheduling` term is false and the guard is never reached, so this can stay or be removed.

### Tests

`tests/native/patches/test_engine_core.py` — 14 cases on a stub engine (no config, checkpoint or device):

- all-prefill skips; any non-prefill still fetches; empty `running` still fetches (`all([])` is True, so the emptiness check carries weight)
- the three upstream conditions stay untouched (no spec / async on / nothing ran)
- a `None` result is not forwarded
- **the regression in miniature** — a chunked-prefill run of 101 steps fetches **once** instead of on every step
- the guard is per-step, not sticky: a prefilling request does not suppress the fetch for a decode request that joins later

Measurements and the full write-up: rebellions-sw/fsw-inference#561
