### PR TITLE
perf(mega-cache): stream the bundle to disk and mmap it on load

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dev = [
 ]
 
 runtime = [
-    "rebel-compiler~=0.11.3.dev96",
+    "rebel-compiler~=0.11.3.dev235",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dev = [
 ]
 
 runtime = [
-    "rebel-compiler~=0.11.3.dev235",
+    "rebel-compiler~=0.11.3.dev237",
 ]
 
 

--- a/tests/native/v1/worker/test_mega_cache.py
+++ b/tests/native/v1/worker/test_mega_cache.py
@@ -28,7 +28,6 @@ import re
 from types import SimpleNamespace
 
 import pytest
-import torch
 
 from tests.native.vllm_config import make_vllm_config
 from vllm_rbln.v1.worker import mega_cache, rbln_model_runner
@@ -356,32 +355,28 @@ def bundle(tmp_path, monkeypatch):
 
     state = SimpleNamespace(
         artifact=b"bundle-bytes",
-        save_result=None,
+        nothing_to_save=False,  # every graph came out of the loaded bundle
         save_raises=None,
         loaded=[],
         set_dirs=[],
-        steps=[],  # boundary calls in the order they happened
     )
-    state.save_result = (state.artifact, object())
     state.path = mega_cache.bundle_path(MODEL, SIG)
 
-    def fake_save():
-        state.steps.append("serialize")
+    def fake_write(dst):
         if state.save_raises is not None:
             raise state.save_raises
-        return state.save_result
+        if state.nothing_to_save:
+            return False
+        dst.write(state.artifact)
+        return True
 
-    def fake_load(data):
-        state.loaded.append(data)
+    def fake_read(src):
+        state.loaded.append(src.read())
         return object()  # stands in for torch's CacheInfo
 
-    def fake_flush():
-        state.steps.append("flush")
-
     monkeypatch.setattr(rbln_mega_cache, "set_dir", state.set_dirs.append)
-    monkeypatch.setattr(rbln_mega_cache, "flush_to_bundle", fake_flush)
-    monkeypatch.setattr(torch.compiler, "save_cache_artifacts", fake_save)
-    monkeypatch.setattr(torch.compiler, "load_cache_artifacts", fake_load)
+    monkeypatch.setattr(rbln_mega_cache, "write_bundle", fake_write)
+    monkeypatch.setattr(rbln_mega_cache, "read_bundle", fake_read)
     return state
 
 
@@ -404,12 +399,6 @@ class TestSaveLoad:
 
         mega_cache.load(MODEL, SIG)
         assert bundle.loaded == [bundle.artifact]
-
-    def test_save_flushes_staged_blobs_first(self, bundle):
-        # Disk-staged .rbln blobs enter the bundle only via flush_to_bundle(),
-        # so flushing after serializing would drop every one of them.
-        mega_cache.save(MODEL, SIG)
-        assert bundle.steps == ["flush", "serialize"]
 
     def test_both_point_rebel_at_the_cache_root(self, bundle):
         mega_cache.save(MODEL, SIG)
@@ -446,22 +435,24 @@ class TestSaveLoad:
 
     def test_resave_replaces_in_place(self, bundle):
         mega_cache.save(MODEL, SIG)
-        bundle.save_result = (b"second-bundle", object())
+        bundle.artifact = b"second-bundle"
         mega_cache.save(MODEL, SIG)
         assert _bundle_bytes(bundle.path) == b"second-bundle"
 
     def test_nothing_new_compiled_keeps_the_bundle(self, bundle):
-        # torch returns None when the run recorded no new artifact -- i.e. every
-        # graph came out of the loaded bundle. Re-saving must not empty it.
+        # rebel reports nothing to write when the run recorded no new artifact
+        # -- i.e. every graph came out of the loaded bundle. Re-saving must not
+        # empty it.
         mega_cache.save(MODEL, SIG)
-        bundle.save_result = None
+        bundle.nothing_to_save = True
         mega_cache.save(MODEL, SIG)
         assert _bundle_bytes(bundle.path) == bundle.artifact
 
     def test_nothing_to_save_writes_no_bundle(self, bundle):
-        bundle.save_result = None
+        bundle.nothing_to_save = True
         mega_cache.save(MODEL, SIG)
         assert not os.path.exists(bundle.path)
+        assert not _tmp_leftovers(bundle.path)
 
     def test_save_failure_leaves_no_bundle(self, bundle):
         bundle.save_raises = RuntimeError("boom")
@@ -493,11 +484,12 @@ class TestSaveLoad:
 
     def test_out_of_space_keeps_the_previous_bundle(self, bundle, monkeypatch):
         mega_cache.save(MODEL, SIG)
-        bundle.save_result = (b"second-bundle", object())
+        first = bundle.artifact
+        bundle.artifact = b"second-bundle"
         with monkeypatch.context() as m:
             m.setattr(mega_cache.os, "replace", _raiser(OSError(errno.ENOSPC, "boom")))
             mega_cache.save(MODEL, SIG)
-        assert _bundle_bytes(bundle.path) == bundle.artifact
+        assert _bundle_bytes(bundle.path) == first
         assert not _tmp_leftovers(bundle.path)
 
     def test_out_of_space_is_logged_at_error(self, bundle, monkeypatch, caplog):
@@ -517,19 +509,23 @@ class TestSaveLoad:
         assert not _tmp_leftovers(bundle.path)
 
     def test_corrupt_bundle_warns_and_recompiles(self, bundle, monkeypatch, caplog):
+        from rebel.core import mega_cache as rbln_mega_cache
+
         os.makedirs(os.path.dirname(bundle.path), exist_ok=True)
         with open(bundle.path, "wb") as f:
             f.write(b"garbage")
         monkeypatch.setattr(
-            torch.compiler, "load_cache_artifacts", _raiser(RuntimeError("bad bundle"))
+            rbln_mega_cache, "read_bundle", _raiser(RuntimeError("bad bundle"))
         )
         with caplog.at_level(logging.WARNING, logger=mega_cache.logger.name):
             mega_cache.load(MODEL, SIG)  # must not propagate
         assert "bad bundle" in caplog.text
 
     def test_unreadable_bundle_warns_and_skips(self, bundle, monkeypatch, caplog):
+        from rebel.core import mega_cache as rbln_mega_cache
+
         mega_cache.save(MODEL, SIG)
-        monkeypatch.setattr(torch.compiler, "load_cache_artifacts", lambda _: None)
+        monkeypatch.setattr(rbln_mega_cache, "read_bundle", lambda _: None)
         with caplog.at_level(logging.WARNING, logger=mega_cache.logger.name):
             mega_cache.load(MODEL, SIG)
         assert "unreadable" in caplog.text
@@ -599,15 +595,14 @@ class TestConformance:
     """Drift alarms: the save/load path is stubbed everywhere above, so nothing
     else in this file would notice either dependency changing shape."""
 
-    def test_torch_mega_cache_api(self):
-        assert callable(torch.compiler.save_cache_artifacts)
-        assert callable(torch.compiler.load_cache_artifacts)
-
     def test_rebel_mega_cache_api(self):
+        # save()/load() are thin wrappers over these; an older rebel without
+        # them degrades to "no cache" through the broad excepts, silently.
         from rebel.core import mega_cache as rbln_mega_cache
 
         assert len(inspect.signature(rbln_mega_cache.set_dir).parameters) == 1
-        assert not inspect.signature(rbln_mega_cache.flush_to_bundle).parameters
+        assert len(inspect.signature(rbln_mega_cache.write_bundle).parameters) == 1
+        assert len(inspect.signature(rbln_mega_cache.read_bundle).parameters) == 1
 
     def test_rbln_artifact_type_is_registered_with_torch(self):
         # rebel registers it at import; without it a bundle's rbln entries

--- a/uv.lock
+++ b/uv.lock
@@ -2107,7 +2107,7 @@ wheels = [
 
 [[package]]
 name = "rebel-compiler"
-version = "0.11.3.dev96+gc9ed8686.prod"
+version = "0.11.3.dev235+g2a25bf6b.prod"
 source = { registry = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/simple/" }
 dependencies = [
     { name = "attrs" },
@@ -2129,10 +2129,10 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.3.dev96+gc9ed8686.prod/rebel_compiler-0.11.3.dev96+gc9ed8686.prod-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "md5:443280f407c12907439411a6f0cc7118" },
-    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.3.dev96+gc9ed8686.prod/rebel_compiler-0.11.3.dev96+gc9ed8686.prod-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "md5:8417f541095a940951b29aecd6fca4e5" },
-    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.3.dev96+gc9ed8686.prod/rebel_compiler-0.11.3.dev96+gc9ed8686.prod-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "md5:031702af157b0151e61018061622b1ee" },
-    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.3.dev96+gc9ed8686.prod/rebel_compiler-0.11.3.dev96+gc9ed8686.prod-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "md5:e80d2de5c4de65c01be18df5e12516b4" },
+    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.3.dev235+g2a25bf6b.prod/rebel_compiler-0.11.3.dev235+g2a25bf6b.prod-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "md5:b6d8e8852138fe7718287f9a99a2eaf6" },
+    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.3.dev235+g2a25bf6b.prod/rebel_compiler-0.11.3.dev235+g2a25bf6b.prod-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "md5:7b50348082bb0eb9a872fa602be6da01" },
+    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.3.dev235+g2a25bf6b.prod/rebel_compiler-0.11.3.dev235+g2a25bf6b.prod-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "md5:e19280b1bc209ead9b21f10da1529d6a" },
+    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.3.dev235+g2a25bf6b.prod/rebel_compiler-0.11.3.dev235+g2a25bf6b.prod-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "md5:0e6513e1566fe0853cc516575d248507" },
 ]
 
 [[package]]
