### PR TITLE
perf(pp): reuse intermediate tensors buffer

### DIFF
--- a/tests/native/v1/worker/test_rbln_model_runner.py
+++ b/tests/native/v1/worker/test_rbln_model_runner.py
@@ -1402,6 +1402,7 @@ class TestDummyRunPPIntermediateTensors:
             vllm_config=SimpleNamespace(),
             input_stager=SimpleNamespace(stage=stage),
             model_executable=lambda **k: None,
+            intermediate_tensors_dict={},
         )
         monkeypatch.setattr(RBLNModelRunner, "use_wrapped_compute_logits", False)
         monkeypatch.setattr(

--- a/vllm_rbln/v1/worker/input_stager.py
+++ b/vllm_rbln/v1/worker/input_stager.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import torch
+from vllm.sequence import IntermediateTensors
 
 
 @dataclass(frozen=True)
@@ -44,7 +45,7 @@ class InputBuffer:
 class StagedModelInputs:
     input_ids: torch.Tensor
     positions: torch.Tensor
-    intermediate_tensors: torch.Tensor | None
+    intermediate_tensors: IntermediateTensors | None
     inputs_embeds: torch.Tensor | None
     token_indices: torch.Tensor | None
     # For Eagle3 drafter
@@ -72,7 +73,7 @@ class InputStager:
         *,
         input_ids: torch.Tensor,
         positions: torch.Tensor,
-        intermediate_tensors: torch.Tensor | None = None,
+        intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
         token_indices: torch.Tensor | None = None,
         hidden_states: torch.Tensor | None = None,

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -29,7 +29,7 @@ from vllm.distributed.kv_transfer import (
     get_kv_transfer_group,
     has_kv_transfer_group,
 )
-from vllm.distributed.parallel_state import get_pp_group
+from vllm.distributed.parallel_state import TensorMetadata, get_pp_group
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.model_loader import get_model_loader
@@ -419,10 +419,8 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         self.seq_lens = torch.zeros(self.max_num_tokens, dtype=torch.int32)
         self.seq_lens_np = self.seq_lens.numpy()
         self.discard_request_mask = torch.zeros(self.max_num_reqs, dtype=torch.bool)
+        self.intermediate_tensors_dict: dict[tuple[int, int], IntermediateTensors] = {}
         self.input_stager = InputStager(self.device)
-
-        # None in the first PP rank. The rest are after load_model
-        self.intermediate_tensors: IntermediateTensors | None = None
 
         # OPTIMIZATION: Cache the tensors rather than creating them every step.
         # Keep in int64 to avoid overflow with long context
@@ -1585,6 +1583,77 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             invalid_req_indices,
         )
 
