### PR TITLE
fix(ci): route the compiler override to the test env and verify it

### DIFF
--- a/.buildkite/scripts/rebel-compiler-override.sh
+++ b/.buildkite/scripts/rebel-compiler-override.sh
@@ -7,10 +7,11 @@ host="${REBEL_PYPI_ENDPOINT%/}"
 index="https://${creds}@${host#https://}/simple"
 
 echo "+++ :package: override rebel-compiler==${REBEL_COMPILER_VERSION}"
-# --python .venv on both: bare `uv pip` targets VIRTUAL_ENV (/opt/venv in the
-# devtools image), not the .venv the tests run in.
-uv pip uninstall --python .venv rebel-compiler
-uv pip install --python .venv --extra-index-url "$index" "rebel-compiler==${REBEL_COMPILER_VERSION}"
+# Install into the interpreter the tests run on: bare `uv pip` targets
+# VIRTUAL_ENV (/opt/venv in the devtools image), not the project env.
+py="$(uv run --no-sync python -c 'import sys; print(sys.executable)')"
+uv pip uninstall --python "$py" rebel-compiler
+uv pip install --python "$py" --extra-index-url "$index" "rebel-compiler==${REBEL_COMPILER_VERSION}"
 
 installed="$(uv run --no-sync python -c 'import importlib.metadata as m; print(m.version("rebel-compiler"))')"
 test "${installed}" = "${REBEL_COMPILER_VERSION}"

--- a/.buildkite/scripts/rebel-compiler-override.sh
+++ b/.buildkite/scripts/rebel-compiler-override.sh
@@ -7,18 +7,12 @@ host="${REBEL_PYPI_ENDPOINT%/}"
 index="https://${creds}@${host#https://}/simple"
 
 echo "+++ :package: override rebel-compiler==${REBEL_COMPILER_VERSION}"
-# Bare `uv pip` commands target VIRTUAL_ENV (the devtools image bakes /opt/venv),
-# while the tests run through `uv run` in the project .venv. Pin the target on
-# both commands. Removing first makes a stale compiler surviving in the test
-# env impossible: a mistargeted install then fails every test at import
-# instead of silently validating the lock pin.
+# --python .venv on both: bare `uv pip` targets VIRTUAL_ENV (/opt/venv in the
+# devtools image), not the .venv the tests run in.
 uv pip uninstall --python .venv rebel-compiler
 uv pip install --python .venv --extra-index-url "$index" "rebel-compiler==${REBEL_COMPILER_VERSION}"
 
 installed="$(uv run --no-sync python -c 'import importlib.metadata as m; print(m.version("rebel-compiler"))')"
-if [ "${installed}" != "${REBEL_COMPILER_VERSION}" ]; then
-  echo "rebel-compiler in the test env is ${installed}, not ${REBEL_COMPILER_VERSION}" >&2
-  exit 1
-fi
+test "${installed}" = "${REBEL_COMPILER_VERSION}"
 buildkite-agent annotate --style success --context rebel-compiler \
   "rebel-compiler overridden to \`${installed}\` (pypi.rebellions.in/simple)" || true

--- a/.buildkite/scripts/rebel-compiler-override.sh
+++ b/.buildkite/scripts/rebel-compiler-override.sh
@@ -7,6 +7,14 @@ host="${REBEL_PYPI_ENDPOINT%/}"
 index="https://${creds}@${host#https://}/simple"
 
 echo "+++ :package: override rebel-compiler==${REBEL_COMPILER_VERSION}"
-uv pip install --extra-index-url "$index" "rebel-compiler==${REBEL_COMPILER_VERSION}"
+# Bare `uv pip install` targets VIRTUAL_ENV (the devtools image bakes /opt/venv),
+# while the tests run through `uv run` in the project .venv. Pin the target.
+uv pip install --python .venv --extra-index-url "$index" "rebel-compiler==${REBEL_COMPILER_VERSION}"
+
+installed="$(uv run --no-sync python -c 'import importlib.metadata as m; print(m.version("rebel-compiler"))')"
+if [ "${installed}" != "${REBEL_COMPILER_VERSION}" ]; then
+  echo "rebel-compiler in the test env is ${installed}, not ${REBEL_COMPILER_VERSION}" >&2
+  exit 1
+fi
 buildkite-agent annotate --style success --context rebel-compiler \