@@ -2940,7 +2940,7 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'test'" },
     { name = "pyyaml" },
     { name = "qwen-vl-utils" },
-    { name = "rebel-compiler", marker = "extra == 'runtime'", specifier = "~=0.11.3.dev96" },
+    { name = "rebel-compiler", marker = "extra == 'runtime'", specifier = "~=0.11.3.dev235" },
     { name = "setuptools", specifier = ">=64" },
     { name = "setuptools-scm", specifier = ">=8" },
     { name = "setuptools-scm", marker = "extra == 'build'" },

--- a/uv.lock
+++ b/uv.lock
@@ -2107,7 +2107,7 @@ wheels = [
 
 [[package]]
 name = "rebel-compiler"
-version = "0.11.3.dev235+g2a25bf6b.prod"
+version = "0.11.3.dev237+g687d3f76.prod"
 source = { registry = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/simple/" }
 dependencies = [
     { name = "attrs" },
@@ -2129,10 +2129,10 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.3.dev235+g2a25bf6b.prod/rebel_compiler-0.11.3.dev235+g2a25bf6b.prod-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "md5:b6d8e8852138fe7718287f9a99a2eaf6" },
-    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.3.dev235+g2a25bf6b.prod/rebel_compiler-0.11.3.dev235+g2a25bf6b.prod-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "md5:7b50348082bb0eb9a872fa602be6da01" },
-    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.3.dev235+g2a25bf6b.prod/rebel_compiler-0.11.3.dev235+g2a25bf6b.prod-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "md5:e19280b1bc209ead9b21f10da1529d6a" },
-    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.3.dev235+g2a25bf6b.prod/rebel_compiler-0.11.3.dev235+g2a25bf6b.prod-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "md5:0e6513e1566fe0853cc516575d248507" },
+    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.3.dev237+g687d3f76.prod/rebel_compiler-0.11.3.dev237+g687d3f76.prod-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "md5:8444db55d686c118de4ba9465eee4f20" },
+    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.3.dev237+g687d3f76.prod/rebel_compiler-0.11.3.dev237+g687d3f76.prod-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "md5:88d148596e9ba40ec37c5b8c624f5d63" },
+    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.3.dev237+g687d3f76.prod/rebel_compiler-0.11.3.dev237+g687d3f76.prod-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "md5:9374d9e7ae14673618a1e3db70b83eb2" },
+    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.3.dev237+g687d3f76.prod/rebel_compiler-0.11.3.dev237+g687d3f76.prod-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "md5:bb5a0e0f36a3b3006fab65cc75193c0e" },
 ]
 
 [[package]]