+    def _create_or_get_intermediate_tensors(
+        self, num_reqs_padded: int, query_len: int
+    ) -> IntermediateTensors:
+        """
+        Create a new IntermediateTensors, or reuse an existing one if a matching
+        shape is already created.
+        """
+
+        key = (num_reqs_padded, query_len)
+        if (tensors := self.intermediate_tensors_dict.get(key)) is None:
+            empty = self.model.make_empty_intermediate_tensors(
+                batch_size=num_reqs_padded * query_len,
+                dtype=self.model_config.dtype,
+                device=self.device,
+            )
+            tensors = IntermediateTensors(
+                {
+                    name: t.view(num_reqs_padded, query_len, -1)
+                    for name, t in empty.items()
+                }
+            )
+            self.intermediate_tensors_dict[key] = tensors
+        return tensors
+
+    def recv_intermediate_tensors(self) -> IntermediateTensors:
+        """Receive the previous PP stage's output into this stage's tensors.
+
+        NOTE(RBLN): this is essentially the same as GroupCoordinator.recv_tensor_dict,
+        except that the upstream version allocates a new empty tensor on every call.
+        Here we instead reuse buffers via _create_or_get_intermediate_tensors, keeping
+        the graph input pinned to a fixed tensor.
+        """
+        pp_group = get_pp_group()
+        src = (pp_group.rank_in_group - 1) % pp_group.world_size
+
+        recv_metadata_list: list[tuple[str, Any]] = pp_group.recv_object(src=src)
+        for name, meta in recv_metadata_list:
+            assert isinstance(meta, TensorMetadata), (
+                f"intermediate {name!r} is not a tensor: {meta!r}"
+            )
+
+        num_reqs_padded, query_len = (int(d) for d in recv_metadata_list[0][1].size[:2])
+        intermediate_tensors = self._create_or_get_intermediate_tensors(
+            num_reqs_padded, query_len
+        )
+        received = [
+            (name, tuple(meta.size), meta.dtype) for name, meta in recv_metadata_list
+        ]
+        expected = [
+            (name, tuple(t.shape), t.dtype) for name, t in intermediate_tensors.items()
+        ]
+        assert received == expected, (
+            f"previous stage sent {received}, this stage expects {expected}"
+        )
+
+        group = (
+            pp_group.cpu_group
+            if self.device == torch.device("cpu")
+            else pp_group.device_group
+        )
+        handles = [
+            torch.distributed.irecv(
+                intermediate_tensors[name], src=pp_group.ranks[src], group=group
+            )
+            for name, _ in recv_metadata_list
+        ]
+        for handle in handles:
+            handle.wait()
+
+        return intermediate_tensors
+
     @torch.inference_mode()
     def execute_model(
         self,
@@ -2414,16 +2483,8 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         if get_pp_group().is_first_rank:
             intermediate_tensors = None
         else:
-            intermediate_tensors = self.model.make_empty_intermediate_tensors(
-                batch_size=batch_desc.num_reqs_padded * query_len,
-                dtype=self.model_config.dtype,
-                device=self.device,
-            )
-            intermediate_tensors = IntermediateTensors(
-                {
-                    k: v.view(batch_desc.num_reqs_padded, query_len, -1)
-                    for k, v in intermediate_tensors.items()
-                }
+            intermediate_tensors = self._create_or_get_intermediate_tensors(
+                batch_desc.num_reqs_padded, query_len
             )
 
         # NOTE(RBLN): Clone tensors to make tensors non-view tensors.

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -1186,10 +1186,7 @@ class RBLNWorker(WorkerBase):
         forward_pass = scheduler_output.total_num_scheduled_tokens > 0
 
         if forward_pass and not get_pp_group().is_first_rank:
-            # NOTE(RBLN): DO NOT all_gather_group for RBLN pp
-            intermediate_tensors = IntermediateTensors(
-                get_pp_group().recv_tensor_dict()
-            )
+            intermediate_tensors = self.model_runner.recv_intermediate_tensors()
 
         output = self.model_runner.execute_model(scheduler_output, intermediate_tensors)
         if isinstance(output, ModelRunnerOutput | NoneType):

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -1183,9 +1183,11 @@ class RBLNWorker(WorkerBase):
         scheduler_output: "SchedulerOutput",
     ) -> ModelRunnerOutput | None:
         intermediate_tensors = None
-        forward_pass = scheduler_output.total_num_scheduled_tokens > 0
 
-        if forward_pass and not get_pp_group().is_first_rank:
+        if (
+            scheduler_output.total_num_scheduled_tokens > 0
+            and not get_pp_group().is_first_rank
+        ):
             intermediate_tensors = self.model_runner.recv_intermediate_tensors()
 
         output = self.model_runner.execute_model(scheduler_output, intermediate_tensors)


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

Allocate intermediate tensors once per graph and reuse them instead of allocating new tensors on every step.


When using device tensors, the graph input tensor changed on every PP step because `GroupCoordinator.recv_tensor_dict` allocates a new empty tensor on each call. This caused severe performance degradation.

---


### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [x] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

Run the simple TTFT check below before and after this PR:

```
import os

os.environ["HF_HUB_OFFLINE"] = "1"
os.environ["RBLN_ROOT_IP"] = "127.0.0.1"
os.environ["RBLN_LOCAL_IP"] = "127.0.0.1"
os.environ["VLLM_DISABLE_COMPILE_CACHE"] = "1"
os.environ["VLLM_RBLN_AUTO_PORT"] = "1"
os.environ["VLLM_RBLN_DISABLE_COMPILE_CACHE"] = "1"
os.environ["VLLM_RBLN_COMPILE_STRICT_MODE"] = "1"
os.environ["VLLM_RBLN_USE_VLLM_MODEL"] = "1"

import numpy as np
from vllm import LLM, SamplingParams

def main():
    np.random.seed(42)

    llm = LLM(
        model="MiniMaxAI/MiniMax-M2.7",
        max_num_seqs=4,
        block_size=8192,
        enable_chunked_prefill=True,
        max_num_batched_tokens=512,
        pipeline_parallel_size=4,
        enable_prefix_caching=False,
        disable_log_stats=False,
        kv_cache_dtype="fp8",
    )

    prompt = np.random.randint(1000, 151642, (1, 50*1024)).tolist()
    _ = llm.generate(prompt, SamplingParams(temperature=0.0, max_tokens=1, ignore_eos=True))
    outputs = llm.generate(prompt, SamplingParams(temperature=0.0, max_tokens=1, ignore_eos=True))
    ttft = outputs[0].metrics.first_token_ts - outputs[0].metrics.scheduled_ts
    print(f"TTFT: {ttft}")

if __name__ == "__main__":
    main()
```

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes


For the simplest fix, I implemented `recv_intermediate_tensors` in the model runner. However, as you can see in the model worker, receiving PP intermediate tensors is originally the model worker's responsibility, the model runner just takes the intermediate tensors as execute-model input and runs the forward pass. Given that, it might be a better direction to patch `GroupCoordinator.recv_tensor_dict` to accept buffers as an argument instead. What do you think @rebel-cjlee? I'll update the implementation based on feedback.

I also removed the `forward_pass` variable the name was confusing since it seems to mean running the forward pass, but "pass" could also read as skipping the forward and it was only used once anyway.

---