### PR TITLE
refactor(optimum): prepare decoder graph inputs once per phase

### DIFF
--- a/tests/optimum/v1/models/optimum/test_decoder_mixin.py
+++ b/tests/optimum/v1/models/optimum/test_decoder_mixin.py
@@ -11,15 +11,29 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import types
+
 import torch
 
 from vllm_rbln.model_executor.models.optimum.model_base import RBLNOptimumDecoderMixin
 
 
 def test_padding_row_does_not_alias_a_real_slot():
-    padded = RBLNOptimumDecoderMixin.pad_cache_slot_ids(
-        torch.tensor([0], dtype=torch.int16), 4
+    obj = RBLNOptimumDecoderMixin.__new__(RBLNOptimumDecoderMixin)
+    obj.decoder_batch_size = 4
+    obj.use_multiple_decoder = False
+    obj.available_blocks = torch.arange(50, 60, dtype=torch.int16)
+    model_input = types.SimpleNamespace(
+        input_tokens=torch.tensor([[7]]),
+        input_positions=torch.tensor([[3]]),
+        block_tables=torch.tensor([[10]]),
     )
 
+    inputs = obj.prepare_decode_inputs(
+        model_input, cache_slot_ids=torch.tensor([0], dtype=torch.int16)
+    )
+
+    padded = inputs.local_block_tables
+    assert padded is not None
     assert padded[0, 0] == 0  # the scheduled request keeps its slot
     assert 0 not in {int(padded[row, 0]) for row in range(1, 4)}

--- a/tests/optimum/v1/models/optimum/test_qwen3_5_linear_state.py
+++ b/tests/optimum/v1/models/optimum/test_qwen3_5_linear_state.py
@@ -49,19 +49,24 @@ class TestDecodeLayoutWiring:
         obj.available_blocks = torch.arange(50, 60, dtype=torch.int16)
         return obj
 
-    def test_pad_decoder_items_scatters_to_batch_idx_rows(self):
+    def test_prepare_decode_inputs_scatters_to_batch_idx_rows(self):
         # Running order [B, A]; B's row is 1, A's row is 0. The real
-        # pad_decoder_items must land B (running idx 0) on row 1 and A on row 0.
+        # prepare_decode_inputs must land B (running idx 0) on row 1 and A on row 0.
         obj = self._bare_qwen3_5(max_batch_size=4)
-        input_ids = torch.tensor([[201], [200]])  # running order: B=201, A=200
-        positions = torch.tensor([[5], [7]])
-        block_tables = torch.tensor([[10], [11]], dtype=torch.int16)
+        model_input = types.SimpleNamespace(
+            input_tokens=torch.tensor([[201], [200]]),  # running order: B=201, A=200
+            input_positions=torch.tensor([[5], [7]]),
+            block_tables=torch.tensor([[10], [11]], dtype=torch.int16),
+        )
         batch_indices = torch.tensor([1, 0])  # rows of [B, A]
 
-        padded_ids, padded_pos, padded_bt = obj.pad_decoder_items(
-            input_ids, positions, block_tables, input_block_ids=batch_indices
+        decode_inputs = obj.prepare_decode_inputs(
+            model_input, input_block_ids=batch_indices
         )
 
+        padded_ids = decode_inputs.input_ids
+        padded_pos = decode_inputs.cache_position
+        padded_bt = decode_inputs.block_tables
         assert padded_ids[1, 0] == 201 and padded_ids[0, 0] == 200  # B->1, A->0
         assert padded_pos[1, 0] == 5 and padded_pos[0, 0] == 7
         assert padded_bt[1, 0] == 10 and padded_bt[0, 0] == 11

--- a/vllm_rbln/model_executor/models/optimum/blip2.py
+++ b/vllm_rbln/model_executor/models/optimum/blip2.py
@@ -60,36 +60,25 @@ class RBLNOptimumBlip2ForConditionalGeneration(
         )
 
     def forward(self, model_input: ModelInputForRBLN, **kwargs) -> torch.Tensor:
-        input_ids = model_input.input_tokens
-        cache_position = model_input.input_positions
-        block_tables = model_input.block_tables
+        request_nums = model_input.input_tokens.shape[0]
 
-        is_prompt = model_input.is_prompt
-
-        request_nums = input_ids.shape[0]
-
-        kwargs = self.preprocess_for_decoder(
-            is_prompt, block_tables, input_ids, cache_position
-        )
-
-        if is_prompt:
-            block_tables = kwargs.pop("block_tables")
-            cache_position = kwargs.pop("cache_position")
-
-            inputs_embeds = model_input.inputs_embeds
+        if model_input.is_prompt:
+            prefill_inputs = self.prepare_prefill_inputs(model_input)
             logits = self.model.language_model.prefill_decoder(
-                inputs_embeds=inputs_embeds,
-                cache_position=cache_position,
-                block_tables=block_tables,
+                inputs_embeds=model_input.inputs_embeds,
+                cache_position=prefill_inputs.cache_position,
+                block_tables=prefill_inputs.block_tables,
             ).logits
         else:
-            padded_batch_size = kwargs.pop("padded_batch_size", self.decoder_batch_size)
+            decode_inputs = self.prepare_decode_inputs(model_input)
             self.model.language_model.decoder = self.model.language_model.decoders[
-                padded_batch_size
+                decode_inputs.padded_batch_size
             ]
-
-            logits = self.model.language_model.decoder(**kwargs).logits
-        if not is_prompt:
+            logits = self.model.language_model.decoder(
+                input_ids=decode_inputs.input_ids,
+                cache_position=decode_inputs.cache_position,
+                block_tables=decode_inputs.block_tables,
+            ).logits
             logits = logits[:request_nums]
         return logits
 

--- a/vllm_rbln/model_executor/models/optimum/decoder_only.py
+++ b/vllm_rbln/model_executor/models/optimum/decoder_only.py
@@ -44,27 +44,28 @@ class RBLNOptimumForCausalLM(
         )
 
     def forward(self, model_input: ModelInputForRBLN, **kwargs) -> torch.Tensor:
-        input_ids = model_input.input_tokens
-        cache_position = model_input.input_positions
-        block_tables = model_input.block_tables
-        dummy_block = model_input.dummy_block
+        request_nums = model_input.input_tokens.shape[0]
 
-        request_nums = input_ids.shape[0]
-        is_prompt = model_input.is_prompt
-
-        kwargs = self.preprocess_for_decoder(
-            is_prompt, block_tables, input_ids, cache_position, dummy_block=dummy_block
-        )
-        padded_batch_size = kwargs.pop("padded_batch_size", self.decoder_batch_size)
-
-        if is_prompt:
+        if model_input.is_prompt:
             if self.model.prefill_decoder is None:
                 raise version_error
-            return self.model.prefill_decoder(**kwargs).logits
+            prefill_inputs = self.prepare_prefill_inputs(model_input)
+            return self.model.prefill_decoder(
+                input_ids=prefill_inputs.input_ids,
+                cache_position=prefill_inputs.cache_position,
+                block_tables=prefill_inputs.block_tables,
+            ).logits
         else:
-            self.model.decoder = self.model.decoders[padded_batch_size]
+            decode_inputs = self.prepare_decode_inputs(
+                model_input, dummy_block=model_input.dummy_block
+            )
+            self.model.decoder = self.model.decoders[decode_inputs.padded_batch_size]
 
-            logits = self.model.decoder(**kwargs).logits
+            logits = self.model.decoder(
+                input_ids=decode_inputs.input_ids,
+                cache_position=decode_inputs.cache_position,
+                block_tables=decode_inputs.block_tables,
+            ).logits
             if self.attn_impl != "flash_attn":
                 return logits[:request_nums]
 

--- a/vllm_rbln/model_executor/models/optimum/exaone4_5.py
+++ b/vllm_rbln/model_executor/models/optimum/exaone4_5.py
@@ -168,20 +168,21 @@ class RBLNOptimumExaone4_5_ForConditionalGeneration(
         result.update(self._process_video_input(video_input))
         return result
 
-    def build_prefill_inputs(
+    def build_prefill_inputs_from_cache(
         self,
         input_ids: torch.Tensor,
         cached_mm_outputs: list,
         *,
         cache_position: torch.Tensor | None = None,
         running_requests_ids: list[str] | None = None,
+        mrope_position_deltas: dict[str, float] | None = None,
     ) -> dict:
         # NOTE: this guard is currently unreachable — init_model() only enables
         # the EC path for "RBLNQwen3VLForConditionalGeneration", so EXAONE-4.5
         # never enters here today. It documents the contract for when EC is
         # extended: the sliding-window/hybrid-cache prefill needs the cache
-        # slot ids from ModelInputForRBLN, which build_prefill_inputs does
-        # not receive.
+        # slot ids from ModelInputForRBLN, which build_prefill_inputs_from_cache
+        # does not receive.
         raise NotImplementedError(
             "EC disaggregation is not implemented for EXAONE-4.5."
         )
@@ -224,44 +225,31 @@ class RBLNOptimumExaone4_5_ForConditionalGeneration(
         )
 
     def forward(self, model_input: ModelInputForRBLN, **kwargs) -> torch.Tensor:
-        input_ids = model_input.input_tokens
-        cache_position = model_input.input_positions
-        block_tables = model_input.block_tables
         cache_slot_ids = model_input.cache_slot_ids
         assert cache_slot_ids is not None
+        request_nums = model_input.input_tokens.shape[0]
 
-        request_nums = input_ids.shape[0]
-        is_prompt = model_input.is_prompt
-
-        kwargs = self.preprocess_for_decoder(
-            is_prompt, block_tables, input_ids, cache_position
-        )
-
-        padded_batch_size = kwargs.pop("padded_batch_size", self.decoder_batch_size)
-        cache_position = kwargs.pop("cache_position")
-        input_ids = kwargs.pop("input_ids")
-        block_tables = kwargs.pop("block_tables")
-
-        if is_prompt:
-            inputs_embeds = model_input.inputs_embeds
+        if model_input.is_prompt:
+            prefill_inputs = self.prepare_prefill_inputs(model_input)
             logits = self.model.prefill_decoder(
-                input_ids=input_ids,
-                inputs_embeds=inputs_embeds,
-                cache_position=cache_position,
+                input_ids=prefill_inputs.input_ids,
+                inputs_embeds=model_input.inputs_embeds,
+                cache_position=prefill_inputs.cache_position,
                 local_block_tables=cache_slot_ids,
-                block_tables=block_tables if self.is_hybrid else None,
+                block_tables=prefill_inputs.block_tables if self.is_hybrid else None,
             ).logits
         else:
-            self.model.decoder = self.model.decoders[padded_batch_size]
-            inputs_embeds = self.model.embed_tokens(input_ids)
+            decode_inputs = self.prepare_decode_inputs(
+                model_input, cache_slot_ids=cache_slot_ids
+            )
+            self.model.decoder = self.model.decoders[decode_inputs.padded_batch_size]
+            inputs_embeds = self.model.embed_tokens(decode_inputs.input_ids)
             logits = self.model.decoder(
-                input_ids=input_ids,
+                input_ids=decode_inputs.input_ids,
                 inputs_embeds=inputs_embeds,
-                cache_position=cache_position,
-                local_block_tables=self.pad_cache_slot_ids(
-                    cache_slot_ids, padded_batch_size
-                ),
-                block_tables=block_tables if self.is_hybrid else None,
+                cache_position=decode_inputs.cache_position,
+                local_block_tables=decode_inputs.local_block_tables,
+                block_tables=decode_inputs.block_tables if self.is_hybrid else None,
             ).logits
             logits = logits[:request_nums]
         return logits

--- a/vllm_rbln/model_executor/models/optimum/gemma3.py
+++ b/vllm_rbln/model_executor/models/optimum/gemma3.py
@@ -58,7 +58,7 @@ class MultimodalHybridAttentionStateManager:
             attention_mask=attention_mask,
         )
 
-    def build_decode_inputs(
+    def build_decode_attention_inputs(
         self,
         running_requests_ids: list[str],
         position_ids: torch.Tensor,
@@ -136,24 +136,15 @@ class RBLNOptimumGemma3ForConditionalGeneration(
         self.attention_manager = MultimodalHybridAttentionStateManager()
 
     def forward(self, model_input: ModelInputForRBLN, **kwargs) -> torch.Tensor:
-        input_ids = model_input.input_tokens
-        position_ids = model_input.input_positions
-        block_tables = model_input.block_tables
         cache_slot_ids = model_input.cache_slot_ids
         assert cache_slot_ids is not None
 
-        is_prompt = model_input.is_prompt
         running_requests_ids = model_input.running_requests_ids
-        request_nums = input_ids.shape[0]
+        request_nums = model_input.input_tokens.shape[0]
 
-        kwargs = self.preprocess_for_decoder(
-            is_prompt, block_tables, input_ids, position_ids
-        )
-        cache_position = kwargs.pop("cache_position")
-        input_ids = kwargs.pop("input_ids")
-        block_tables = kwargs.pop("block_tables")
-
-        if is_prompt:
+        if model_input.is_prompt:
+            prefill_inputs = self.prepare_prefill_inputs(model_input)
+            input_ids = prefill_inputs.input_ids
             # token_type_ids model_input != token_type_ids of gemma3
             # https://github.com/huggingface/transformers/blob/d0c9c66d1c09df3cd70bf036e813d88337b20d4c/src/transformers/models/gemma3/processing_gemma3.py#L143
             token_type_ids = torch.zeros_like(input_ids)
@@ -170,10 +161,10 @@ class RBLNOptimumGemma3ForConditionalGeneration(
                 raise version_error
             output = self.model.language_model.prefill_decoder(
                 inputs_embeds=inputs_embeds,
-                cache_position=cache_position,
+                cache_position=prefill_inputs.cache_position,
                 attention_mask=attention_mask,
                 local_block_tables=cache_slot_ids,
-                block_tables=block_tables,
+                block_tables=prefill_inputs.block_tables,
                 token_type_ids=token_type_ids,
             )
             logits = output.logits
@@ -188,9 +179,11 @@ class RBLNOptimumGemma3ForConditionalGeneration(
         else:
             if self.model.language_model.decoders is None:
                 raise ValueError("Decoders is None")
-            padded_batch_size = kwargs.pop("padded_batch_size", self.decoder_batch_size)
+            decode_inputs = self.prepare_decode_inputs(
+                model_input, cache_slot_ids=cache_slot_ids
+            )
             self.model.language_model.decoder = self.model.language_model.decoders[
-                padded_batch_size
+                decode_inputs.padded_batch_size
             ]
             # `cache_position` and `position_ids` are distinguished due to the
             # padding space reserved in the cache during prefill.
@@ -198,19 +191,17 @@ class RBLNOptimumGemma3ForConditionalGeneration(
                 cache_position,
                 position_ids,
                 attention_mask,
-            ) = self.attention_manager.build_decode_inputs(
+            ) = self.attention_manager.build_decode_attention_inputs(
                 running_requests_ids,
-                cache_position,
-                padded_batch_size,
+                decode_inputs.cache_position,
+                decode_inputs.padded_batch_size,
             )
 
             logits = self.model.language_model.decoder(
-                input_ids=input_ids,
+                input_ids=decode_inputs.input_ids,
                 cache_position=cache_position,
-                block_tables=block_tables,
-                local_block_tables=self.pad_cache_slot_ids(
-                    cache_slot_ids, padded_batch_size
-                ),
+                block_tables=decode_inputs.block_tables,
+                local_block_tables=decode_inputs.local_block_tables,
                 attention_mask=attention_mask,
                 position_ids=position_ids,
             ).logits

--- a/vllm_rbln/model_executor/models/optimum/idefics3.py
+++ b/vllm_rbln/model_executor/models/optimum/idefics3.py
@@ -63,34 +63,25 @@ class RBLNOptimumIdefics3ForConditionalGeneration(
         return self.model.text_model.prefill_decoder
 
     def forward(self, model_input: ModelInputForRBLN, **kwargs) -> torch.Tensor:
-        input_ids = model_input.input_tokens
-        cache_position = model_input.input_positions
-        block_tables = model_input.block_tables
+        request_nums = model_input.input_tokens.shape[0]
 
-        request_nums = input_ids.shape[0]
-        is_prompt = model_input.is_prompt
-
-        kwargs = self.preprocess_for_decoder(
-            is_prompt, block_tables, input_ids, cache_position
-        )
-
-        if is_prompt:
-            block_tables = kwargs.pop("block_tables")
-            cache_position = kwargs.pop("cache_position")
-
-            inputs_embeds = model_input.inputs_embeds
+        if model_input.is_prompt:
+            prefill_inputs = self.prepare_prefill_inputs(model_input)
             logits = self.model.text_model.prefill_decoder(
-                inputs_embeds=inputs_embeds,
-                cache_position=cache_position,
-                block_tables=block_tables,
+                inputs_embeds=model_input.inputs_embeds,
+                cache_position=prefill_inputs.cache_position,
+                block_tables=prefill_inputs.block_tables,
             ).logits
         else:
-            padded_batch_size = kwargs.pop("padded_batch_size", self.decoder_batch_size)
+            decode_inputs = self.prepare_decode_inputs(model_input)
             self.model.text_model.decoder = self.model.text_model.decoders[
-                padded_batch_size
+                decode_inputs.padded_batch_size
             ]
-            logits = self.model.text_model.decoder(**kwargs).logits
-        if not is_prompt:
+            logits = self.model.text_model.decoder(
+                input_ids=decode_inputs.input_ids,
+                cache_position=decode_inputs.cache_position,
+                block_tables=decode_inputs.block_tables,
+            ).logits
             logits = logits[:request_nums]
         return logits
 

--- a/vllm_rbln/model_executor/models/optimum/llava.py
+++ b/vllm_rbln/model_executor/models/optimum/llava.py
@@ -24,6 +24,8 @@ from vllm.model_executor.models.llava import (
 
 from .base import ModelInputForRBLN, version_error
 from .model_base import (
+    DecodeInputs,
+    PrefillInputs,
     RBLNOptimumDecoderMixin,
     RBLNOptimumModelBase,
     RBLNOptimumMultimodalMixin,
@@ -92,34 +94,24 @@ class RBLNOptimumLlavaForConditionalGeneration(
         return logits
 
     def forward(self, model_input: ModelInputForRBLN, **kwargs) -> torch.Tensor:
-        input_ids = model_input.input_tokens
-        cache_position = model_input.input_positions
-        block_tables = model_input.block_tables
-
         is_prompt = model_input.is_prompt
+        request_nums = model_input.input_tokens.shape[0]
 
-        request_nums = input_ids.shape[0]
-
-        kwargs = self.preprocess_for_decoder(
-            is_prompt, block_tables, input_ids, cache_position
-        )
-        input_ids = kwargs.pop("input_ids")
-        cache_position = kwargs.pop("cache_position")
-        block_tables = kwargs.pop("block_tables")
-        if not is_prompt:
-            padded_batch_size = kwargs.pop("padded_batch_size", self.decoder_batch_size)
+        inputs: PrefillInputs | DecodeInputs
+        if is_prompt:
+            inputs = self.prepare_prefill_inputs(model_input)
+        else:
+            inputs = self.prepare_decode_inputs(model_input)
             self.model.language_model.decoder = self.model.language_model.decoders[
-                padded_batch_size
+                inputs.padded_batch_size
             ]
-
-        inputs_embeds = model_input.inputs_embeds if is_prompt else None
 
         logits = self._forward(
             is_prefill=is_prompt,
-            block_tables=block_tables,
-            input_ids=input_ids,
-            inputs_embeds=inputs_embeds,
-            cache_position=cache_position,
+            block_tables=inputs.block_tables,
+            input_ids=inputs.input_ids,
+            inputs_embeds=model_input.inputs_embeds if is_prompt else None,
+            cache_position=inputs.cache_position,
         )
 
         if not is_prompt:

--- a/vllm_rbln/model_executor/models/optimum/llava_next.py
+++ b/vllm_rbln/model_executor/models/optimum/llava_next.py
@@ -23,6 +23,8 @@ from vllm.model_executor.models.llava_next import (
 
 from .base import ModelInputForRBLN, version_error
 from .model_base import (
+    DecodeInputs,
+    PrefillInputs,
     RBLNOptimumDecoderMixin,
     RBLNOptimumModelBase,
     RBLNOptimumMultimodalMixin,
@@ -91,34 +93,24 @@ class RBLNOptimumLlavaNextForConditionalGeneration(
         return logits
 
     def forward(self, model_input: ModelInputForRBLN, **kwargs) -> torch.Tensor:
-        input_ids = model_input.input_tokens
-        cache_position = model_input.input_positions
-        block_tables = model_input.block_tables
-
         is_prompt = model_input.is_prompt
+        request_nums = model_input.input_tokens.shape[0]
 
-        request_nums = input_ids.shape[0]
-
-        kwargs = self.preprocess_for_decoder(
-            is_prompt, block_tables, input_ids, cache_position
-        )
-        input_ids = kwargs.pop("input_ids")
-        cache_position = kwargs.pop("cache_position")
-        block_tables = kwargs.pop("block_tables")
-        if not is_prompt:
-            padded_batch_size = kwargs.pop("padded_batch_size", self.decoder_batch_size)
+        inputs: PrefillInputs | DecodeInputs
+        if is_prompt:
+            inputs = self.prepare_prefill_inputs(model_input)
+        else:
+            inputs = self.prepare_decode_inputs(model_input)
             self.model.language_model.decoder = self.model.language_model.decoders[
-                padded_batch_size
+                inputs.padded_batch_size
             ]
-
-        inputs_embeds = model_input.inputs_embeds if is_prompt else None
 
         logits = self._forward(
             is_prefill=is_prompt,
-            block_tables=block_tables,
-            input_ids=input_ids,
-            inputs_embeds=inputs_embeds,
-            cache_position=cache_position,
+            block_tables=inputs.block_tables,
+            input_ids=inputs.input_ids,
+            inputs_embeds=model_input.inputs_embeds if is_prompt else None,
+            cache_position=inputs.cache_position,
         )
 
         if not is_prompt:

--- a/vllm_rbln/model_executor/models/optimum/model_base.py
+++ b/vllm_rbln/model_executor/models/optimum/model_base.py
@@ -15,7 +15,7 @@ import json
 import math
 import os
 from dataclasses import replace
-from typing import Any
+from typing import Any, NamedTuple
 
 import torch
 import torch.nn as nn
@@ -280,6 +280,25 @@ class RBLNOptimumModelBase(nn.Module):
         return self.model.rbln_config.dtype
 
 
+class PrefillInputs(NamedTuple):
+    """Inputs of the compiled prefill graph, one request."""
+
+    input_ids: torch.Tensor  # [1, seq_len] int64
+    cache_position: torch.Tensor  # [1, seq_len] int32
+    block_tables: torch.Tensor  # [num_blocks] int16
+
+
+class DecodeInputs(NamedTuple):
+    """Inputs of the compiled decode graph, padded to ``padded_batch_size``."""
+
+    input_ids: torch.Tensor  # [padded_batch_size, 1] int64
+    cache_position: torch.Tensor  # [padded_batch_size, 1] int32
+    block_tables: torch.Tensor  # [padded_batch_size, num_blocks] int16
+    # Padded cache slot ids, None unless ``cache_slot_ids`` was given.
+    local_block_tables: torch.Tensor | None  # [padded_batch_size, 1] int16
+    padded_batch_size: int
+
+
 class RBLNOptimumDecoderMixin(VllmModelForTextGeneration):
     attn_impl: str | None
 
@@ -306,128 +325,85 @@ class RBLNOptimumDecoderMixin(VllmModelForTextGeneration):
             dtype=torch.int16,
         )
 
-    def pad_decoder_items(
+    def prepare_prefill_inputs(self, model_input: ModelInputForRBLN) -> PrefillInputs:
+        return PrefillInputs(
+            input_ids=model_input.input_tokens.to(torch.int64),
+            cache_position=model_input.input_positions.to(torch.int32),
+            block_tables=model_input.block_tables.squeeze(0).to(torch.int16),
+        )
+
+    def prepare_decode_inputs(
         self,
-        input_ids: torch.Tensor,
-        positions: torch.Tensor,
-        block_tables: torch.Tensor,
+        model_input: ModelInputForRBLN,
+        *,
+        cache_slot_ids: torch.Tensor | None = None,
         input_block_ids: torch.Tensor | None = None,
-        padded_batch_size: int | None = None,
         dummy_block: int | None = None,
-    ):
-        assert input_ids.shape[1] == 1
-        if input_block_ids is None and padded_batch_size is None:
-            raise ValueError(
-                "Either input_block_ids or padded_batch_size must be provided."
-            )
-        elif input_block_ids is not None and padded_batch_size is not None:
-            raise ValueError(
-                "Cannot provide both input_block_ids and padded_batch_size."
-            )
+    ) -> DecodeInputs:
+        """Pad the decode batch to the decoder's batch size.
 
-        if padded_batch_size is None:
-            padded_batch_size = self.decoder_batch_size
-
-        original_batch_size = input_ids.shape[0]
-
-        padded_input_ids = torch.zeros(padded_batch_size, 1, dtype=input_ids.dtype)
-        padded_position_ids = torch.zeros(padded_batch_size, 1, dtype=positions.dtype)
-        padded_block_tables = torch.zeros(
-            padded_batch_size, block_tables.shape[1], dtype=block_tables.dtype
-        ).fill_(-1)
-
-        mask = torch.ones_like(
-            padded_block_tables,
-            dtype=torch.bool,
-            device=block_tables.device,
-        )
-
-        if input_block_ids is None:
-            padded_input_ids[:original_batch_size] = input_ids
-            padded_position_ids[:original_batch_size] = positions
-            padded_block_tables[:original_batch_size] = block_tables
-            mask[:original_batch_size, :] = False
-        else:
-            padded_input_ids[input_block_ids] = input_ids
-            padded_position_ids[input_block_ids] = positions
-            padded_block_tables[input_block_ids] = block_tables
-            mask[input_block_ids, :] = False
-
-        if torch.any(mask):
-            if dummy_block is not None:
-                padding_blocks = torch.tensor([dummy_block], dtype=block_tables.dtype)
-            else:
-                padding_blocks = self.available_blocks[
-                    ~torch.isin(self.available_blocks, block_tables.flatten())
-                ]
-            padded_block_tables[mask] = padding_blocks[0]
-        return padded_input_ids, padded_position_ids, padded_block_tables
-
-    def preprocess_for_decoder(
-        self,
-        is_prompt: bool,
-        block_tables: torch.Tensor,
-        input_ids: torch.Tensor | None = None,
-        cache_position: torch.Tensor | None = None,
-        input_block_ids: list[int] | None = None,
-        dummy_block: int | None = None,
-    ):
-        padded_batch_size = None
-        # 1. Set the type
-        # TODO: Does it require changing the dtype dynamically?
-        input_ids = input_ids.to(torch.int64) if input_ids is not None else None
-        cache_position = (
-            cache_position.to(torch.int32) if cache_position is not None else None
-        )
-        block_tables = block_tables.to(torch.int16)
-
-        # 2. Adjust the shape of tensors by squeezing and padding
-        if is_prompt:
-            block_tables = block_tables.squeeze(0)
-            padded_batch_size = 1
-        else:
-            if input_block_ids is None:
-                padded_batch_size = self.decoder_batch_size
-                if input_ids is not None:
-                    request_nums = input_ids.shape[0]
-                # Select lower-bounded batch size in case of multiple decoders
-                if self.use_multiple_decoder:
-                    padded_batch_size = select_bucket_size(
-                        request_nums, self.decoder_batch_sizes
-                    )
-
-            input_ids, cache_position, block_tables = self.pad_decoder_items(
-                input_ids,
-                cache_position,
-                block_tables,
-                input_block_ids=input_block_ids,
-                padded_batch_size=padded_batch_size,
-                dummy_block=dummy_block,
-            )
-        kwargs = {
-            "block_tables": block_tables,
-            "padded_batch_size": padded_batch_size,
-            "input_ids": input_ids,
-            "cache_position": cache_position,
-        }
-        return kwargs
-
-    @staticmethod
-    def pad_cache_slot_ids(
-        cache_slot_ids: torch.Tensor,
-        padded_batch_size: int,
-    ) -> torch.Tensor:
-        """Pad the decode cache slot ids to [padded_batch_size, 1].
-
-        Padding rows must not alias a scheduled request's row in the
-        per-sequence cache, so the pad value is the lowest id no scheduled
-        request owns (0 when the batch is full and no padding row exists).
+        Requests occupy rows [0, num_reqs) unless ``input_block_ids`` names each
+        request's row. Padding rows point at ``dummy_block``, or at a block no
+        request in this batch uses. ``cache_slot_ids`` is padded with the lowest
+        slot no scheduled request owns, so a padding row never aliases a real
+        row of the per-sequence cache.
         """
-        used_ids = set(cache_slot_ids.tolist())
-        pad_value = next((i for i in range(padded_batch_size) if i not in used_ids), 0)
-        padded = torch.full((padded_batch_size, 1), pad_value, dtype=torch.int16)
-        padded[: cache_slot_ids.shape[0], 0] = cache_slot_ids
-        return padded
+        input_ids = model_input.input_tokens
+        block_tables = model_input.block_tables
+        assert input_ids.shape[1] == 1
+        num_reqs = input_ids.shape[0]
+
+        rows: torch.Tensor | slice
+        if input_block_ids is not None:
+            padded_batch_size = self.decoder_batch_size
+            rows = input_block_ids
+        else:
+            padded_batch_size = (
+                select_bucket_size(num_reqs, self.decoder_batch_sizes)
+                if self.use_multiple_decoder
+                else self.decoder_batch_size
+            )
+            rows = slice(0, num_reqs)
+
+        num_blocks = block_tables.shape[1]
+        if padded_batch_size > num_reqs:
+            if dummy_block is None:
+                dummy_block = int(
+                    self.available_blocks[
+                        ~torch.isin(self.available_blocks, block_tables.flatten())
+                    ][0]
+                )
+            padded_block_tables = torch.full(
+                (padded_batch_size, num_blocks), dummy_block, dtype=torch.int16
+            )
+        else:
+            padded_block_tables = torch.empty(
+                (padded_batch_size, num_blocks), dtype=torch.int16
+            )
+        padded_input_ids = torch.zeros(padded_batch_size, 1, dtype=torch.int64)
+        padded_cache_position = torch.zeros(padded_batch_size, 1, dtype=torch.int32)
+        padded_input_ids[rows] = input_ids.to(torch.int64)
+        padded_cache_position[rows] = model_input.input_positions.to(torch.int32)
+        padded_block_tables[rows] = block_tables.to(torch.int16)
+
+        local_block_tables = None
+        if cache_slot_ids is not None:
+            used_slots = set(cache_slot_ids.tolist())
+            pad_slot = next(
+                (i for i in range(padded_batch_size) if i not in used_slots), 0
+            )
+            local_block_tables = torch.full(
+                (padded_batch_size, 1), pad_slot, dtype=torch.int16
+            )
+            local_block_tables[rows] = cache_slot_ids.unsqueeze(1)
+
+        return DecodeInputs(
+            input_ids=padded_input_ids,
+            cache_position=padded_cache_position,
+            block_tables=padded_block_tables,
+            local_block_tables=local_block_tables,
+            padded_batch_size=padded_batch_size,
+        )
 
     def get_prefill_decoder(self) -> runtime_utils.RBLNRuntimeModel:
         return self.model.prefill_decoder

--- a/vllm_rbln/model_executor/models/optimum/paligemma.py
+++ b/vllm_rbln/model_executor/models/optimum/paligemma.py
@@ -61,44 +61,35 @@ class RBLNOptimumPaliGemmaForConditionalGeneration(
         )
 
     def forward(self, model_input: ModelInputForRBLN, **kwargs) -> torch.Tensor:
-        input_ids = model_input.input_tokens
-        cache_position = model_input.input_positions
-        block_tables = model_input.block_tables
+        request_nums = model_input.input_tokens.shape[0]
 
-        request_nums = input_ids.shape[0]
-        is_prompt = model_input.is_prompt
-
-        kwargs = self.preprocess_for_decoder(
-            is_prompt, block_tables, input_ids, cache_position
-        )
-
-        if is_prompt:
-            block_tables = kwargs.pop("block_tables")
-            cache_position = kwargs.pop("cache_position")
-
-            inputs_embeds = model_input.inputs_embeds
+        if model_input.is_prompt:
+            prefill_inputs = self.prepare_prefill_inputs(model_input)
             logits = self.model.language_model.prefill_decoder(
-                inputs_embeds=inputs_embeds,
-                cache_position=cache_position,
-                block_tables=block_tables,
+                inputs_embeds=model_input.inputs_embeds,
+                cache_position=prefill_inputs.cache_position,
+                block_tables=prefill_inputs.block_tables,
             ).logits
         else:
-            padded_batch_size = kwargs.pop("padded_batch_size", self.decoder_batch_size)
+            decode_inputs = self.prepare_decode_inputs(model_input)
             self.model.language_model.decoder = self.model.language_model.decoders[
-                padded_batch_size
+                decode_inputs.padded_batch_size
             ]
             # NOTE(eunji.lee): attention_mask, position_ids are required
             # to paligemma in optimum-rbln.
             # They depends on the version of gemma in paligemma.
             attention_mask, position_ids = self.generate_params_for_gemma(
-                padded_batch_size,
+                decode_inputs.padded_batch_size,
                 self.model.rbln_config.language_model,
-                kwargs["cache_position"],
+                decode_inputs.cache_position,
             )
             logits = self.model.language_model.decoder(
-                attention_mask=attention_mask, position_ids=position_ids, **kwargs
+                input_ids=decode_inputs.input_ids,
+                cache_position=decode_inputs.cache_position,
+                block_tables=decode_inputs.block_tables,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
             ).logits
-        if not is_prompt:
             logits = logits[:request_nums]
         return logits
 

--- a/vllm_rbln/model_executor/models/optimum/qwen2_vl.py
+++ b/vllm_rbln/model_executor/models/optimum/qwen2_vl.py
@@ -507,9 +507,6 @@ class RBLNOptimumQwenVLForConditionalGeneration(
         """
         cache_position = model_input.input_positions
         running_requests_ids = model_input.running_requests_ids
-        # int32 mirrors the cache_position dtype the prior decode path used
-        # (cast in preprocess_for_decoder before computing position embeds).
-        cache_position = cache_position.to(torch.int32)
         padded_batch_size = self.decoder_batch_size
         if self.use_multiple_decoder:
             padded_batch_size = select_bucket_size(
@@ -533,47 +530,34 @@ class RBLNOptimumQwenVLForConditionalGeneration(
         return torch.cat(position_embeds, dim=1)
 
     def forward(self, model_input: ModelInputForRBLN, **kwargs) -> torch.Tensor:
-        input_ids = model_input.input_tokens
-        cache_position = model_input.input_positions
-        block_tables = model_input.block_tables
-
-        request_nums = input_ids.shape[0]
-        is_prompt = model_input.is_prompt
+        request_nums = model_input.input_tokens.shape[0]
 
         # FIXME This should be removed in the future
         # by moving the padding logic into model runner.
         assert len(model_input.running_requests_ids) == request_nums, (
             f"The number of running requests is "
             f"{len(model_input.running_requests_ids)}, "
-            f"but the shape of input_ids is {input_ids.shape}"
+            f"but the shape of input_ids is {model_input.input_tokens.shape}"
         )
 
-        kwargs = self.preprocess_for_decoder(
-            is_prompt, block_tables, input_ids, cache_position
-        )
-        cache_position = kwargs.pop("cache_position")
-        block_tables = kwargs.pop("block_tables")
-
-        if is_prompt:
-            prefill_kwargs = {
-                "inputs_embeds": model_input.inputs_embeds,
-                "position_embed": model_input.position_embed,
-                "block_tables": block_tables,
-                "cache_position": cache_position,
-            }
-            logits = self.model.prefill_decoder(**prefill_kwargs).logits
+        if model_input.is_prompt:
+            prefill_inputs = self.prepare_prefill_inputs(model_input)
+            logits = self.model.prefill_decoder(
+                inputs_embeds=model_input.inputs_embeds,
+                position_embed=model_input.position_embed,
+                block_tables=prefill_inputs.block_tables,
+                cache_position=prefill_inputs.cache_position,
+            ).logits
         else:
-            padded_batch_size = kwargs.pop("padded_batch_size", self.decoder_batch_size)
-            self.model.decoder = self.model.decoders[padded_batch_size]
-            input_ids = kwargs.pop("input_ids")
-            inputs_embeds = self.model.embed_tokens(input_ids)
+            decode_inputs = self.prepare_decode_inputs(model_input)
+            self.model.decoder = self.model.decoders[decode_inputs.padded_batch_size]
+            inputs_embeds = self.model.embed_tokens(decode_inputs.input_ids)
             logits = self.model.decoder(
                 inputs_embeds=inputs_embeds,
-                cache_position=cache_position,
+                cache_position=decode_inputs.cache_position,
                 position_embed=model_input.position_embed,
-                block_tables=block_tables,
+                block_tables=decode_inputs.block_tables,
             ).logits
-        if not is_prompt:
             logits = logits[:request_nums]
         return logits
 

--- a/vllm_rbln/model_executor/models/optimum/qwen3_vl.py
+++ b/vllm_rbln/model_executor/models/optimum/qwen3_vl.py
@@ -311,21 +311,18 @@ class RBLNOptimumQwen3VLForConditionalGeneration(
         if not model_input.is_prompt:
             return super().forward(model_input, **kwargs)
 
-        input_ids = model_input.input_tokens
-        request_nums = input_ids.shape[0]
+        request_nums = model_input.input_tokens.shape[0]
         assert len(model_input.running_requests_ids) == request_nums, (
             f"The number of running requests is "
             f"{len(model_input.running_requests_ids)}, "
-            f"but the shape of input_ids is {input_ids.shape}"
+            f"but the shape of input_ids is {model_input.input_tokens.shape}"
         )
-        decoder_kwargs = self.preprocess_for_decoder(
-            True, model_input.block_tables, input_ids, model_input.input_positions
-        )
+        prefill_inputs = self.prepare_prefill_inputs(model_input)
         prefill_kwargs = {
             "inputs_embeds": model_input.inputs_embeds,
             "position_embed": model_input.position_embed,
-            "block_tables": decoder_kwargs.pop("block_tables"),
-            "cache_position": decoder_kwargs.pop("cache_position"),
+            "block_tables": prefill_inputs.block_tables,
+            "cache_position": prefill_inputs.cache_position,
         }
         if model_input.visual_pos_mask is not None:
             prefill_kwargs["visual_pos_mask"] = model_input.visual_pos_mask
@@ -412,40 +409,27 @@ class RBLNOptimumQwen3_5ForConditionalGeneration(
         the batch out with the request at row == batch_idx, then gathers
         logits back to running order.
         """
-        input_ids = model_input.input_tokens
-        cache_position = model_input.input_positions
-        block_tables = model_input.block_tables
-
         if model_input.is_prompt:
             assert model_input.cache_slot_ids is not None
-            batch_idx = int(model_input.cache_slot_ids[0])
-            kw = self.preprocess_for_decoder(
-                True, block_tables, input_ids, cache_position
-            )
-            prefill_kwargs = {
-                "inputs_embeds": model_input.inputs_embeds,
-                "position_embed": model_input.position_embed,
-                "block_tables": kw.pop("block_tables"),
-                "cache_position": kw.pop("cache_position"),
-                "batch_idx": batch_idx,
-            }
-            return self.model.prefill_decoder(**prefill_kwargs).logits
+            prefill_inputs = self.prepare_prefill_inputs(model_input)
+            return self.model.prefill_decoder(
+                inputs_embeds=model_input.inputs_embeds,
+                position_embed=model_input.position_embed,
+                block_tables=prefill_inputs.block_tables,
+                cache_position=prefill_inputs.cache_position,
+                batch_idx=int(model_input.cache_slot_ids[0]),
+            ).logits
 
         batch_indices = self._decode_batch_indices(model_input)
-        kw = self.preprocess_for_decoder(
-            False,
-            block_tables,
-            input_ids,
-            cache_position,
-            input_block_ids=batch_indices,
+        decode_inputs = self.prepare_decode_inputs(
+            model_input, input_block_ids=batch_indices
         )
-        input_ids = kw.pop("input_ids")
-        inputs_embeds = self.model.embed_tokens(input_ids)
-        self.model.decoder = self.model.decoders[self.decoder_batch_size]
+        inputs_embeds = self.model.embed_tokens(decode_inputs.input_ids)
+        self.model.decoder = self.model.decoders[decode_inputs.padded_batch_size]
         logits = self.model.decoder(
             inputs_embeds=inputs_embeds,
-            cache_position=kw.pop("cache_position"),
+            cache_position=decode_inputs.cache_position,
             position_embed=model_input.position_embed,
-            block_tables=kw.pop("block_tables"),
+            block_tables=decode_inputs.block_tables,
         ).logits
         return logits[batch_indices]

--- a/vllm_rbln/model_executor/models/optimum/sliding_window.py
+++ b/vllm_rbln/model_executor/models/optimum/sliding_window.py
@@ -59,43 +59,31 @@ class RBLNOptimumSlidingWindowAttentionForCausalLM(
         self.is_hybrid = getattr(self.model.rbln_config, "cache_impl", None) == "hybrid"
 
     def forward(self, model_input: ModelInputForRBLN, **kwargs) -> torch.Tensor:
-        input_ids = model_input.input_tokens
-        cache_position = model_input.input_positions
-        block_tables = model_input.block_tables
         cache_slot_ids = model_input.cache_slot_ids
         assert cache_slot_ids is not None
+        request_nums = model_input.input_tokens.shape[0]
 
-        request_nums = input_ids.shape[0]
-        is_prompt = model_input.is_prompt
-
-        kwargs = self.preprocess_for_decoder(
-            is_prompt, block_tables, input_ids, cache_position
-        )
-
-        padded_batch_size = kwargs.pop("padded_batch_size", self.decoder_batch_size)
-        cache_position = kwargs.pop("cache_position")
-        input_ids = kwargs.pop("input_ids")
-        block_tables = kwargs.pop("block_tables")
-
-        if is_prompt:
+        if model_input.is_prompt:
             if self.model.prefill_decoder is None:
                 raise version_error
+            prefill_inputs = self.prepare_prefill_inputs(model_input)
             output = self.model.prefill_decoder(
-                input_ids=input_ids,
-                cache_position=cache_position,
+                input_ids=prefill_inputs.input_ids,
+                cache_position=prefill_inputs.cache_position,
                 local_block_tables=cache_slot_ids,
-                block_tables=block_tables if self.is_hybrid else None,
+                block_tables=prefill_inputs.block_tables if self.is_hybrid else None,
             )
             logits = output.logits
         else:
-            self.model.decoder = self.model.decoders[padded_batch_size]
+            decode_inputs = self.prepare_decode_inputs(
+                model_input, cache_slot_ids=cache_slot_ids
+            )
+            self.model.decoder = self.model.decoders[decode_inputs.padded_batch_size]
             logits = self.model.decoder(
-                input_ids=input_ids,
-                cache_position=cache_position,
-                local_block_tables=self.pad_cache_slot_ids(
-                    cache_slot_ids, padded_batch_size
-                ),
-                block_tables=block_tables if self.is_hybrid else None,
+                input_ids=decode_inputs.input_ids,
+                cache_position=decode_inputs.cache_position,
+                local_block_tables=decode_inputs.local_block_tables,
+                block_tables=decode_inputs.block_tables if self.is_hybrid else None,
             ).logits
             logits = logits[:request_nums]
         return logits

--- a/vllm_rbln/model_executor/models/optimum/whisper.py
+++ b/vllm_rbln/model_executor/models/optimum/whisper.py
@@ -212,7 +212,6 @@ class RBLNOptimumWhisperForConditionalGeneration(
     def forward(self, model_input: ModelInputForRBLN, **kwargs) -> torch.Tensor:
         input_ids = model_input.input_tokens
         block_tables = model_input.block_tables
-        request_nums = input_ids.shape[0]
         is_prompt = model_input.is_prompt
         valid_block_ids = block_tables.flatten().to(torch.int32)
 
@@ -280,19 +279,15 @@ class RBLNOptimumWhisperForConditionalGeneration(
             self.dec_lengths[batch_idx] = len(token_sequence)
 
         else:
-            cache_position = torch.zeros(request_nums, 1, dtype=torch.int32)
-            kwargs = self.preprocess_for_decoder(
-                is_prompt=False,
-                block_tables=block_tables,
-                input_ids=input_ids,
-                cache_position=cache_position,
+            decode_inputs = self.prepare_decode_inputs(
+                model_input,
                 input_block_ids=valid_block_ids,
                 dummy_block=model_input.dummy_block,
             )
-            decoder_cache_position = kwargs.pop("cache_position")
-            decoder_block_tables = kwargs.pop("block_tables")
-            decoder_input_ids = kwargs.pop("input_ids")
-            # Generate cache_position using dec_lengths
+            # Whisper tracks decoder positions itself in dec_lengths.
+            decoder_cache_position = torch.zeros(
+                decode_inputs.padded_batch_size, 1, dtype=torch.int32
+            )
             for batch_idx in valid_block_ids:
                 decoder_cache_position[batch_idx] = self.dec_lengths[batch_idx]
                 decoder_attention_mask[
@@ -300,10 +295,10 @@ class RBLNOptimumWhisperForConditionalGeneration(
                 ] = 1
                 self.dec_lengths[batch_idx] += 1
             decoder_output = self.model.decoder(
-                decoder_input_ids=decoder_input_ids.contiguous(),
+                decoder_input_ids=decode_inputs.input_ids.contiguous(),
                 decoder_attention_mask=decoder_attention_mask,
                 cache_position=decoder_cache_position,
-                block_tables=decoder_block_tables,
+                block_tables=decode_inputs.block_tables,
             )
 
         lm_logits = decoder_output.logits

--- a/vllm_rbln/v1/worker/ec_disagg_helpers.py
+++ b/vllm_rbln/v1/worker/ec_disagg_helpers.py
@@ -148,20 +148,12 @@ class ECDisaggHelpersMixin:
                 )
             cached_mm_outputs.append(self.encoder_cache[mm_hash])
 
-        input_ids = model_input.input_tokens
-        kwargs = self.model.preprocess_for_decoder(
-            True,
-            model_input.block_tables,
-            input_ids,
-            model_input.input_positions,
-        )
-        cache_position = kwargs.pop("cache_position")
-        block_tables = kwargs.pop("block_tables")
+        prefill_inputs = self.model.prepare_prefill_inputs(model_input)
 
         prefill_params = self.model.build_prefill_inputs_from_cache(
-            input_ids,
+            model_input.input_tokens,
             cached_mm_outputs,
-            cache_position=cache_position,
+            cache_position=prefill_inputs.cache_position,
             running_requests_ids=model_input.running_requests_ids,
             mrope_position_deltas=self.mrope_position_deltas,
             # Needed for partial prefix-cache hits: carries partial_prefix so the
@@ -175,7 +167,7 @@ class ECDisaggHelpersMixin:
         language_model = self.model.get_language_model()
         logits = language_model.prefill_decoder(
             **prefill_params,
-            block_tables=block_tables,
+            block_tables=prefill_inputs.block_tables,
         ).logits
         return logits
 

--- a/vllm_rbln/v1/worker/optimum_model_runner.py
+++ b/vllm_rbln/v1/worker/optimum_model_runner.py
@@ -660,7 +660,6 @@ class RBLNOptimumModelRunner(
             )
 
         seq_len = len(prompt_tokens)
-        input_positions = list(range(seq_len))
         num_blocks = num_blocks_per_req[req_index]
         # Full prompt tokens before any prefix-cache trim; needed by MRoPE
         # models to recompute positions over the whole prompt on a partial hit.
@@ -679,7 +678,6 @@ class RBLNOptimumModelRunner(
             total_cached_length = sum(cached_length)
             if total_cached_length > 0:
                 prompt_tokens = prompt_tokens[total_cached_length:]
-                input_positions = input_positions[total_cached_length:]
                 assert len(prompt_tokens) > 0, (
                     "The prompt tokens is empty after removing the cached tokens."
                 )
@@ -702,7 +700,9 @@ class RBLNOptimumModelRunner(
         )
 
         input_tokens = torch.tensor(prompt_tokens).unsqueeze(0)
-        input_positions = torch.tensor(input_positions).unsqueeze(0)
+        input_positions = torch.arange(
+            total_cached_length, seq_len, dtype=torch.int32
+        ).unsqueeze(0)
         block_table = block_table.unsqueeze(0)
         return (
             input_tokens,
@@ -743,8 +743,8 @@ class RBLNOptimumModelRunner(
                 block_tables_list.append(block_table)
             running_request_ids.append(req_id)
 
-        input_tokens = torch.tensor(input_tokens)
-        input_positions = torch.tensor(input_positions)
+        input_tokens = torch.tensor(input_tokens, dtype=torch.int64)
+        input_positions = torch.tensor(input_positions, dtype=torch.int32)
         block_tables = torch.stack(block_tables_list)
 
         return input_tokens, input_positions, block_tables, running_request_ids


### PR DESCRIPTION
## Summary

This PR simplifies how Optimum decoder models prepare inputs for compiled prefill and decode graphs.

Previously, decoder inputs were cast, padded, and unpacked through multiple helpers at every call site. This change introduces phase-specific, typed input preparation so each tensor is created once in the dtype and shape expected by the compiled graph.

## What Changed

### 1. Added phase-specific input preparation

`RBLNOptimumDecoderMixin` now provides:

- `prepare_prefill_inputs(model_input) -> PrefillInputs`
- `prepare_decode_inputs(model_input, ...) -> DecodeInputs`

Both methods return typed `NamedTuple`s that document the graph input contract.

This replaces:

- `preprocess_for_decoder`
- `pad_decoder_items`
- `pad_cache_slot_ids`
- Dictionary-based return values and repeated `pop()` calls

Each model already branches on `model_input.is_prompt`, so input preparation now follows the same explicit prefill/decode structure.

### 2. Reduced decode padding allocations

Decode buffers are allocated directly with their final shapes and dtypes:

| Input | Dtype |
|---|---|
| `input_ids` | `torch.int64` |
| `cache_position` | `torch.int32` |
| `block_tables` | `torch.int16` |
| `local_block_tables` | `torch.int16` |

Additional improvements:

- Block tables are initialized with the padding block, removing the full-size boolean mask.
- Cache slot IDs are padded within `prepare_decode_inputs`.
- Sliding-window and hybrid models no longer require a separate cache-slot padding call.
- Padding rows continue to use `dummy_block` when provided, or an unused block otherwise.
- Cache-slot padding uses the lowest slot not owned by a scheduled request.

### 3. Updated the model runner to emit final dtypes

The runner now creates tensors directly in the graph-compatible dtype:

- Prefill positions use `torch.arange(..., dtype=torch.int32)`.
- Decode tokens use `torch.int64`.
- Decode positions use `torch.int32`.

This removes redundant conversions from the model execution path. Block tables remain the only decode input requiring a conversion because vLLM provides them as `int32`.

### 4. Migrated Optimum model call sites

Optimum decoder models now consume `PrefillInputs` or `DecodeInputs` directly, including:

- Decoder-only models
- BLIP-2
- EXAONE-4.5
- Gemma 3
- Idefics 3
- LLaVA and LLaVA-Next
- PaliGemma
- Qwen2-VL and Qwen3-VL
- Sliding-window and hybrid-cache models
- Whisper
- EC disaggregation helpers

The `ModelInputForRBLN` and runner-to-model interfaces remain unchanged.

## Additional Fixes

### EXAONE-4.5 EC hook

Renamed the EXAONE-4.5 EC stub from:

```python
build_prefill_inputs
```

to:

```python
build_prefill_inputs_from_cache
```

The previous method name did not match the hook invoked by the EC helper, causing the model to fall through to the base implementation.

### Gemma 3 attention helper

Renamed:

```python
MultimodalHybridAttentionStateManager.build_decode_inputs
```

to:

```python
build_decode_attention_inputs
```

This distinguishes attention-state preparation from the new decoder graph input preparation.

## Scope and Follow-up

Padding remains in the model layer for now. Moving it into the runner requires model-specific batch layout handling, including:

- Qwen3.5 row placement using `cache_slot_ids`
- Whisper per-step prefill behavior
- Gemma 3 padding-length offsets

This can be handled in a follow-up change.

## Testing

Run:

```bash
uv run --no-sync pytest \
  tests/optimum/v1/models/optimum/ \
  tests/optimum/v1/worker/test_optimum_model_runner.py \
  -q
```

Expected result:

```text
42 passed
```

The updated tests directly cover:

- Decode input preparation
- Cache-slot padding without aliasing scheduled requests
- Row scattering through `input_block_ids`
- Gemma 3 hybrid attention state
- Optimum model runner behavior

Run pre-commit checks with:

```bash
uvx pre-commit run --files <changed files>
```

All hooks pass except for a pre-existing `mypy-local` error in `model_base.py`:

```text
Need type annotation for "tail_starts"
```

This error is also present on the `dev` branch and is unrelated to this PR.

## Validation Required

No NPU end-to-end test has been run.

Unit tests cover the decoder mixin, runner, Gemma 3, and Qwen3.5. The following paths still require device-level validation before merge:

- EXAONE-4.5
- Whisper
- LLaVA and LLaVA-Next
- PaliGemma
- Idefics 3
- BLIP-2
- EC consumer path

## Type of Change

- [x] Refactor / code cleanup

## Checklist

- [x] PR title follows Conventional Commits
- [x] Test method and expected result are documented
- [ ] Linked to an existing issue
- [ ] Relevant documentation updated, if applicable
- [ ] NPU end-to-end validation completed