### PR TITLE
fix(worker): index the device env var as a pool and rename it to RBLN_VISIBLE_DEVICES

### DIFF
--- a/.buildkite/pipelines/vllm-rbln/scripts/lane.py
+++ b/.buildkite/pipelines/vllm-rbln/scripts/lane.py
@@ -30,6 +30,7 @@ _RSD_ENV = "VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"
 _PARALLEL_KEYS = (
     "tensor_parallel_size",
     "pipeline_parallel_size",
+    "prefill_context_parallel_size",
     "data_parallel_size",
 )
 
@@ -49,15 +50,18 @@ def host_chip() -> str | None:
 
 
 def device_count() -> int:
-    """NPUs this run may use. RBLN_DEVICES wins when set, since a job may be
-    given some of them."""
-    visible = [d for d in os.environ.get("RBLN_DEVICES", "").split(",") if d.strip()]
+    """NPUs this run may use. The visible list wins when set, since a job may be
+    given some of them. Both spellings are read because this runs before the
+    platform plugin folds the deprecated one into the other."""
+    visible_list = os.environ.get("RBLN_VISIBLE_DEVICES", "")
+    raw = visible_list or os.environ.get("RBLN_DEVICES", "")
+    visible = [d for d in raw.split(",") if d.strip()]
     return len(visible) or len(glob.glob("/dev/rbln*"))
 
 
 def devices_needed(serve: dict[str, Any], env: dict[str, str]) -> int:
-    """Mirrors RBLNWorker._init_device_env: DP ranks do not share, and every
-    (tp x pp) rank takes VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK devices."""
+    """Mirrors RBLNWorker._init_device_env: DP ranks do not share, and every rank
+    of vLLM's world size takes VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK devices."""
     needed = int(env.get(_RSD_ENV, 1))
     for key in _PARALLEL_KEYS:
         needed *= int(serve.get(key, 1))