@@ -2940,7 +2940,7 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'test'" },
     { name = "pyyaml" },
     { name = "qwen-vl-utils" },
-    { name = "rebel-compiler", marker = "extra == 'runtime'", specifier = "~=0.11.3.dev235" },
+    { name = "rebel-compiler", marker = "extra == 'runtime'", specifier = "~=0.11.3.dev237" },
     { name = "setuptools", specifier = ">=64" },
     { name = "setuptools-scm", specifier = ">=8" },
     { name = "setuptools-scm", marker = "extra == 'build'" },

--- a/vllm_rbln/v1/worker/mega_cache.py
+++ b/vllm_rbln/v1/worker/mega_cache.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 """torch.compiler mega-cache bundle helpers for the rbln model runner.
 
-Persists/restores `torch.compiler.{save,load}_cache_artifacts()` bundles as a
-per-(model, config-signature, rank) file under VLLM_CACHE_ROOT.
+Persists/restores the rbln mega-cache bundle (torch.compiler cache-artifact
+layout, written and read by rebel.core.mega_cache) as a per-(model,
+config-signature, rank) file under VLLM_CACHE_ROOT.
 """
 
 import contextlib
@@ -23,7 +24,6 @@ import hashlib
 import os
 import re
 
-import torch
 import vllm.envs as envs
 
 from vllm_rbln.logger import init_logger