-  "rebel-compiler overridden to \`${REBEL_COMPILER_VERSION}\` (pypi.rebellions.in/simple)" || true
+  "rebel-compiler overridden to \`${installed}\` (pypi.rebellions.in/simple)" || true

--- a/.buildkite/scripts/rebel-compiler-override.sh
+++ b/.buildkite/scripts/rebel-compiler-override.sh
@@ -1,19 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
-[ -n "${REBEL_COMPILER_VERSION:-}" ] || exit 0
+[[ -n "${REBEL_COMPILER_VERSION:-}" ]] || exit 0
 
 creds="${UV_INDEX_REBELLIONS_USERNAME}:${UV_INDEX_REBELLIONS_PASSWORD}"
 host="${REBEL_PYPI_ENDPOINT%/}"
 index="https://${creds}@${host#https://}/simple"
 
 echo "+++ :package: override rebel-compiler==${REBEL_COMPILER_VERSION}"
-# Install into the interpreter the tests run on: bare `uv pip` targets
-# VIRTUAL_ENV (/opt/venv in the devtools image), not the project env.
-py="$(uv run --no-sync python -c 'import sys; print(sys.executable)')"
-uv pip uninstall --python "$py" rebel-compiler
-uv pip install --python "$py" --extra-index-url "$index" "rebel-compiler==${REBEL_COMPILER_VERSION}"
+
+# `uv run` resolves the interpreter the tests use; bare `uv pip` would target VIRTUAL_ENV instead.
+python="$(uv run --no-sync python -c 'import sys; print(sys.executable)')"
+uv pip uninstall --python "${python}" rebel-compiler
+uv pip install --python "${python}" --extra-index-url "${index}" "rebel-compiler==${REBEL_COMPILER_VERSION}"
 
 installed="$(uv run --no-sync python -c 'import importlib.metadata as m; print(m.version("rebel-compiler"))')"
-test "${installed}" = "${REBEL_COMPILER_VERSION}"
+[[ "${installed}" == "${REBEL_COMPILER_VERSION}" ]]
+
 buildkite-agent annotate --style success --context rebel-compiler \
   "rebel-compiler overridden to \`${installed}\` (pypi.rebellions.in/simple)" || true

--- a/.buildkite/scripts/rebel-compiler-override.sh
+++ b/.buildkite/scripts/rebel-compiler-override.sh
@@ -7,8 +7,12 @@ host="${REBEL_PYPI_ENDPOINT%/}"
 index="https://${creds}@${host#https://}/simple"
 
 echo "+++ :package: override rebel-compiler==${REBEL_COMPILER_VERSION}"
-# Bare `uv pip install` targets VIRTUAL_ENV (the devtools image bakes /opt/venv),
-# while the tests run through `uv run` in the project .venv. Pin the target.
+# Bare `uv pip` commands target VIRTUAL_ENV (the devtools image bakes /opt/venv),
+# while the tests run through `uv run` in the project .venv. Pin the target on
+# both commands. Removing first makes a stale compiler surviving in the test
+# env impossible: a mistargeted install then fails every test at import
+# instead of silently validating the lock pin.
+uv pip uninstall --python .venv rebel-compiler
 uv pip install --python .venv --extra-index-url "$index" "rebel-compiler==${REBEL_COMPILER_VERSION}"
 
 installed="$(uv run --no-sync python -c 'import importlib.metadata as m; print(m.version("rebel-compiler"))')"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,15 @@ Use the narrowest test target that covers the change. Start by running the speci
 
 Run `pre-commit` through `uvx`, since it is not a project dependency. Pass `--files` explicitly to avoid depending on the current staging state.
 