--- a/examples/experimental/qwen3_data_parallel.py
+++ b/examples/experimental/qwen3_data_parallel.py
@@ -66,7 +66,7 @@ def main(
 
     # CUDA_VISIBLE_DEVICES for each DP rank is set automatically inside the
     # engine processes.
-    os.environ["RBLN_DEVICES"] = str(local_dp_rank + 2)
+    os.environ["RBLN_VISIBLE_DEVICES"] = str(local_dp_rank + 2)
 
     # Sample prompts.
     prompts = [

--- a/examples/optimum/ec_disagg/serve_ec_encoder.sh
+++ b/examples/optimum/ec_disagg/serve_ec_encoder.sh
@@ -41,7 +41,7 @@ launch_encoder() {
     local port=$((BASE_PORT + idx))
 
     echo "Starting encoder $idx (device=$device, port=$port, push→$LLM_HOST:$LLM_PULL_PORT)"
-    RBLN_DEVICES=$device vllm serve "$MODEL_ID" \
+    RBLN_VISIBLE_DEVICES=$device vllm serve "$MODEL_ID" \
         --port "$port" \
         --mm-processor-kwargs '{"max_pixels": 802816}' \
         --ec-transfer-config "{

--- a/examples/optimum/ec_disagg/serve_ec_llm.sh
+++ b/examples/optimum/ec_disagg/serve_ec_llm.sh
@@ -25,7 +25,7 @@ PULL_PORT="${PULL_PORT:-16100}"
 # LLM devices
 LLM_DEVICES="${LLM_DEVICES:-22,23,24,25,26,27,28,29}"
 
-export RBLN_DEVICES=$LLM_DEVICES
+export RBLN_VISIBLE_DEVICES=$LLM_DEVICES
 exec vllm serve "$MODEL_ID" \
     --port "$PORT" \
     --mm-processor-kwargs '{"max_pixels": 802816}' \

--- a/tests/native/test_platform.py
+++ b/tests/native/test_platform.py
@@ -123,7 +123,7 @@ class TestPlatformIdentity:
             # Ops dispatch on CPU even when tensors live on the device.
             ("dispatch_key", "CPU"),
             # RBLNWorker._init_device_env narrows this var per rank.
-            ("device_control_env_var", "RBLN_DEVICES"),
+            ("device_control_env_var", "RBLN_VISIBLE_DEVICES"),
             ("simple_compile_backend", "bypass"),
         ],
     )
@@ -560,6 +560,46 @@ class TestPreRegisterAndUpdate:
         before = EngineArgs.get_batch_defaults.__func__
         RblnPlatform.pre_register_and_update()
         assert EngineArgs.get_batch_defaults.__func__ is before
+
+
+class TestDeprecatedDeviceControlEnvVar:
+    """``RBLN_DEVICES`` is folded into ``device_control_env_var`` and unset.
+
+    Unsetting is the point: the runtime takes both names but prefers the
+    deprecated one, so one left behind would override the pool a worker
+    narrows itself to.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolated_env(self):
+        # patch.dict, not monkeypatch.delenv: the code under test creates the
+        # current name, and a key a test never held is not restored.
+        with patch.dict(os.environ):
+            os.environ.pop("RBLN_DEVICES", None)
+            os.environ.pop(RblnPlatform.device_control_env_var, None)
+            yield
+
+    def test_legacy_value_carries_over_and_the_name_goes(self):
+        os.environ["RBLN_DEVICES"] = "4,5"
+
+        RblnPlatform.pre_register_and_update()
+
+        assert os.environ[RblnPlatform.device_control_env_var] == "4,5"
+        assert "RBLN_DEVICES" not in os.environ
+
+    def test_the_current_name_wins_when_both_are_set(self):
+        os.environ["RBLN_DEVICES"] = "4,5"
+        os.environ[RblnPlatform.device_control_env_var] = "6,7"
+
+        RblnPlatform.pre_register_and_update()
+
+        assert os.environ[RblnPlatform.device_control_env_var] == "6,7"
+        assert "RBLN_DEVICES" not in os.environ
+
+    def test_nothing_is_invented_when_neither_is_set(self):
+        RblnPlatform.pre_register_and_update()
+
+        assert RblnPlatform.device_control_env_var not in os.environ
 
 
 class TestCustomKvCacheSpecs:

--- a/tests/native/test_utils.py
+++ b/tests/native/test_utils.py
@@ -102,23 +102,32 @@ def test_extra_entries_are_real_additions():
 def test_native_env_pins_no_host_description():
     """The suite may pin behavior, never machine identity: pinning the device
     list or the SOC would hard-code one host's topology."""
-    host_description = {"RBLN_DEVICES", "RBLN_FORCE_NPU_NAME", "RBLN_TARGET_SOC"}
+    host_description = {
+        "RBLN_VISIBLE_DEVICES",
+        "RBLN_DEVICES",
+        "RBLN_FORCE_NPU_NAME",
+        "RBLN_TARGET_SOC",
+    }
     assert not (set(NATIVE_ENV) & host_description)
 
 
 class TestDeviceInventory:
     """The guard that keeps a multi-device test off a host with too few NPUs."""
 
-    def test_visible_list_wins_over_the_nodes(self, monkeypatch):
-        monkeypatch.setenv("RBLN_DEVICES", "3,4")
+    @pytest.mark.parametrize("name", ["RBLN_VISIBLE_DEVICES", "RBLN_DEVICES"])
+    def test_visible_list_wins_over_the_nodes(self, monkeypatch, name):
+        # The deprecated name counts too: this helper runs in the parent pytest
+        # process, before the platform plugin folds one name into the other.
+        monkeypatch.setenv(name, "3,4")
         assert rbln_device_count() == 2
 
     @pytest.mark.parametrize("blank", ["", " "])
     def test_blank_visible_list_falls_back_to_the_nodes(self, monkeypatch, blank):
         # Read as zero it would skip every device test on a host that has them.
+        monkeypatch.delenv("RBLN_VISIBLE_DEVICES", raising=False)
         monkeypatch.delenv("RBLN_DEVICES", raising=False)
         mounted = rbln_device_count()
-        monkeypatch.setenv("RBLN_DEVICES", blank)
+        monkeypatch.setenv("RBLN_VISIBLE_DEVICES", blank)
         assert rbln_device_count() == mounted
 
     @pytest.mark.parametrize(

--- a/tests/native/utils.py
+++ b/tests/native/utils.py
@@ -228,23 +228,24 @@ _RBLN_DEVICE_NODES = "/dev/rbln*"
 
 
 def rbln_device_count() -> int:
-    """How many NPUs this session may use. ``RBLN_DEVICES`` wins when set, since a
-    job may be given two of eight. Otherwise the device nodes are counted rather
+    """How many NPUs this session may use. The visible list wins when set, since
+    a job may be given two of eight. Otherwise the device nodes are counted rather
     than asking the driver: this runs in the parent pytest process, which must not
-    open the device (that would pin it for the whole session)."""
-    visible = [
-        entry
-        for entry in os.environ.get("RBLN_DEVICES", "").split(",")
-        if entry.strip()
-    ]
+    open the device (that would pin it for the whole session).
+
+    Both spellings are read because this runs before the platform plugin folds
+    the deprecated one into the other."""
+    visible_list = os.environ.get("RBLN_VISIBLE_DEVICES", "")
+    raw = visible_list or os.environ.get("RBLN_DEVICES", "")
+    visible = [entry for entry in raw.split(",") if entry.strip()]
     # Exported but empty means "no restriction", not "no devices".
     return len(visible) or len(glob.glob(_RBLN_DEVICE_NODES))
 
 
 def devices_needed(engine_kwargs: dict, rsd: int = 1) -> int:
     """NPUs an engine built with ``engine_kwargs`` will occupy. Mirrors
-    RBLNWorker._init_device_env: DP ranks do not share, and every (tp x pp) rank
-    takes ``rsd`` devices.
+    RBLNWorker._init_device_env: DP ranks do not share, and every rank of
+    vLLM's world size takes ``rsd`` devices.
 
     ``rsd`` is a spec's ``CompileModelSpec.rsd``, i.e. the
     VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK the engine will run with. It is an
@@ -255,6 +256,7 @@ def devices_needed(engine_kwargs: dict, rsd: int = 1) -> int:
     return (
         engine_kwargs.get("tensor_parallel_size", 1)
         * engine_kwargs.get("pipeline_parallel_size", 1)
+        * engine_kwargs.get("prefill_context_parallel_size", 1)
         * engine_kwargs.get("data_parallel_size", 1)
         * rsd
     )

--- a/tests/native/v1/worker/test_rbln_worker.py
+++ b/tests/native/v1/worker/test_rbln_worker.py
@@ -92,7 +92,7 @@ def _env_cleanup(monkeypatch):
     monkeypatch.setattr(platform_interface, "_assigned_physical_gpu_ids", None)
     # Save/restore the process env vars the worker touches.
     keys = [
-        "RBLN_DEVICES",
+        "RBLN_VISIBLE_DEVICES",
         "RBLN_NPUS_PER_DEVICE",
         "LOCAL_RANK",
         "WORLD_SIZE",
@@ -145,7 +145,9 @@ def make_worker(monkeypatch):
             "current_platform",
             SimpleNamespace(
                 device_type="cpu",
-                device_control_env_var="RBLN_DEVICES",
+                # Not a literal: device_id_to_physical_device_id below reads it
+                # off RblnPlatform, so the two must not drift apart.
+                device_control_env_var=RblnPlatform.device_control_env_var,
                 dist_backend="gloo",
                 get_device_name=lambda: device_name,
                 # The real mapping: the pool semantics under test are upstream's.
@@ -233,51 +235,51 @@ class TestInitDeviceEnv:
 
     def test_unset_pool_is_the_whole_host(self, make_worker):
         make_worker(world_size=1)
-        assert os.environ["RBLN_DEVICES"] == "0"
+        assert os.environ["RBLN_VISIBLE_DEVICES"] == "0"
 
     @pytest.mark.parametrize("local_rank, expected", [(0, "0"), (1, "1")])
     def test_unset_pool_indexes_by_local_rank(self, make_worker, local_rank, expected):
         make_worker(world_size=4, local_rank=local_rank)
-        assert os.environ["RBLN_DEVICES"] == expected
+        assert os.environ["RBLN_VISIBLE_DEVICES"] == expected
 
     def test_dp_rank_alone_does_not_offset(self, make_worker):
         # data_parallel_rank is reset to 0 for non-MoE DP, so deriving the
         # offset from it put every replica on the same NPU.
         make_worker(world_size=1, data_parallel_size=4, data_parallel_rank=3)
-        assert os.environ["RBLN_DEVICES"] == "0"
+        assert os.environ["RBLN_VISIBLE_DEVICES"] == "0"
 
     def test_pool_indexes_by_local_rank(self, make_worker):
-        os.environ["RBLN_DEVICES"] = "4,5,6,7"
+        os.environ["RBLN_VISIBLE_DEVICES"] = "4,5,6,7"
         make_worker(world_size=4, local_rank=1)
-        assert os.environ["RBLN_DEVICES"] == "5"
+        assert os.environ["RBLN_VISIBLE_DEVICES"] == "5"
 
     def test_pool_larger_than_needed_is_allowed(self, make_worker):
-        os.environ["RBLN_DEVICES"] = "0,1,2,3"
+        os.environ["RBLN_VISIBLE_DEVICES"] = "0,1,2,3"
         make_worker(world_size=2, local_rank=1)
-        assert os.environ["RBLN_DEVICES"] == "1"
+        assert os.environ["RBLN_VISIBLE_DEVICES"] == "1"
 
     def test_exported_but_empty_pool_means_no_restriction(self, make_worker):
-        os.environ["RBLN_DEVICES"] = ""
+        os.environ["RBLN_VISIBLE_DEVICES"] = ""
         make_worker(world_size=2, local_rank=1)
-        assert os.environ["RBLN_DEVICES"] == "1"
+        assert os.environ["RBLN_VISIBLE_DEVICES"] == "1"
 
     def test_trailing_separator_tolerated(self, make_worker):
-        os.environ["RBLN_DEVICES"] = "3,"
+        os.environ["RBLN_VISIBLE_DEVICES"] = "3,"
         make_worker(world_size=1)
-        assert os.environ["RBLN_DEVICES"] == "3"
+        assert os.environ["RBLN_VISIBLE_DEVICES"] == "3"
 
     def test_pool_too_small_names_the_pool(self, make_worker):
-        os.environ["RBLN_DEVICES"] = "0,1"
-        with pytest.raises(ValueError, match="RBLN_DEVICES='0,1'"):
+        os.environ["RBLN_VISIBLE_DEVICES"] = "0,1"
+        with pytest.raises(ValueError, match="RBLN_VISIBLE_DEVICES='0,1'"):
             make_worker(world_size=4, local_rank=2)
 
     def test_ray_nodes_divide_what_this_node_must_cover(self, make_worker):
-        os.environ["RBLN_DEVICES"] = "0,1"
+        os.environ["RBLN_VISIBLE_DEVICES"] = "0,1"
         make_worker(world_size=4, num_ray_nodes=2, local_rank=1)
-        assert os.environ["RBLN_DEVICES"] == "1"
+        assert os.environ["RBLN_VISIBLE_DEVICES"] == "1"
 
     def test_non_integer_entry_raises(self, make_worker):
-        os.environ["RBLN_DEVICES"] = "a,b,c,d"
+        os.environ["RBLN_VISIBLE_DEVICES"] = "a,b,c,d"
         with pytest.raises(ValueError):
             make_worker(world_size=4, local_rank=0)
 
@@ -295,23 +297,23 @@ class TestInitDeviceEnv:
     ):
         # A rank's group is enumerated, not derived by multiplying its entry,
         # which reached past the pool the job was given.
-        os.environ["RBLN_DEVICES"] = pool
+        os.environ["RBLN_VISIBLE_DEVICES"] = pool
         make_worker(
             world_size=world_size, num_devices=num_devices, local_rank=local_rank
         )
-        assert os.environ["RBLN_DEVICES"] == expected
+        assert os.environ["RBLN_VISIBLE_DEVICES"] == expected
 
     @pytest.mark.parametrize("local_rank, expected", [(0, "0,1"), (1, "2,3")])
     def test_unset_pool_with_rsd(self, make_worker, local_rank, expected):
         make_worker(
             world_size=2, num_devices=2, has_torch_rbln=True, local_rank=local_rank
         )
-        assert os.environ["RBLN_DEVICES"] == expected
+        assert os.environ["RBLN_VISIBLE_DEVICES"] == expected
         assert os.environ["RBLN_NPUS_PER_DEVICE"] == "2"
 
     def test_multi_device_without_torch_rbln_skips_npus(self, make_worker):
         make_worker(world_size=2, num_devices=2, has_torch_rbln=False)
-        assert os.environ["RBLN_DEVICES"] == "0,1"
+        assert os.environ["RBLN_VISIBLE_DEVICES"] == "0,1"
         assert "RBLN_NPUS_PER_DEVICE" not in os.environ
 
     def test_single_device_skips_npus(self, make_worker):
@@ -325,17 +327,17 @@ class TestInitDeviceEnv:
             data_parallel_rank=3,
             assigned_physical_gpu_ids=[3],
         )
-        assert os.environ["RBLN_DEVICES"] == "3"
+        assert os.environ["RBLN_VISIBLE_DEVICES"] == "3"
 
     def test_dp_mapping_wins_over_pool_position(self, make_worker):
-        os.environ["RBLN_DEVICES"] = "4,5,6,7"
+        os.environ["RBLN_VISIBLE_DEVICES"] = "4,5,6,7"
         make_worker(world_size=1, data_parallel_size=4, assigned_physical_gpu_ids=[6])
-        assert os.environ["RBLN_DEVICES"] == "6"
+        assert os.environ["RBLN_VISIBLE_DEVICES"] == "6"
 
     def test_dp_mapping_with_rsd_raises(self, make_worker):
         # vLLM's slicer has no notion of rsd, so it hands over one entry per
         # rank where this rank needs num_devices of them.
-        os.environ["RBLN_DEVICES"] = "0,1,2,3"
+        os.environ["RBLN_VISIBLE_DEVICES"] = "0,1,2,3"
         with pytest.raises(ValueError, match="needs 2 NPU"):
             make_worker(
                 world_size=1,

--- a/tests/native/v1/worker/test_rbln_worker.py
+++ b/tests/native/v1/worker/test_rbln_worker.py
@@ -120,7 +120,6 @@ def make_worker(monkeypatch):
         world_size_across_dp=None,
         assigned_physical_gpu_ids=None,
         num_devices=1,
-        num_ray_nodes=1,
         has_torch_rbln=False,
         device_name="RBLN-CA25",
         vllm_config=None,
@@ -159,7 +158,6 @@ def make_worker(monkeypatch):
         monkeypatch.setattr(
             wm.envs, "VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK", num_devices
         )
-        monkeypatch.setattr(wm.envs, "VLLM_RBLN_NUM_RAY_NODES", num_ray_nodes)
         monkeypatch.setattr(wm, "has_torch_rbln", has_torch_rbln)
         return RBLNWorker(
             vllm_config=vllm_config,
@@ -272,11 +270,6 @@ class TestInitDeviceEnv:
         os.environ["RBLN_VISIBLE_DEVICES"] = "0,1"
         with pytest.raises(ValueError, match="RBLN_VISIBLE_DEVICES='0,1'"):
             make_worker(world_size=4, local_rank=2)
-
-    def test_ray_nodes_divide_what_this_node_must_cover(self, make_worker):
-        os.environ["RBLN_VISIBLE_DEVICES"] = "0,1"
-        make_worker(world_size=4, num_ray_nodes=2, local_rank=1)
-        assert os.environ["RBLN_VISIBLE_DEVICES"] == "1"
 
     def test_non_integer_entry_raises(self, make_worker):
         os.environ["RBLN_VISIBLE_DEVICES"] = "a,b,c,d"

--- a/tests/native/v1/worker/test_rbln_worker.py
+++ b/tests/native/v1/worker/test_rbln_worker.py
@@ -24,11 +24,13 @@ from unittest.mock import patch
 
 import pytest
 import torch
+import vllm.platforms.interface as platform_interface
 from torch._dynamo.exc import BackendCompilerFailed
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorBase_V1
 from vllm.v1.worker.worker_base import CompilationTimes, WorkerBase
 
 import vllm_rbln.v1.worker.rbln_worker as wm
+from vllm_rbln.platform import RblnPlatform
 from vllm_rbln.v1.worker.rbln_worker import (
     RBLNWorker,
     init_worker_distributed_environment,
@@ -84,7 +86,10 @@ def _fake_super_init(
 
 
 @pytest.fixture(autouse=True)
-def _env_cleanup():
+def _env_cleanup(monkeypatch):
+    # The logical-to-physical mapping is process-global and refuses a second,
+    # conflicting publish, so one test's DP mapping would fail the next.
+    monkeypatch.setattr(platform_interface, "_assigned_physical_gpu_ids", None)
     # Save/restore the process env vars the worker touches.
     keys = [
         "RBLN_DEVICES",
@@ -143,6 +148,10 @@ def make_worker(monkeypatch):
                 device_control_env_var="RBLN_DEVICES",
                 dist_backend="gloo",
                 get_device_name=lambda: device_name,
+                # The real mapping: the pool semantics under test are upstream's.
+                device_id_to_physical_device_id=(
+                    RblnPlatform.device_id_to_physical_device_id
+                ),
             ),
         )
         monkeypatch.setattr(
@@ -216,29 +225,84 @@ class TestConformance:
 
 
 class TestInitDeviceEnv:
-    def test_auto_tp1(self, make_worker):
+    """The env var is a pool of NPUs to index into, one entry per NPU.
+
+    A rank takes ``VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK`` consecutive entries
+    starting at ``local_rank`` times that count.
+    """
+
+    def test_unset_pool_is_the_whole_host(self, make_worker):
         make_worker(world_size=1)
         assert os.environ["RBLN_DEVICES"] == "0"
 
     @pytest.mark.parametrize("local_rank, expected", [(0, "0"), (1, "1")])
-    def test_auto_slices_by_local_rank(self, make_worker, local_rank, expected):
+    def test_unset_pool_indexes_by_local_rank(self, make_worker, local_rank, expected):
         make_worker(world_size=4, local_rank=local_rank)
         assert os.environ["RBLN_DEVICES"] == expected
 
-    def test_auto_dp_rank_offsets_range(self, make_worker):
-        # dp_rank=1, tp=2 -> device range starts at total_device_count(2).
-        make_worker(
-            world_size=2, data_parallel_size=2, data_parallel_rank=1, local_rank=0
-        )
-        assert os.environ["RBLN_DEVICES"] == "2"
-
-    def test_auto_ray_nodes_divide_world_size(self, make_worker):
-        # world_size 4 // 2 ray nodes -> effective 2 devices.
-        make_worker(world_size=4, num_ray_nodes=2, local_rank=0)
+    def test_dp_rank_alone_does_not_offset(self, make_worker):
+        # data_parallel_rank is reset to 0 for non-MoE DP, so deriving the
+        # offset from it put every replica on the same NPU.
+        make_worker(world_size=1, data_parallel_size=4, data_parallel_rank=3)
         assert os.environ["RBLN_DEVICES"] == "0"
 
+    def test_pool_indexes_by_local_rank(self, make_worker):
+        os.environ["RBLN_DEVICES"] = "4,5,6,7"
+        make_worker(world_size=4, local_rank=1)
+        assert os.environ["RBLN_DEVICES"] == "5"
+
+    def test_pool_larger_than_needed_is_allowed(self, make_worker):
+        os.environ["RBLN_DEVICES"] = "0,1,2,3"
+        make_worker(world_size=2, local_rank=1)
+        assert os.environ["RBLN_DEVICES"] == "1"
+
+    def test_exported_but_empty_pool_means_no_restriction(self, make_worker):
+        os.environ["RBLN_DEVICES"] = ""
+        make_worker(world_size=2, local_rank=1)
+        assert os.environ["RBLN_DEVICES"] == "1"
+
+    def test_trailing_separator_tolerated(self, make_worker):
+        os.environ["RBLN_DEVICES"] = "3,"
+        make_worker(world_size=1)
+        assert os.environ["RBLN_DEVICES"] == "3"
+
+    def test_pool_too_small_names_the_pool(self, make_worker):
+        os.environ["RBLN_DEVICES"] = "0,1"
+        with pytest.raises(ValueError, match="RBLN_DEVICES='0,1'"):
+            make_worker(world_size=4, local_rank=2)
+
+    def test_ray_nodes_divide_what_this_node_must_cover(self, make_worker):
+        os.environ["RBLN_DEVICES"] = "0,1"
+        make_worker(world_size=4, num_ray_nodes=2, local_rank=1)
+        assert os.environ["RBLN_DEVICES"] == "1"
+
+    def test_non_integer_entry_raises(self, make_worker):
+        os.environ["RBLN_DEVICES"] = "a,b,c,d"
+        with pytest.raises(ValueError):
+            make_worker(world_size=4, local_rank=0)
+
+    @pytest.mark.parametrize(
+        "pool, world_size, num_devices, local_rank, expected",
+        [
+            ("1,2", 1, 2, 0, "1,2"),
+            ("0,1,2,3,4,5,6,7", 2, 4, 0, "0,1,2,3"),
+            ("0,1,2,3,4,5,6,7", 2, 4, 1, "4,5,6,7"),
+            ("4,5,6,7", 2, 2, 1, "6,7"),
+        ],
+    )
+    def test_rsd_takes_consecutive_entries(
+        self, make_worker, pool, world_size, num_devices, local_rank, expected
+    ):
+        # A rank's group is enumerated, not derived by multiplying its entry,
+        # which reached past the pool the job was given.
+        os.environ["RBLN_DEVICES"] = pool
+        make_worker(
+            world_size=world_size, num_devices=num_devices, local_rank=local_rank
+        )
+        assert os.environ["RBLN_DEVICES"] == expected
+
     @pytest.mark.parametrize("local_rank, expected", [(0, "0,1"), (1, "2,3")])
-    def test_multi_device_slices_and_sets_npus(self, make_worker, local_rank, expected):
+    def test_unset_pool_with_rsd(self, make_worker, local_rank, expected):
         make_worker(
             world_size=2, num_devices=2, has_torch_rbln=True, local_rank=local_rank
         )
@@ -254,57 +318,31 @@ class TestInitDeviceEnv:
         make_worker(world_size=1, num_devices=1, has_torch_rbln=True)
         assert "RBLN_NPUS_PER_DEVICE" not in os.environ
 
-    def test_explicit_expands_device_id_for_local_rank(self, make_worker):
-        # Preset device list: local_rank 1 -> device_id 5 -> expanded to "5".
-        os.environ["RBLN_DEVICES"] = "4,5,6,7"
-        make_worker(world_size=4, local_rank=1)
-        assert os.environ["RBLN_DEVICES"] == "5"
-
-    def test_explicit_wrong_count_raises(self, make_worker):
-        os.environ["RBLN_DEVICES"] = "0,1"
-        with pytest.raises(AssertionError):
-            make_worker(world_size=4)
-
-    def test_explicit_non_int_raises(self, make_worker):
-        os.environ["RBLN_DEVICES"] = "a,b,c,d"
-        with pytest.raises(ValueError):
-            make_worker(world_size=4, local_rank=0)
-
-    @pytest.mark.parametrize("dp_rank, assigned", [(0, [4]), (2, [6])])
-    def test_dp_mapping_wins_over_env(self, make_worker, dp_rank, assigned):
-        # Under DP the env var holds the whole deployment; vLLM 0.24 puts this
-        # rank's share on the config instead.
-        os.environ["RBLN_DEVICES"] = "4,5,6,7"
+    def test_dp_mapping_carries_the_offset(self, make_worker):
         make_worker(
             world_size=1,
             data_parallel_size=4,
-            data_parallel_rank=dp_rank,
-            assigned_physical_gpu_ids=assigned,
+            data_parallel_rank=3,
+            assigned_physical_gpu_ids=[3],
         )
-        assert os.environ["RBLN_DEVICES"] == str(assigned[0])
+        assert os.environ["RBLN_DEVICES"] == "3"
 
-    def test_dp_mapping_expands_by_num_devices(self, make_worker):
-        os.environ["RBLN_DEVICES"] = "0,1,2,3"
-        make_worker(
-            world_size=2,
-            data_parallel_size=2,
-            data_parallel_rank=1,
-            assigned_physical_gpu_ids=[2, 3],
-            num_devices=2,
-            local_rank=1,
-        )
-        assert os.environ["RBLN_DEVICES"] == "6,7"
-
-    def test_no_mapping_falls_back_to_env(self, make_worker):
-        os.environ["RBLN_DEVICES"] = "0,1"
-        make_worker(world_size=2, data_parallel_size=2, data_parallel_rank=1)
-        assert os.environ["RBLN_DEVICES"] == "0"
-
-    def test_dp_mapping_wrong_count_raises(self, make_worker):
+    def test_dp_mapping_wins_over_pool_position(self, make_worker):
         os.environ["RBLN_DEVICES"] = "4,5,6,7"
-        with pytest.raises(AssertionError):
+        make_worker(world_size=1, data_parallel_size=4, assigned_physical_gpu_ids=[6])
+        assert os.environ["RBLN_DEVICES"] == "6"
+
+    def test_dp_mapping_with_rsd_raises(self, make_worker):
+        # vLLM's slicer has no notion of rsd, so it hands over one entry per
+        # rank where this rank needs num_devices of them.
+        os.environ["RBLN_DEVICES"] = "0,1,2,3"
+        with pytest.raises(ValueError, match="needs 2 NPU"):
             make_worker(
-                world_size=1, data_parallel_size=4, assigned_physical_gpu_ids=[4, 5]
+                world_size=1,
+                data_parallel_size=2,
+                data_parallel_rank=1,
+                assigned_physical_gpu_ids=[1],
+                num_devices=2,
             )
 
 

--- a/tests/native/v1/worker/test_utils.py
+++ b/tests/native/v1/worker/test_utils.py
@@ -1038,13 +1038,13 @@ class TestReplicationFactorIsGated:
 # ---------------------------------------------------------------------------
 class TestRblnSysfsReaders:
     def test_visible_indices_from_env(self):
-        with patch.dict(os.environ, {"RBLN_DEVICES": "2,0,1"}):
+        with patch.dict(os.environ, {"RBLN_VISIBLE_DEVICES": "2,0,1"}):
             assert get_rbln_visible_card_indices() == [0, 1, 2]
 
     def test_owned_indices_resolve_container_local_numbering(self, tmp_path):
-        """`RBLN_DEVICES` indexes the container's devices, not sysfs card names.
+        """`RBLN_VISIBLE_DEVICES` indexes the container's devices, not sysfs card names.
 
-        Measured on a container exposing /dev/rbln4..7: `RBLN_DEVICES=4,5,6,7`
+        Measured on a container exposing /dev/rbln4..7: `RBLN_VISIBLE_DEVICES=4,5,6,7`
         enumerates zero logical devices, `0,1,2,3` works, and holding `rbln:0`
         there put the context on physical rbln4. So entry `i` is the `i`-th
         present device and must not be used as a sysfs name.
@@ -1052,7 +1052,7 @@ class TestRblnSysfsReaders:
         for index in (4, 5, 6, 7):
             (tmp_path / f"rbln{index}").touch()
         with (
-            patch.dict(os.environ, {"RBLN_DEVICES": "0,1,2,3"}),
+            patch.dict(os.environ, {"RBLN_VISIBLE_DEVICES": "0,1,2,3"}),
             patch("vllm_rbln.v1.worker.utils.RBLN_DEV_DIR", str(tmp_path)),
         ):
             assert get_rbln_owned_card_indices() == [4, 5, 6, 7]
@@ -1063,7 +1063,7 @@ class TestRblnSysfsReaders:
         for index in (4, 5, 6, 7):
             (tmp_path / f"rbln{index}").touch()
         with (
-            patch.dict(os.environ, {"RBLN_DEVICES": "4,5,6,7"}),
+            patch.dict(os.environ, {"RBLN_VISIBLE_DEVICES": "4,5,6,7"}),
             patch("vllm_rbln.v1.worker.utils.RBLN_DEV_DIR", str(tmp_path)),
         ):
             assert get_rbln_owned_card_indices() == [4, 5, 6, 7]
@@ -1072,7 +1072,7 @@ class TestRblnSysfsReaders:
         """No /dev/rbln* (unit env, host without the driver) keeps the previous
         behaviour exactly rather than guessing."""
         with (
-            patch.dict(os.environ, {"RBLN_DEVICES": "1,2"}),
+            patch.dict(os.environ, {"RBLN_VISIBLE_DEVICES": "1,2"}),
             patch("vllm_rbln.v1.worker.utils.RBLN_DEV_DIR", str(tmp_path)),
         ):
             assert get_rbln_owned_card_indices() == [1, 2]
@@ -1097,7 +1097,7 @@ class TestRblnSysfsReaders:
             card.mkdir()
             (card / "dram_used").write_text("0\n")
         with (
-            patch.dict(os.environ, {"RBLN_DEVICES": "0,1,2,3"}),
+            patch.dict(os.environ, {"RBLN_VISIBLE_DEVICES": "0,1,2,3"}),
             patch("vllm_rbln.v1.worker.utils.RBLN_DEV_DIR", str(dev)),
             patch("vllm_rbln.v1.worker.utils.RBLN_SYSFS_CLASS_DIR", str(sysfs)),
         ):
@@ -1117,7 +1117,7 @@ class TestRblnSysfsReaders:
         (sysfs / "rbln4" / "dram_used").write_text("0\n")
         (sysfs / "rbln5" / "dram_used").write_text("2048\n")
         with (
-            patch.dict(os.environ, {"RBLN_DEVICES": "0,1"}),
+            patch.dict(os.environ, {"RBLN_VISIBLE_DEVICES": "0,1"}),
             patch("vllm_rbln.v1.worker.utils.RBLN_DEV_DIR", str(dev)),
             patch("vllm_rbln.v1.worker.utils.RBLN_SYSFS_CLASS_DIR", str(sysfs)),
         ):
@@ -1128,14 +1128,14 @@ class TestRblnSysfsReaders:
             (tmp_path / f"rbln{index}").mkdir()
         (tmp_path / "rsd0").mkdir()
         with (
-            patch.dict(os.environ, {"RBLN_DEVICES": ""}),
+            patch.dict(os.environ, {"RBLN_VISIBLE_DEVICES": ""}),
             patch("vllm_rbln.v1.worker.utils.RBLN_SYSFS_CLASS_DIR", str(tmp_path)),
         ):
             assert get_rbln_visible_card_indices() == [0, 1, 3]
 
     def test_dram_total_is_none_without_sysfs(self, tmp_path):
         with (
-            patch.dict(os.environ, {"RBLN_DEVICES": ""}),
+            patch.dict(os.environ, {"RBLN_VISIBLE_DEVICES": ""}),
             patch(
                 "vllm_rbln.v1.worker.utils.RBLN_SYSFS_CLASS_DIR",
                 str(tmp_path / "missing"),
@@ -1145,7 +1145,7 @@ class TestRblnSysfsReaders:
             assert read_rbln_card_dram_used_bytes() == 0
 
     def test_dram_total_reads_uniform_capacity(self, tmp_path):
-        # RBLN_DEV_DIR must be patched too: both readers resolve RBLN_DEVICES
+        # RBLN_DEV_DIR must be patched too: both readers resolve RBLN_VISIBLE_DEVICES
         # against the device nodes actually present, so leaving /dev alone makes
         # the result depend on the host's card numbering. On a container exposing
         # /dev/rbln4..7 "0,1" resolves to cards 4 and 5, which this fake sysfs
@@ -1161,7 +1161,7 @@ class TestRblnSysfsReaders:
             (card / "dram_used").write_text(f"{index * 1024}\n")
             (dev / f"rbln{index}").touch()
         with (
-            patch.dict(os.environ, {"RBLN_DEVICES": "0,1"}),
+            patch.dict(os.environ, {"RBLN_VISIBLE_DEVICES": "0,1"}),
             patch("vllm_rbln.v1.worker.utils.RBLN_DEV_DIR", str(dev)),
             patch("vllm_rbln.v1.worker.utils.RBLN_SYSFS_CLASS_DIR", str(sysfs)),
         ):
@@ -1185,7 +1185,7 @@ class TestRblnSysfsReaders:
             (card / "dram_total").write_text(f"{size}\n")
             (dev / f"rbln{index}").touch()
         with (
-            patch.dict(os.environ, {"RBLN_DEVICES": "0,1"}),
+            patch.dict(os.environ, {"RBLN_VISIBLE_DEVICES": "0,1"}),
             patch("vllm_rbln.v1.worker.utils.RBLN_DEV_DIR", str(dev)),
             patch("vllm_rbln.v1.worker.utils.RBLN_SYSFS_CLASS_DIR", str(sysfs)),
             pytest.raises(RuntimeError, match="different dram_total"),
@@ -1195,7 +1195,7 @@ class TestRblnSysfsReaders:
     def test_dram_total_ignores_cards_we_do_not_own(self, tmp_path):
         """Capacity must come from our own cards, like `dram_used`.
 
-        A container holding /dev/rbln4..7 with RBLN_DEVICES=0,1 owns physical
+        A container holding /dev/rbln4..7 with RBLN_VISIBLE_DEVICES=0,1 owns physical
         cards 4 and 5. Reading the raw entry instead would report card 0's
         capacity -- somebody else's card, and a different SKU here.
         """
@@ -1215,7 +1215,7 @@ class TestRblnSysfsReaders:
             (card / "dram_total").write_text("75161927680\n")
 
         with (
-            patch.dict(os.environ, {"RBLN_DEVICES": "0,1"}),
+            patch.dict(os.environ, {"RBLN_VISIBLE_DEVICES": "0,1"}),
             patch("vllm_rbln.v1.worker.utils.RBLN_DEV_DIR", str(dev)),
             patch("vllm_rbln.v1.worker.utils.RBLN_SYSFS_CLASS_DIR", str(sysfs)),
         ):
@@ -1250,7 +1250,7 @@ class TestRblnSysfsReaders:
         (card / "dram_total").write_text(f"{reported}\n")
         (dev / "rbln0").touch()
         with (
-            patch.dict(os.environ, {"RBLN_DEVICES": "0"}),
+            patch.dict(os.environ, {"RBLN_VISIBLE_DEVICES": "0"}),
             patch("vllm_rbln.v1.worker.utils.RBLN_DEV_DIR", str(dev)),
             patch("vllm_rbln.v1.worker.utils.RBLN_SYSFS_CLASS_DIR", str(sysfs)),
         ):

--- a/tests/optimum/v1/sample/conftest.py
+++ b/tests/optimum/v1/sample/conftest.py
@@ -34,7 +34,7 @@ def fresh_inductor_cache_per_test(monkeypatch):
 def pin_npu_per_worker(monkeypatch):
     worker = os.environ.get("PYTEST_XDIST_WORKER", "gw0")
     idx = int(worker[2:]) if worker[2:].isdigit() else 0
-    monkeypatch.setenv("RBLN_DEVICES", str(idx))
+    monkeypatch.setenv("RBLN_VISIBLE_DEVICES", str(idx))
 
 
 @pytest.fixture(autouse=True)

--- a/vllm_rbln/envs.py
+++ b/vllm_rbln/envs.py
@@ -58,7 +58,6 @@ if TYPE_CHECKING:
     # True unless device-tensor mode is explicitly disabled.
     VLLM_RBLN_AUTO_PORT: bool = True
     VLLM_RBLN_ENFORCE_MODEL_FP32: bool = False
-    VLLM_RBLN_NUM_RAY_NODES: int = 1
     # --- DYNAMIC KV CACHE ---
     VLLM_RBLN_USE_DYNAMIC_KV_CACHE: bool = False
     # --- ATTENTION ---
@@ -279,10 +278,6 @@ environment_variables = {
             in ("true", "1")
         )
     ),
-    # Number of Ray nodes
-    "VLLM_RBLN_NUM_RAY_NODES": lambda: int(
-        os.environ.get("VLLM_RBLN_NUM_RAY_NODES", 1)
-    ),
     # --- DYNAMIC KV CACHE ---
     # Size the KV cache from the compiled artifact instead of the estimate
     "VLLM_RBLN_USE_DYNAMIC_KV_CACHE": (
@@ -417,7 +412,6 @@ RBLN_NON_COMPILE_ENV = frozenset(
         # sampler graphs compile with use_cache=False, never enter the bundle
         "VLLM_RBLN_SAMPLER",
         "VLLM_RBLN_COMPILE_STRICT_MODE",
-        "VLLM_RBLN_NUM_RAY_NODES",
         "VLLM_RBLN_ENABLE_WARM_UP",
         "VLLM_RBLN_METRICS",
         "VLLM_RBLN_METRICS_FILE",

--- a/vllm_rbln/platform.py
+++ b/vllm_rbln/platform.py
@@ -51,6 +51,8 @@ USE_DEVICE_TENSOR: bool = (
 )
 # RBLN default for an unset max_num_seqs (upstream vLLM defaults to 256).
 RBLN_DEFAULT_MAX_NUM_SEQS = 1
+# Superseded by RblnPlatform.device_control_env_var.
+DEPRECATED_DEVICE_CONTROL_ENV_VAR = "RBLN_DEVICES"
 
 
 def bypass_backend(graph_module: torch.fx.GraphModule, example_inputs):
@@ -73,7 +75,7 @@ class RblnPlatform(Platform):
     dist_backend: str = "rbln-ccl" if USE_DEVICE_TENSOR else ""
     dispatch_key: str = "CPU"
     ray_device_key: str = "RBLN"
-    device_control_env_var: str = "RBLN_DEVICES"
+    device_control_env_var: str = "RBLN_VISIBLE_DEVICES"
     simple_compile_backend = "bypass"
 
     @classmethod
@@ -220,10 +222,33 @@ class RblnPlatform(Platform):
         EngineArgs._rbln_user_mnbt_patched = True
 
     @classmethod
+    def _adopt_deprecated_device_control_env_var(cls) -> None:
+        """Fold ``RBLN_DEVICES`` into ``device_control_env_var`` and unset it.
+
+        The runtime takes both names but prefers ``RBLN_DEVICES``, so one left
+        in the environment would override the pool a worker narrows itself to
+        and put every rank on the same NPUs.
+        """
+        legacy = os.environ.pop(DEPRECATED_DEVICE_CONTROL_ENV_VAR, None)
+        if legacy is None:
+            return
+        in_effect = os.environ.setdefault(cls.device_control_env_var, legacy)
+        logger.warning_once(
+            "%s is deprecated and will be removed in a future release. Please "
+            "use %s instead; this run uses %s=%s.",
+            DEPRECATED_DEVICE_CONTROL_ENV_VAR,
+            cls.device_control_env_var,
+            cls.device_control_env_var,
+            in_effect,
+        )
+
+    @classmethod
     def pre_register_and_update(
         cls, parser: "FlexibleArgumentParser | None" = None
     ) -> None:
-        # Runs before max_num_seqs is resolved from None to its default.
+        # Early enough that vLLM has read neither the device-control env var nor
+        # max_num_seqs, which is still None here.
+        cls._adopt_deprecated_device_control_env_var()
         cls._override_default_max_num_seqs()
         cls._capture_user_max_num_batched_tokens()
 

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -55,6 +55,10 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
 from vllm.distributed.parallel_state import get_dp_group, get_pp_group, get_tp_group
 from vllm.model_executor.layers.attention import Attention
 from vllm.platforms import current_platform
+from vllm.platforms.interface import (
+    get_assigned_physical_gpu_ids,
+    set_assigned_physical_gpu_ids,
+)
 from vllm.profiler.wrapper import TorchProfilerWrapper
 from vllm.sequence import IntermediateTensors
 from vllm.tasks import SupportedTask
@@ -205,44 +209,37 @@ class RBLNWorker(WorkerBase):
         pass
 
     def _init_device_env(self) -> None:
-        world_size = self.parallel_config.world_size // envs.VLLM_RBLN_NUM_RAY_NODES
         env_var = current_platform.device_control_env_var
-
         num_devices = envs.VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK
-        total_device_count = world_size * num_devices
+        local_world_size = (
+            self.parallel_config.world_size // envs.VLLM_RBLN_NUM_RAY_NODES
+        )
 
-        if env_var not in os.environ:
-            dev_begin = total_device_count * self.parallel_config.data_parallel_rank
-            dev_end = dev_begin + total_device_count
-            device_ids = [str(i) for i in range(dev_begin, dev_end)]
-            start_idx = self.local_rank * num_devices
-            end_idx = start_idx + num_devices
-            selected_devices = ",".join(device_ids[start_idx:end_idx])
-        else:
-            # vLLM 0.24 stopped narrowing the device-control env var per DP rank
-            # and puts the mapping on the config instead, so under DP the env var
-            # now holds the whole deployment's list (vllm/v1/engine/utils.py,
-            # set_assigned_physical_gpu_ids_for_dp_rank). getattr: older vLLM has
-            # no such field.
-            assigned = getattr(self.parallel_config, "assigned_physical_gpu_ids", None)
-            if assigned:
-                device_ids = [str(i) for i in assigned]
-            else:
-                device_ids = os.environ[env_var].split(",")
-            assert len(device_ids) == world_size, (
-                f"device_ids: {device_ids} should have device count: {world_size}"
-            )
-            try:
-                device_id = int(device_ids[self.local_rank])
-                start_idx = device_id * num_devices
-                end_idx = start_idx + num_devices
-                device_ids = [str(i) for i in range(start_idx, end_idx)]
-                selected_devices = ",".join(device_ids)
-            except ValueError as e:
-                raise ValueError(
-                    f"device_ids: {device_ids} should be a list of integers"
-                ) from e
+        # UniProcExecutor never publishes the mapping, so publish it here rather
+        # than only reading it.
+        assigned = self.parallel_config.assigned_physical_gpu_ids
+        if assigned and get_assigned_physical_gpu_ids() is None:
+            set_assigned_physical_gpu_ids(assigned)
 
+        needed = local_world_size * num_devices
+        try:
+            # The whole node's share, so a pool too small for it is reported by
+            # every rank rather than by whichever one runs off the end.
+            node_devices = [
+                current_platform.device_id_to_physical_device_id(index)
+                for index in range(needed)
+            ]
+        except IndexError as e:
+            raise ValueError(
+                f"this node needs {needed} NPU(s): local world size "
+                f"{local_world_size} x {num_devices} per rank, and "
+                f"{env_var}={os.environ.get(env_var, '')!r} does not hold that "
+                f"many. One entry per NPU is expected."
+            ) from e
+
+        first = self.local_rank * num_devices
+        selected = node_devices[first : first + num_devices]
+        selected_devices = ",".join(str(device) for device in selected)
         os.environ[env_var] = selected_devices
         logger.info(
             "Local rank: %d, Selected devices: %s",

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -187,9 +187,10 @@ class RBLNWorker(WorkerBase):
         if envs.VLLM_RBLN_USE_DYNAMIC_KV_CACHE:
             self._foreign_dram_used_bytes = read_rbln_card_dram_used_bytes()
             logger.debug(
-                "foreign device DRAM at worker init: %d bytes (RBLN_DEVICES=%s)",
+                "foreign device DRAM at worker init: %d bytes "
+                "(RBLN_VISIBLE_DEVICES=%s)",
                 self._foreign_dram_used_bytes,
-                os.environ.get("RBLN_DEVICES", ""),
+                os.environ.get("RBLN_VISIBLE_DEVICES", ""),
             )
 
         self.profiler: Any | None = None

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -212,9 +212,6 @@ class RBLNWorker(WorkerBase):
     def _init_device_env(self) -> None:
         env_var = current_platform.device_control_env_var
         num_devices = envs.VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK
-        local_world_size = (
-            self.parallel_config.world_size // envs.VLLM_RBLN_NUM_RAY_NODES
-        )
 
         # UniProcExecutor never publishes the mapping, so publish it here rather
         # than only reading it.
@@ -222,24 +219,20 @@ class RBLNWorker(WorkerBase):
         if assigned and get_assigned_physical_gpu_ids() is None:
             set_assigned_physical_gpu_ids(assigned)
 
-        needed = local_world_size * num_devices
+        first = self.local_rank * num_devices
         try:
-            # The whole node's share, so a pool too small for it is reported by
-            # every rank rather than by whichever one runs off the end.
-            node_devices = [
-                current_platform.device_id_to_physical_device_id(index)
-                for index in range(needed)
+            selected = [
+                current_platform.device_id_to_physical_device_id(first + offset)
+                for offset in range(num_devices)
             ]
         except IndexError as e:
             raise ValueError(
-                f"this node needs {needed} NPU(s): local world size "
-                f"{local_world_size} x {num_devices} per rank, and "
-                f"{env_var}={os.environ.get(env_var, '')!r} does not hold that "
-                f"many. One entry per NPU is expected."
+                f"local rank {self.local_rank} needs {num_devices} NPU(s) from "
+                f"index {first} of {env_var}="
+                f"{os.environ.get(env_var, '')!r}, or of the data parallel "
+                f"mapping when one is in effect. One entry per NPU is expected."
             ) from e
 
-        first = self.local_rank * num_devices
-        selected = node_devices[first : first + num_devices]
         selected_devices = ",".join(str(device) for device in selected)
         os.environ[env_var] = selected_devices
         logger.info(

--- a/vllm_rbln/v1/worker/utils.py
+++ b/vllm_rbln/v1/worker/utils.py
@@ -49,7 +49,7 @@ logger = init_logger(__name__)
 
 RBLN_SYSFS_CLASS_DIR = "/sys/class/rebellions"
 # sysfs lists every card on the host, /dev only ours; reading sysfs by the raw
-# RBLN_DEVICES entry would charge a neighbouring container's workload to us.
+# RBLN_VISIBLE_DEVICES entry would charge a neighbouring container's workload to us.
 RBLN_DEV_DIR = "/dev"
 
 # 144 GiB of quad-chiplet DRAM minus the 4 GiB system region
@@ -117,13 +117,13 @@ def num_attn_module(model_config, cache_dtype) -> int:
 
 
 def get_rbln_visible_card_indices() -> list[int]:
-    """Card indices this process may use, from `RBLN_DEVICES`.
+    """Card indices this process may use, from `RBLN_VISIBLE_DEVICES`.
 
     Unset or empty means every card under /sys/class/rebellions. Prefer
     `get_rbln_owned_card_indices`; this one reads each entry as a sysfs card
     name and remains only as the fallback for hosts with no device nodes.
     """
-    raw = os.environ.get("RBLN_DEVICES", "")
+    raw = os.environ.get("RBLN_VISIBLE_DEVICES", "")
     if raw.strip():
         return sorted(
             {int(token) for token in raw.replace(",", " ").split() if token.strip()}
@@ -154,7 +154,7 @@ def _rbln_present_card_indices() -> list[int]:
 
 
 def get_rbln_owned_card_indices() -> list[int]:
-    """sysfs card indices this process owns, with `RBLN_DEVICES` resolved.
+    """sysfs card indices this process owns, with `RBLN_VISIBLE_DEVICES` resolved.
 
     Entry `i` selects the `i`-th present device; a physical name is accepted too,
     but the positional reading wins when both are possible.
@@ -164,7 +164,7 @@ def get_rbln_owned_card_indices() -> list[int]:
         # No device nodes (unit tests, host without the driver): nothing better
         # is knowable, so keep the previous behaviour exactly.
         return get_rbln_visible_card_indices()
-    raw = os.environ.get("RBLN_DEVICES", "")
+    raw = os.environ.get("RBLN_VISIBLE_DEVICES", "")
     if not raw.strip():
         return present
     owned: list[int] = []


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

`RBLN_DEVICES` was read as a per-rank slot list. It is now read as a pool of NPUs, the same way `CUDA_VISIBLE_DEVICES` works: one entry per NPU, extra entries are left unused, and each rank picks its own from the pool. The variable is renamed to `RBLN_VISIBLE_DEVICES` to match the CUDA name.

Most of the logic is now upstream's. `Platform.device_id_to_physical_device_id()` already parses the pool, applies the data parallel mapping, and raises on a short pool. The only RBLN part left is that a rank takes `VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK` entries instead of one:

```
selected = [
    current_platform.device_id_to_physical_device_id(first + offset)
    for offset in range(num_devices)
]
```

This removes the two branches, the length `assert`, the `entry * rsd` multiplication, and the DP offset calculation.


#### Fixed bugs

| # | Bug | Before | After |
|---|---|---|---|
| 1 | rsd>1 used NPUs that were not given to the job | `RBLN_DEVICES=4` + rsd 4 -> NPU 16-19 | the same value is now an error; every NPU has to be listed |
| 2 | non-MoE DP could not start without the env var | every replica picked NPU 0, 3 of 4 failed to register | `0, 1, 2, 3`, engine builds |
| 3 | a pool larger than the world size was rejected | `0,1,2,3` + tp 2 -> `AssertionError` | uses `0, 1`, leaves 2 and 3 idle |
| 4 | an exported but empty value crashed | `RBLN_DEVICES=""` -> `AssertionError` / `ValueError` | same as unset |
| 5 | `--device-ids` was ignored | `--device-ids 4,5` + tp 2 -> NPU 0, 1 | NPU 4, 5 |
| 8 | user config was checked with `assert` | message did not say what to fix; a trailing comma crashed | `ValueError` naming the count and the pool |
| 9 | multi node DP used the global DP rank | node B asked for NPU 4-7 that it does not have | vLLM's node-local mapping is used |
| 10 | the two device budget helpers counted different units | test skipped or worker failed | both count NPUs; `prefill_context_parallel_size` added |

#### Migration

**1. rsd > 1 must list every NPU.** One entry is one NPU now, not a group. `RBLN_VISIBLE_DEVICES=4` with rsd 4 is an error, because a rank needs 4 entries and the pool has 1.

```
# to keep the NPUs the old code actually used (4 x 4 = 16)
before:  RBLN_DEVICES=4                     with rsd=4   -> ran on NPU 16-19
after:   RBLN_VISIBLE_DEVICES=16,17,18,19   with rsd=4

# to use NPU 4-7, which "=4" looked like it meant
after:   RBLN_VISIBLE_DEVICES=4,5,6,7       with rsd=4
```

**2. `RBLN_DEVICES` still works** but prints a deprecation warning. It is moved to `RBLN_VISIBLE_DEVICES` and unset at startup. Unsetting is required: the runtime accepts both names but prefers `RBLN_DEVIECS`, so one left in the environment would override the value each worker writes for itself and put every rank on the same NPUs.

**3. `VLLM_RBLN_NUM_RAY_NODES` is removed.** Please drop it from launch scripts.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [x] 🛠 Bug fix (`fix`)
* [x] ❓ Other (`other`): env var rename and removal

---

### 🧪 How to Test

Unit

```bash
uv run --no-sync pytest tests/native/v1/worker/test_rbln_worker.py::TestInitDeviceEnv \
  tests/native/test_platform.py::TestDeprecatedDeviceControlEnvVar \
  tests/native/test_envs.py tests/native/test_utils.py -q
```

On a 32-NPU host, one layer only (`VLLM_RBLN_NUM_HIDDEN_LAYERS=1`, `Felladrin/Llama-160M-Chat-v1`), reading: `Local rank: %d, Selected devices: %s`:

| Case | Expected |
|---|---|
| non-MoE, DP 4, env unset | `0 / 1 / 2 / 3`, engine builds |
| MoE, DP 4, env unset | `0 / 1 / 2 / 3` |
| `RBLN_VISIBLE_DEVICES=0,1,2,3`, tp 2 | `0 / 1`, engine builds |
| `--device-ids 4,5`, tp 2, env unset | `4 / 5` |
| `RBLN_DEVICES=2,3`, tp 2 | deprecation warning, `2 / 3` |
| `RBLN_VISIBLE_DEVICES=4`, rsd 4 | clear `ValueError` |
| `RBLN_VISIBLE_DEVICES=4,5,6,7`, rsd 4 | `4,5,6,7` |

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

Before, non-MoE DP 4 with no env var:

```
(EngineCore_DP0) Local rank: 0, Selected devices: 0
(EngineCore_DP1) Local rank: 0, Selected devices: 0
(EngineCore_DP2) Local rank: 0, Selected devices: 0
(EngineCore_DP3) Local rank: 0, Selected devices: 0
RuntimeError: rbln_register_device_id failed for rbln:0 on physical NPU(s) [0]
```

After:

```
(EngineCore_DP0) Local rank: 0, Selected devices: 0
(EngineCore_DP1) Local rank: 0, Selected devices: 1
(EngineCore_DP2) Local rank: 0, Selected devices: 2
(EngineCore_DP3) Local rank: 0, Selected devices: 3
=== engine built
```

rsd 4 with a pool of four, one run:

```
RBLN_VISIBLE_DEVICES=4,5,6,7   VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK=4

Local rank: 0, Selected devices: 4,5,6,7
=== engine built

| NPU |     Process     |     PID    |  CTX  |
| 4   | VLLM::EngineCor |  3126262   | 10001 | 
| 5   | VLLM::EngineCor |  3126262   | 10002 |
| 6   | VLLM::EngineCor |  3126262   | 10003 |
| 7   | VLLM::EngineCor |  3126262   | 10004 | 
```

Deprecated name:

```
WARNING [platform.py:236] RBLN_DEVICES is deprecated and will be removed in a future release. Please use RBLN_VISIBLE_DEVICES instead; this run uses RBLN_VISIBLE_DEVICES=2,3.
```

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

- `device_control_env_var` is a shared `RblnPlatform` attribute and vLLM uses it for the DP device mapping on **both model paths**. The optimum path does not read `RBLN_DEVICES` ifself, but it is affected through that path. **The optimum suite was not run**.
- `set_assigned_physical_gpu_ids()` is called in the worker because `UniProcExecutor` never publishes the mapping. tp 1 without DP uses `uni`, so `--device-ids` would be ignored there otherwise.
- Multi node DP and Ray were **not tested**. Ray is not installed in my environment, and I confirmed with the team that no deployment uses the Ray executor at the moment.

---