@@ -189,7 +189,7 @@ def load(model: str, sig: str) -> None:
         return
     try:
         with open(path, "rb") as src:
-            info = torch.compiler.load_cache_artifacts(src.read())
+            info = rbln_mega_cache.read_bundle(src)
         if info is None:
             logger.warning(
                 "Ignored an unreadable rbln mega-cache bundle at %s; recompiling",
@@ -211,23 +211,22 @@ def save(model: str, sig: str) -> None:
     path = bundle_path(model, sig)
     tmp_path = f"{path}.{os.getpid()}.tmp"
     try:
-        rbln_mega_cache.flush_to_bundle()
-        result = torch.compiler.save_cache_artifacts()
-        if result is None:
-            return
-        artifact_bytes, _ = result
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(tmp_path, "wb") as dst:
-            dst.write(artifact_bytes)
-            # Delayed allocation defers ENOSPC to flush, so a bundle could be
-            # renamed into place truncated without this.
-            dst.flush()
-            os.fsync(dst.fileno())
+            written = rbln_mega_cache.write_bundle(dst)
+            if written:
+                # Delayed allocation defers ENOSPC to flush, so a bundle could
+                # be renamed into place truncated without this.
+                dst.flush()
+                os.fsync(dst.fileno())
+        if not written:
+            os.remove(tmp_path)
+            return
         os.replace(tmp_path, path)
         logger.info(
             "Saved rbln mega-cache bundle to %s (%.1f MiB)",
             path,
-            len(artifact_bytes) / (1 << 20),
+            os.path.getsize(path) / (1 << 20),
         )
     except Exception as exc:  # pylint: disable=broad-exception-caught
         with contextlib.suppress(OSError):


### PR DESCRIPTION
### 🚀 Summary of Changes

Saving the mega-cache bundle materializes three RAM copies of every staged `.rbln` blob (flush read, torch serializer bytearray, `to_bytes()`), so each rank's RSS jumps by ~3x its bundle size at save. On an 8-rank DP run all ranks save at once, and that transient was ~47% of the observed compile-time host-memory peak. Loading read the whole bundle and torch sliced a copy per artifact, ~2x the bundle.

`save()` and `load()` are now thin wrappers over rebel's `write_bundle(dst)` / `read_bundle(src)` (rebellions-sw/rebel_compiler#13404). rebel owns the bundle format on both sides: staged blobs stream into the bundle file, and the bundle is mmapped on load so torch's per-artifact slices are zero-copy. The tmp/fsync/rename protocol, the ENOSPC handling, and the bundle keying are unchanged; existing bundles load as before.

Synthetic payload (process RSS): save transient ~3.0x payload → ~0.04x; load transient ~2x payload anonymous → 0 anonymous (file-backed pages only).

**Requires a rebel with `write_bundle`/`read_bundle`.** An older rebel raises `AttributeError` inside the existing broad excepts, so save logs "could not persist" and load logs "failed to load" and the run compiles cold — no crash, no cache. `TestConformance.test_rebel_mega_cache_api` fails until the pin covers #13404; merge this after that publishes.

---

### 📌 Related Issues / Tickets

* Depends on rebellions-sw/rebel_compiler#13404

---

### ✅ Type of Change

* [x] ⚙️ Performance improvement (`perf`)

---

### 🧪 How to Test

1. Run `pytest tests/native/v1/worker/test_mega_cache.py`
2. `TestSaveLoad` stubs rebel's `write_bundle`/`read_bundle` and asserts the file that reaches disk: round trip, re-save, nothing-to-save leaves no bundle and no `.tmp`, ENOSPC / fsync failure keep the previous bundle, corrupt and unreadable bundles warn and recompile. `TestConformance` asserts rebel exposes both entry points.
3. The streaming and mmap behavior themselves are tested in rebel (`tests/python/test_rebel/test_mega_cache.py` in #13404): byte-identity with torch's serializer, chunked writes, torch receives a memoryview, M: entries outlive the mapping, empty/corrupt files return None.

Run here with a stubbed `rebel` package carrying #13404's `mega_cache.py` and without the native conftest (`import rebel` is broken on this box): 30 passed in the save/load/path classes; `TestSignatureVllmConfig`/`TestWarmupWiring` not runnable locally. CI should confirm the full file once the rebel pin moves.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)