+CI steps that inject a package version (the rebel-compiler override) install
+through the interpreter the tests use — `uv run --no-sync python -c 'import
+sys; print(sys.executable)'` — never through a bare `uv pip`: `uv pip` targets
+`VIRTUAL_ENV` (the CI image activates its own venv) while the tests run in the
+project env, so a bare install can land where no test reads. After installing,
+assert from inside the test env that the installed version equals the requested
+one; a green step whose label names an untested version is worse than a red
+one.
+
 A new `.py` file needs the Apache header that every other file carries; `check-license-header` rejects it otherwise. Copy the header from a neighbouring file.
 
 `tests/native/` defines three session options (see its `conftest.py`):


### PR DESCRIPTION
## TL;DR

Bare `uv pip install` targets `VIRTUAL_ENV` — `/opt/venv`, baked into the devtools image — while the tests run in the project env via `uv run`. Every `compiler-dev-branch-ci → vllm-rbln @ rebel-compiler X` gate run has therefore been validating the **uv.lock pin, not X**. That is how rebellions-sw/rebel_compiler#13336 stayed green through ~27 gate runs over 3 days, until the revert (rebellions-sw/rebel_compiler#13459).

## Evidence

From any trigger build (e.g. [#676](https://obedients.k8s.rebellions.in/orgs/main/pipelines/vllm-rbln-pr-ci/builds/676), [#732](https://obedients.k8s.rebellions.in/orgs/main/pipelines/vllm-rbln-pr-ci/builds/732)):

```
[uv sync → project env]                    [override]
 + numpy==2.3.5                             + numpy==2.5.2                      ← fresh install, no removal line
 + rebel-compiler==0.11.3.dev96+g….prod     + rebel-compiler==0.11.3.dev196+g…  ← no "- dev96" swap line
warning: `VIRTUAL_ENV=/opt/venv` does not match the project environment path `.venv` and will be ignored
```

- The override installs rebel-compiler **plus all 16 of its dependencies as new packages** — an env the tests don't use.
- The fleet detects the underlying bug instantly once the compiler is actually installed: lock bumped to `dev235.prod` → dp4 fails 3/3 ([#733](https://obedients.k8s.rebellions.in/orgs/main/pipelines/vllm-rbln-pr-ci/builds/733)); revert pinned → pass ([#740](https://obedients.k8s.rebellions.in/orgs/main/pipelines/vllm-rbln-pr-ci/builds/740)).

## Change

```bash
python="$(uv run --no-sync python -c 'import sys; print(sys.executable)')"
uv pip uninstall --python "${python}" rebel-compiler
uv pip install --python "${python}" --extra-index-url "${index}" "rebel-compiler==${REBEL_COMPILER_VERSION}"

installed="$(uv run --no-sync python -c 'import importlib.metadata as m; print(m.version("rebel-compiler"))')"
[[ "${installed}" == "${REBEL_COMPILER_VERSION}" ]]
```

- **Resolve the target from the tests' own interpreter.** `uv run` ignores `VIRTUAL_ENV` and always resolves the project env, so install target = test env by construction (holds under `UV_PROJECT_ENVIRONMENT` and across uv versions; a hardcoded `--python .venv` is rejected by the CI's uv — [#751](https://obedients.k8s.rebellions.in/orgs/main/pipelines/vllm-rbln-pr-ci/builds/751)).
- **Uninstall first.** A stale compiler cannot survive in the test env; a mistargeted install now fails every test at import instead of green-validating the lock pin. uv exits 0 when the package is absent.
- **Verify.** Assert installed == requested from inside the test env; the annotation reports the verified version.

The optimum shared-venv step uses the same script and is fixed with it.

## Validation

[#754](https://obedients.k8s.rebellions.in/orgs/main/pipelines/vllm-rbln-pr-ci/builds/754) injects the known-bad `dev235.prod`. Pass criterion is a **red** build: `- dev237.prod / + dev235.prod` swap in the override log, assert green, dp4 failing with `SYS_ECANCELLED` — the fixed gate detecting #13336. (The shared-venv step already ran this override path green: resolve → swap → assert.)

