### PR TITLE
other(ci): cap the auto-bumped optimum-rbln to its patch line

### DIFF
--- a/.github/workflows/pkg_create_pr.yaml
+++ b/.github/workflows/pkg_create_pr.yaml
@@ -40,10 +40,6 @@ jobs:
           VERSION="${{ inputs.optimum-version }}"
           VERSION="${VERSION#v}"
 
-          # `uv add` replaces the whole specifier, so a bare floor would drop the
-          # upper bound and let a published wheel resolve to whatever optimum-rbln
-          # is newest at install time. Cap the bump to its own patch line, the
-          # shape tests/test_packaging_bounds.py requires.
           CEILING=$(python -c 'import re, sys; m = re.match(r"(\d+)\.(\d+)\.(\d+)", sys.argv[1]) or sys.exit(f"cannot derive a patch-line ceiling from {sys.argv[1]!r}"); print(f"{m[1]}.{m[2]}.{int(m[3]) + 1}")' "${VERSION}")
 
           # Bump optimum-rbln in pyproject.toml and refresh uv.lock in one step.

--- a/.github/workflows/pkg_create_pr.yaml
+++ b/.github/workflows/pkg_create_pr.yaml
@@ -40,9 +40,15 @@ jobs:
           VERSION="${{ inputs.optimum-version }}"
           VERSION="${VERSION#v}"
 
+          # `uv add` replaces the whole specifier, so a bare floor would drop the
+          # upper bound and let a published wheel resolve to whatever optimum-rbln
+          # is newest at install time. Cap the bump to its own patch line, the
+          # shape tests/test_packaging_bounds.py requires.
+          CEILING=$(python -c 'import re, sys; m = re.match(r"(\d+)\.(\d+)\.(\d+)", sys.argv[1]) or sys.exit(f"cannot derive a patch-line ceiling from {sys.argv[1]!r}"); print(f"{m[1]}.{m[2]}.{int(m[3]) + 1}")' "${VERSION}")
+
           # Bump optimum-rbln in pyproject.toml and refresh uv.lock in one step.
           for i in {1..6}; do
-            uv add "optimum-rbln>=${VERSION}" --upgrade-package optimum-rbln && exit 0
+            uv add "optimum-rbln>=${VERSION},<${CEILING}" --upgrade-package optimum-rbln && exit 0
             sleep 10
           done
           echo "::error::uv add failed after retries"


### PR DESCRIPTION
## Problem

`.github/workflows/pkg_create_pr.yaml` bumps the pin with

```bash
uv add "optimum-rbln>=${VERSION}" --upgrade-package optimum-rbln
```

`uv add` replaces the **whole** specifier, so the bot drops the upper bound the previous pin carried:

```diff
-    "optimum-rbln>=0.11.2,<0.11.3",
+    "optimum-rbln>=0.11.3a0",
```

`tests/test_packaging_bounds.py` then fails the PR — see #1056 ([build 714](https://obedients.k8s.rebellions.in/orgs/main/pipelines/vllm-rbln-pr-ci/builds/714?job=14ad4fbf-c651-4747-beff-cdad3ec68431)):

```
AssertionError: `optimum-rbln>=0.11.3a0` admits 0.11.4; write `>=0.11.3a0,<0.11.4`
```

This is not a one-off: **every** auto-bump PR fails this way until the workflow itself is fixed. And the guard is guarding something real — a floor alone lets a published wheel resolve to whatever optimum-rbln is newest at install time.

## Change

Derive the patch-line ceiling from the target version and pass the full range, so the bot writes `>=X.Y.Z,<X.Y.Z+1`:

```bash
CEILING=$(python -c '...re.match(r"(\d+)\.(\d+)\.(\d+)"...' "${VERSION}")
uv add "optimum-rbln>=${VERSION},<${CEILING}" --upgrade-package optimum-rbln
```

Ceiling derivation, checked against the shapes this input actually takes:

| input | ceiling | resulting pin |
|---|---|---|
| `0.11.3a0` | `0.11.4` | `>=0.11.3a0,<0.11.4` |
| `v0.11.3` | `0.11.4` | `>=0.11.3,<0.11.4` |
| `0.12.0rc1` | `0.12.1` | `>=0.12.0rc1,<0.12.1` |
| `0.11` | — | step fails loudly |

`latest` never reaches this step: `pkg_update.yaml` resolves it to a concrete version first. Anything the ceiling cannot be derived from fails the step (`set -euo pipefail`) rather than silently uncapping the pin.

Verified the produced spec satisfies the guard: `optimum-rbln>=0.11.3a0,<0.11.4` passes `test_capped_to_patch_line`, and the current-version grep in `pkg_update.yaml` (`sed -E 's/.*optimum-rbln[<>=]{2}([^",]+).*/\1/'`) stops at the comma, so the skip check keeps working with a cap present.

## Not in this PR

#1056's own `pyproject.toml` still needs `"optimum-rbln>=0.11.3a0,<0.11.4"` to go green — that PR is already open and this change only stops the next one from repeating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)