### PR TITLE
feature(config): introduce RBLNConfig on the vLLM-native path

### DIFF
--- a/tests/native/conftest.py
+++ b/tests/native/conftest.py
@@ -517,6 +517,35 @@ def _drop_envs_shadows():
 
 
 @pytest.fixture(autouse=True)
+def _reset_rbln_config(monkeypatch):
+    """`vllm_rbln.config` publishes the resolved config in a module global.
+
+    A worker or scheduler built by one test leaves it behind, so a test that
+    never published one would silently read another test's.
+    """
+    from vllm_rbln import config
+
+    monkeypatch.setattr(config, "_rbln_config", None)
+
+
+@pytest.fixture
+def rbln_config():
+    """Publish an `RBLNConfig` for code that reads it without an engine.
+
+    Only a process with an engine resolves one by itself, so a unit test has
+    to say what it wants to read.
+    """
+    from vllm_rbln.config import RBLNConfig, set_rbln_config
+
+    def _publish(**overrides) -> RBLNConfig:
+        config = RBLNConfig(**overrides)
+        set_rbln_config(config)
+        return config
+
+    return _publish
+
+
+@pytest.fixture(autouse=True)
 def _isolate_rbln_ctx_standalone():
     """Clear the one env var the code under test writes to the process env.
 

--- a/tests/native/test_rbln_config.py
+++ b/tests/native/test_rbln_config.py
@@ -1,0 +1,164 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""`--rbln-*` CLI flags -> `additional_config` -> `RBLNConfig`."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+from vllm_rbln.config import _ENV_PROBE, _GROUP_TITLE, RBLNConfig, build_rbln_config
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    """conftest pins VLLM_RBLN_NUM_HIDDEN_LAYERS; start from the defaults."""
+    for f in dataclasses.fields(RBLNConfig):
+        for name in _ENV_PROBE.get(f.name, (f"VLLM_RBLN_{f.name.upper()}",)):
+            monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture(scope="module")
+def parser() -> FlexibleArgumentParser:
+    # add_cli_args() ends in current_platform.pre_register_and_update(parser),
+    # which is where the RBLN group is registered.
+    return AsyncEngineArgs.add_cli_args(FlexibleArgumentParser())
+
+
+def resolve(parser, argv: list[str]) -> RBLNConfig:
+    args = parser.parse_args(argv)
+    engine_args = AsyncEngineArgs.from_cli_args(args)
+    return build_rbln_config(engine_args.additional_config)
+
+
+def test_group_is_registered(parser):
+    assert any(g.title == _GROUP_TITLE for g in parser._action_groups)
+
+
+def test_every_field_gets_a_flag(parser):
+    group = next(g for g in parser._action_groups if g.title == _GROUP_TITLE)
+    flags = {a.dest for a in group._group_actions}
+    assert flags == {f"rbln_{f.name}" for f in dataclasses.fields(RBLNConfig)}
+
+
+def test_defaults_when_nothing_is_passed(parser):
+    assert resolve(parser, []) == RBLNConfig()
+
+
+def test_flags_reach_the_config(parser):
+    config = resolve(
+        parser,
+        [
+            "--no-rbln-compile-model",
+            "--rbln-num-devices-per-local-rank",
+            "4",
+            "--rbln-decode-batch-bucket-strategy",
+            "manual",
+            "--rbln-decode-batch-bucket-manual-buckets",
+            "1",
+            "4",
+            "16",
+        ],
+    )
+    assert config.compile_model is False
+    assert config.num_devices_per_local_rank == 4
+    assert config.decode_batch_bucket_strategy == "manual"
+    assert config.decode_batch_bucket_manual_buckets == [1, 4, 16]
+
+
+def test_coexists_with_additional_config(parser):
+    """The dotted form is appended at the end of argv, so it must merge."""
+    args = parser.parse_args(
+        ["--rbln-use-w8a8", "--additional-config.num_hidden_layers", "2"]
+    )
+    assert args.additional_config == {"use_w8a8": True, "num_hidden_layers": 2}
+    config = build_rbln_config(args.additional_config)
+    assert (config.use_w8a8, config.num_hidden_layers) == (True, 2)
+
+
+def test_json_form_is_equivalent(parser):
+    """`LLM(additional_config=...)` goes through the same code."""
+    assert resolve(parser, ['--additional-config={"use_w8a8": true}']).use_w8a8 is True
+
+
+def test_an_instance_passes_through(parser):
+    given = RBLNConfig(use_w8a8=True)
+    assert build_rbln_config(given) is given
+
+
+def test_env_is_still_honored(parser, monkeypatch):
+    monkeypatch.setenv("VLLM_RBLN_USE_W8A8", "1")
+    assert resolve(parser, []).use_w8a8 is True
+
+
+def test_unprefixed_custom_kernel_env_is_honored(parser, monkeypatch):
+    monkeypatch.setenv("RBLN_USE_CUSTOM_KERNEL", "1")
+    assert resolve(parser, []).use_custom_kernel is True
+
+
+def test_cli_wins_over_env(parser, monkeypatch):
+    monkeypatch.setenv("VLLM_RBLN_USE_W8A8", "1")
+    assert resolve(parser, ["--no-rbln-use-w8a8"]).use_w8a8 is False
+
+
+def test_unknown_key_is_rejected():
+    with pytest.raises(ValueError, match="are not fields"):
+        build_rbln_config({"compile_modell": False})
+
+
+def test_upstream_key_is_rejected():
+    """`--gdn-prefill-backend` is written into additional_config by arg_utils."""
+    with pytest.raises(ValueError, match="gdn_prefill_backend"):
+        build_rbln_config({"gdn_prefill_backend": "auto"})
+
+
+def test_manual_strategy_needs_buckets():
+    with pytest.raises(ValueError, match="needs at least one entry"):
+        RBLNConfig(decode_batch_bucket_strategy="manual")
+
+
+def test_unresolved_config_raises(monkeypatch):
+    """No silent env fallback: a process that never resolved one must fail."""
+    from vllm_rbln import config as config_module
+
+    monkeypatch.setattr(config_module, "_rbln_config", None)
+    with pytest.raises(RuntimeError, match="never resolved in this process"):
+        config_module.get_rbln_config()
+
+
+def test_json_values_are_coerced():
+    """`additional_config` arrives as JSON, so the types need converting."""
+    assert build_rbln_config({"use_w8a8": "false"}).use_w8a8 is False
+    assert (
+        build_rbln_config({"decode_batch_bucket_limit": "8"}).decode_batch_bucket_limit
+        == 8
+    )
+
+
+def test_invalid_value_is_rejected():
+    with pytest.raises(ValueError):
+        build_rbln_config({"decode_batch_bucket_strategy": "garbage"})
+    with pytest.raises(ValueError):
+        build_rbln_config({"use_w8a8": "junk"})
+
+
+def test_only_compile_fields_change_the_hash():
+    """`mega_cache` uses this for its bundle key, via VllmConfig."""
+    base = RBLNConfig().compute_hash()
+    assert RBLNConfig(sampler=False).compute_hash() == base
+    assert RBLNConfig(use_w8a8=True).compute_hash() != base

--- a/tests/native/v1/core/test_rbln_scheduler.py
+++ b/tests/native/v1/core/test_rbln_scheduler.py
@@ -63,6 +63,20 @@ class TestSchedulerInit:
         assert isinstance(sched.kv_cache_manager, RBLNKVCacheManager)
         assert sched.kv_cache_manager.sub_block_size == 128
 
+    def test_additional_config_reaches_the_scheduler(self):
+        # EngineCore receives an already-built VllmConfig, so __init__ is the
+        # only place the section can be resolved. No env var is involved.
+        from vllm_rbln.config import get_rbln_config
+
+        create_rbln_scheduler(
+            enable_prefix_caching=True,
+            block_size=1024,
+            max_num_batched_tokens=128,
+            max_model_len=2048,
+            additional_config={"sub_block_cache": False},
+        )
+        assert get_rbln_config().sub_block_cache is False
+
     def test_disabled_falls_back_to_base_manager(self):
         # prefix caching off -> plain KVCacheManager.
         sched = create_rbln_scheduler(enable_prefix_caching=False)

--- a/tests/native/v1/core/utils.py
+++ b/tests/native/v1/core/utils.py
@@ -149,6 +149,7 @@ def create_rbln_scheduler(
     policy: str = "fcfs",
     use_kv_connector: MockKVConfig | None = None,
     async_scheduling: bool = False,
+    additional_config: dict | None = None,
 ) -> RBLNScheduler:
     """Build an RBLNScheduler on CPU (ported from upstream tests/v1/core/utils):
     opt-125m config only, num_gpu_blocks set manually, no KV connector."""
@@ -195,6 +196,7 @@ def create_rbln_scheduler(
         parallel_config=ParallelConfig(pipeline_parallel_size=pipeline_parallel_size),
         speculative_config=speculative_config,
         kv_transfer_config=kv_transfer_config,
+        additional_config=additional_config or {},
     )
     kv_cache_config = KVCacheConfig(
         num_blocks=num_blocks,

--- a/tests/native/v1/worker/test_rbln_model_runner.py
+++ b/tests/native/v1/worker/test_rbln_model_runner.py
@@ -864,6 +864,10 @@ def _sched(*, new=(), finished=(), scheduled=None, cached=None, spec=None):
 class TestUpdateStates:
     # Request-state bookkeeping on a real InputBatch; scheduler_output is
     # duck-typed since every access is an attribute or index read.
+    @pytest.fixture(autouse=True)
+    def _config(self, rbln_config):
+        rbln_config()
+
     @staticmethod
     def _runner(monkeypatch, *, input_batch, requests=None):
         monkeypatch.setattr(
@@ -982,8 +986,8 @@ class TestMayReorderBatch:
     # Stable descending sort by num_tokens_no_spec, applied in place. Uses a real
     # InputBatch; scheduler_output is unused by the sort path, so None is passed.
     @staticmethod
-    def _runner(monkeypatch, ib, *, sort=True, groups=1):
-        monkeypatch.setattr(mr.envs, "VLLM_RBLN_SORT_BATCH", sort)
+    def _runner(rbln_config, ib, *, sort=True, groups=1):
+        rbln_config(sort_batch=sort)
         return _make_runner_stub(
             input_batch=ib,
             kv_cache_config=SimpleNamespace(kv_cache_groups=[object()] * groups),
@@ -995,30 +999,30 @@ class TestMayReorderBatch:
         ib.num_tokens_no_spec[: len(tokens)] = tokens
         return ib
 
-    def test_noop_when_sort_disabled(self, monkeypatch):
-        r = self._runner(monkeypatch, self._batch([1, 3, 2, 4]), sort=False)
+    def test_noop_when_sort_disabled(self, rbln_config):
+        r = self._runner(rbln_config, self._batch([1, 3, 2, 4]), sort=False)
         r._may_reorder_batch(None)
         assert r.input_batch.req_ids == ["r0", "r1", "r2", "r3"]
 
-    def test_noop_when_no_kv_cache_groups(self, monkeypatch):
-        r = self._runner(monkeypatch, self._batch([1, 3, 2, 4]), groups=0)
+    def test_noop_when_no_kv_cache_groups(self, rbln_config):
+        r = self._runner(rbln_config, self._batch([1, 3, 2, 4]), groups=0)
         r._may_reorder_batch(None)
         assert r.input_batch.req_ids == ["r0", "r1", "r2", "r3"]
 
-    def test_already_sorted_skips(self, monkeypatch):
-        r = self._runner(monkeypatch, self._batch([4, 3, 2, 1]))
+    def test_already_sorted_skips(self, rbln_config):
+        r = self._runner(rbln_config, self._batch([4, 3, 2, 1]))
         r._may_reorder_batch(None)
         assert r.input_batch.req_ids == ["r0", "r1", "r2", "r3"]
         assert r.input_batch.batch_update_builder.moved == []
 
-    def test_sorts_descending_by_num_tokens(self, monkeypatch):
-        r = self._runner(monkeypatch, self._batch([1, 3, 2, 4]))
+    def test_sorts_descending_by_num_tokens(self, rbln_config):
+        r = self._runner(rbln_config, self._batch([1, 3, 2, 4]))
         r._may_reorder_batch(None)
         assert r.input_batch.req_ids == ["r3", "r1", "r2", "r0"]
         assert r.input_batch.num_tokens_no_spec[:4].tolist() == [4, 3, 2, 1]
 
-    def test_emits_swap_records_for_non_pooling(self, monkeypatch):
-        r = self._runner(monkeypatch, self._batch([1, 3, 2, 4]))
+    def test_emits_swap_records_for_non_pooling(self, rbln_config):
+        r = self._runner(rbln_config, self._batch([1, 3, 2, 4]))
         assert not r.input_batch.is_pooling_model
         r._may_reorder_batch(None)
         # Non-pooling models replay pairwise swaps into the logits-proc builder.

--- a/tests/native/v1/worker/test_rbln_worker.py
+++ b/tests/native/v1/worker/test_rbln_worker.py
@@ -47,6 +47,7 @@ def _make_vllm_config(
     quantization=None,
     enforce_eager=False,
     profiler=None,
+    additional_config=None,
 ):
     return SimpleNamespace(
         profiler_config=SimpleNamespace(profiler=profiler),
@@ -66,6 +67,7 @@ def _make_vllm_config(
         cache_config=SimpleNamespace(gpu_memory_utilization=0.9, num_gpu_blocks=None),
         scheduler_config=SimpleNamespace(),
         device_config=SimpleNamespace(device=torch.device("cpu"), device_type="cpu"),
+        additional_config=additional_config if additional_config is not None else {},
     )
 
 
@@ -222,6 +224,18 @@ class TestConformance:
         override = list(inspect.signature(RBLNWorker.load_model).parameters)
         assert "load_dummy_weights" in base
         assert override == ["self"]
+
+
+class TestConfigResolution:
+    def test_additional_config_reaches_the_worker(self, make_worker):
+        # The worker receives an already-built VllmConfig, so __init__ is the
+        # only place the section can be resolved. No env var is involved.
+        from vllm_rbln.config import get_rbln_config
+
+        make_worker(
+            vllm_config=_make_vllm_config(additional_config={"sort_batch": True})
+        )
+        assert get_rbln_config().sort_batch is True
 
 
 class TestInitDeviceEnv:

--- a/vllm_rbln/config.py
+++ b/vllm_rbln/config.py
@@ -1,0 +1,364 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RBLN options for the vLLM-native model path.
+
+On this path the config *is* `VllmConfig.additional_config`, which
+`check_and_update_config` replaces with the resolved object. Being a
+`VllmConfig` field is what carries it to every worker in the config pickle,
+and what makes `VllmConfig.compute_hash()` call our `compute_hash`.
+`platform.py` gates all of it on `VLLM_RBLN_USE_VLLM_MODEL=1`.
+
+Resolution order, highest first:
+
+  1. `additional_config`, an `RBLNConfig` or a dict of field names. The
+     `--rbln-*` flags write into it.
+  2. `VLLM_RBLN_<FIELD>`, read through `envs.py` so the parsing there still
+     applies. `_ENV_PROBE` lists the names that break the pattern.
+  3. the field default
+
+Most call sites still read `envs.py` directly. They move over one subsystem
+at a time.
+"""
+
+import argparse
+import os
+from dataclasses import field, fields
+from typing import TYPE_CHECKING, Any, Literal
+
+from vllm.config.utils import config as vllm_config_dataclass
+
+from vllm_rbln.logger import init_logger
+
+if TYPE_CHECKING:
+    from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+logger = init_logger(__name__)
+
+_GROUP_TITLE = "RBLNConfig"
+
+DecodeBatchBucketStrategy = Literal["exponential", "linear", "manual"]
+
+
+@vllm_config_dataclass
+class RBLNConfig:
+    """RBLN NPU options for the vLLM-native model path."""
+
+    num_devices_per_local_rank: int = 1
+    """Number of NPU devices assigned to each local rank."""
+
+    sampler: bool = True
+    """Use the customized RBLN sampler."""
+
+    compile_model: bool = True
+    """Compile models with torch.compile. Otherwise run CPU eager mode, if
+    possible."""
+
+    compile_strict_mode: bool = False
+    """Compile with torch.compile's strict mode, which fails on a graph break
+    instead of falling back to eager."""
+
+    num_hidden_layers: int = 0
+    """Build only the first N decoder layers and leave the rest as
+    `PPMissingLayer`, to cut compile time during bring-up. 0 disables the
+    truncation."""
+
+    enforce_model_fp32: bool = False
+    """Force the model dtype to fp32 instead of model_config.dtype."""
+
+    use_dynamic_kv_cache: bool = False
+    """Size the KV cache from the compiled artifact instead of the estimate."""
+
+    flash_causal_attn: bool = True
+    """Use flash attention for causal attention."""
+
+    batch_attn_opt: bool = False
+    """Use the batch attention optimization for paged attention."""
+
+    use_custom_kernel: bool = False
+    """Use the custom RBLN kernels."""
+
+    sort_batch: bool = False
+    """Sort requests within a batch before the forward pass."""
+
+    sub_block_cache: bool = True
+    """Enable sub-block prefix caching. The sub-block size equals
+    max_num_batched_tokens (the prefill chunk size)."""
+
+    specialize_moe_decode: bool = True
+    """Specialize the case where every instance is at the decode stage."""
+
+    use_moe_tokens_mask: bool = True
+    """Apply the tokens mask to the MoE expert kernel."""
+
+    dispatch_all2all: bool = False
+    """Use all2all dispatch instead of all-gather for MoE DP dispatch."""
+
+    combine_all2all: bool = False
+    """Use all2all combine instead of reduce-scatter for MoE DP combine."""
+
+    decode_batch_bucket_strategy: DecodeBatchBucketStrategy = "exponential"
+    """How the decode batch buckets are laid out."""
+
+    decode_batch_bucket_min: int = 1
+    """Smallest decode batch bucket."""
+
+    decode_batch_bucket_step: int = 2
+    """Step between decode batch buckets."""
+
+    decode_batch_bucket_limit: int = 1
+    """Largest decode batch bucket."""
+
+    decode_batch_bucket_manual_buckets: list[int] = field(default_factory=list)
+    """Explicit decode batch sizes, used when the strategy is `manual`."""
+
+    nixl_swa_view_opt: bool = False
+    """Publish a second SWA-sized descriptor range alongside the Full-sized
+    range at the same NIXL base addresses, so SWA groups transfer only
+    `sliding_window` bytes per block over RDMA."""
+
+    use_w8a8: bool = False
+    """Opt in to W8A8. W8A16 runs on every RBLN NPU, W8A8 only on the ones
+    whose kernels take an fp8 activation."""
+
+    def compute_hash(self) -> str:
+        """Hash of the fields that change the compiled artifact.
+
+        `VllmConfig.compute_hash()` calls this and `mega_cache` uses that for
+        its bundle key, so changing a field listed below keeps the compiled
+        graphs.
+        """
+        from vllm.config.utils import get_hash_factors, hash_factors
+
+        ignored_factors = {
+            # Sampler graphs compile with use_cache=False, so they never enter
+            # the bundle. The rest change what runs, not what is built.
+            "sampler",
+            "compile_strict_mode",
+            "sort_batch",
+            "sub_block_cache",
+            "nixl_swa_view_opt",
+        }
+        return hash_factors(get_hash_factors(self, ignored_factors))
+
+    def __post_init__(self) -> None:
+        buckets = self.decode_batch_bucket_manual_buckets
+        if any(b <= 0 for b in buckets):
+            raise ValueError("decode_batch_bucket_manual_buckets must all be > 0")
+        if len(buckets) != len(set(buckets)):
+            raise ValueError("decode_batch_bucket_manual_buckets must be unique")
+        if self.decode_batch_bucket_strategy == "manual" and not buckets:
+            raise ValueError(
+                "decode_batch_bucket_strategy='manual' needs at least one entry "
+                "in decode_batch_bucket_manual_buckets"
+            )
+
+
+# `vllm_config_dataclass` is a `dataclass_transform`, but the mypy hook runs
+# without vllm installed, so it cannot see that this makes a dataclass.
+_FIELDS = fields(RBLNConfig)  # type: ignore[arg-type]
+
+
+# Which env name means "the user set this field". It is VLLM_RBLN_<FIELD>
+# unless listed here.
+_ENV_PROBE: dict[str, tuple[str, ...]] = {
+    # `envs.py` still honors the deprecated VLLM_RBLN_TP_SIZE alias.
+    "num_devices_per_local_rank": (
+        "VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK",
+        "VLLM_RBLN_TP_SIZE",
+    ),
+    "use_custom_kernel": ("RBLN_USE_CUSTOM_KERNEL",),
+}
+
+
+def _env_overrides() -> dict[str, Any]:
+    from vllm_rbln import envs
+
+    overrides: dict[str, Any] = {}
+    for f in _FIELDS:
+        env_name = f"VLLM_RBLN_{f.name.upper()}"
+        for probe in _ENV_PROBE.get(f.name, (env_name,)):
+            if probe in os.environ:
+                overrides[f.name] = getattr(envs, env_name)
+                break
+    return overrides
+
+
+def build_rbln_config(additional_config: Any = None) -> RBLNConfig:
+    """Resolve the RBLN config from `additional_config` and the environment.
+
+    An `RBLNConfig` is returned unchanged, so a process that receives one
+    cannot resolve it into something different.
+    """
+    if isinstance(additional_config, RBLNConfig):
+        return additional_config
+
+    given: dict[str, Any] = additional_config or {}
+    if not isinstance(given, dict):
+        raise ValueError(
+            "additional_config must be an RBLNConfig or a mapping of its field "
+            f"names on the vLLM-native path, got {type(given).__name__}"
+        )
+
+    known = {f.name for f in _FIELDS}
+    if unknown := sorted(set(given) - known):
+        # `extra="forbid"` would catch these too, but its message talks about
+        # keyword arguments. Upstream's --gdn-prefill-backend arrives this way:
+        # arg_utils writes it into additional_config.
+        raise ValueError(
+            f"additional_config takes only RBLNConfig fields on the "
+            f"vLLM-native path, and {unknown} are not fields. The fields are "
+            f"{sorted(known)}."
+        )
+
+    overrides = _env_overrides()
+    shadowed = sorted(set(given) & set(overrides))
+    overrides.update(given)
+
+    if shadowed:
+        logger.warning_once(
+            "Ignoring the environment variables for %s; the CLI value wins.",
+            ", ".join(shadowed),
+        )
+
+    return RBLNConfig(**overrides)
+
+
+_rbln_config: RBLNConfig | None = None
+
+
+def set_rbln_config(config: RBLNConfig) -> None:
+    """Publish the resolved config for this process.
+
+    Each process does this at its own entry point. A worker and EngineCore
+    receive an already-built `VllmConfig`, so its `__post_init__` -- where the
+    platform hook runs -- does not run again there.
+    """
+    global _rbln_config
+    _rbln_config = config
+
+    defaults = RBLNConfig()
+    changed = {
+        f.name: getattr(config, f.name)
+        for f in _FIELDS
+        if getattr(config, f.name) != getattr(defaults, f.name)
+    }
+    logger.info("RBLN config: %s", changed or "all defaults")
+
+
+def get_rbln_config() -> RBLNConfig:
+    """The resolved RBLN config for this process.
+
+    There is deliberately no fallback to the environment. A child process
+    inherits env vars but not `--rbln-*` values, so a fallback would be right
+    when the option came from the environment and wrong when it came from the
+    command line.
+    """
+    if _rbln_config is None:
+        raise RuntimeError(
+            "RBLNConfig was never resolved in this process. Call "
+            "set_rbln_config(build_rbln_config(vllm_config.additional_config)) "
+            "from this process's entry point."
+        )
+    return _rbln_config
+
+
+# `from_cli_args` only copies dataclass fields, so a `--rbln-*` flag cannot
+# have an `EngineArgs` field of its own. Each one writes into
+# `additional_config` instead, which is a real field. That is why the actions
+# below exist instead of plain `store`.
+
+_OWNED = "_rbln_additional_config_owned"
+
+
+def _additional_config(namespace: argparse.Namespace) -> dict[str, Any]:
+    """The namespace's `additional_config`, copied so we can write into it.
+
+    argparse seeds the namespace with the `--additional-config` action's own
+    default object. A reused parser would share that object between
+    `parse_args()` calls, so copy it once before writing.
+    """
+    if not getattr(namespace, _OWNED, False):
+        current = getattr(namespace, "additional_config", None)
+        namespace.additional_config = dict(current) if isinstance(current, dict) else {}
+        setattr(namespace, _OWNED, True)
+    return namespace.additional_config
+
+
+class _StoreRbln(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        _additional_config(namespace)[self.dest.removeprefix("rbln_")] = values
+
+
+class _StoreRblnBool(argparse.BooleanOptionalAction):
+    def __call__(self, parser, namespace, values, option_string=None):
+        if option_string in self.option_strings:
+            _additional_config(namespace)[
+                self.dest.removeprefix("rbln_")
+            ] = not option_string.startswith("--no-")
+
+
+class _MergeAdditionalConfig(argparse.Action):
+    """Replacement for `--additional-config`'s own action: merge, don't clobber.
+
+    `FlexibleArgumentParser.parse_args()` rewrites `--additional-config.x v`
+    into one `--additional-config <json>` and appends it at the end of argv.
+    A plain store action would then drop what the `--rbln-*` flags wrote.
+    """
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if not isinstance(values, dict):
+            # Upstream allows a bare string here, so keep that.
+            namespace.additional_config = values
+            setattr(namespace, _OWNED, False)
+            return
+        _additional_config(namespace).update(values)
+
+
+def add_rbln_cli_args(parser: "FlexibleArgumentParser") -> None:
+    """Add the `RBLNConfig` group to `parser`. Safe to call twice.
+
+    `RblnPlatform.pre_register_and_update(parser)` calls this from inside
+    `AsyncEngineArgs.add_cli_args()`, before `parse_args()`. That is early
+    enough for `--help`, `--help=all` and `--help=rblnconfig`.
+    """
+    if any(group.title == _GROUP_TITLE for group in parser._action_groups):
+        return
+
+    from vllm.engine.arg_utils import get_kwargs
+
+    group = parser.add_argument_group(
+        title=_GROUP_TITLE,
+        description=RBLNConfig.__doc__,
+    )
+    kwargs = get_kwargs(RBLNConfig)
+    for f in _FIELDS:
+        field_kwargs = kwargs[f.name]
+        is_bool = field_kwargs.pop("action", None) is argparse.BooleanOptionalAction
+        group.add_argument(
+            f"--rbln-{f.name.replace('_', '-')}",
+            dest=f"rbln_{f.name}",
+            action=_StoreRblnBool if is_bool else _StoreRbln,
+            **field_kwargs,
+        )
+
+    for action in parser._actions:
+        if action.dest == "additional_config":
+            action.__class__ = _MergeAdditionalConfig
+            break
+    else:
+        logger.warning(
+            "--additional-config not found on the parser; --rbln-* flags may be "
+            "overwritten when --additional-config is also passed."
+        )

--- a/vllm_rbln/platform.py
+++ b/vllm_rbln/platform.py
@@ -250,7 +250,10 @@ class RblnPlatform(Platform):
         # max_num_seqs, which is still None here.
         cls._adopt_deprecated_device_control_env_var()
         cls._override_default_max_num_seqs()
-        cls._capture_user_max_num_batched_tokens()
+        if not envs.VLLM_RBLN_USE_VLLM_MODEL:
+            # Only sync_from_vllm reads the key it writes, and on the native
+            # path it would be an unknown field of RBLNConfig.
+            cls._capture_user_max_num_batched_tokens()
 
         if parser is None:
             return
@@ -263,8 +266,14 @@ class RblnPlatform(Platform):
             if action.dest == "block_size":
                 action.choices = None  # Override choices
 
+        if envs.VLLM_RBLN_USE_VLLM_MODEL:
+            from vllm_rbln.config import add_rbln_cli_args
+
+            add_rbln_cli_args(parser)
+
     @classmethod
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
+        from vllm_rbln.config import build_rbln_config, set_rbln_config
         from vllm_rbln.utils.optimum.converter import sync_vllm_and_optimum
         from vllm_rbln.utils.optimum.predicates import forces_fp32_dtype
         from vllm_rbln.utils.optimum.registry import is_pooling_arch
@@ -285,6 +294,11 @@ class RblnPlatform(Platform):
             cls._validate_dynamic_kv_config(vllm_config)
 
         if envs.VLLM_RBLN_USE_VLLM_MODEL:
+            vllm_config.additional_config = build_rbln_config(
+                vllm_config.additional_config
+            )
+            set_rbln_config(vllm_config.additional_config)
+
             if vllm_config.lora_config is not None:
                 raise ValueError("LoRA is not supported on RBLN.")
 

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -36,7 +36,7 @@ from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
 from vllm.v1.utils import record_function_or_nullcontext
 
-import vllm_rbln.envs as envs
+from vllm_rbln.config import build_rbln_config, get_rbln_config, set_rbln_config
 from vllm_rbln.logger import init_logger
 from vllm_rbln.v1.core.rbln_kv_cache_manager import (
     KVCacheCopyOp,
@@ -70,11 +70,13 @@ class RBLNScheduler(Scheduler):
     ) -> None:
         super().__init__(*args, **kwargs)
 
+        set_rbln_config(build_rbln_config(self.vllm_config.additional_config))
+
         # Replace the upstream KVCacheManager with RBLNKVCacheManager
         # when sub-block prefix caching is enabled.
         # Sub-block size equals the prefill chunk size (max_num_batched_tokens)
         # so that each prefill does not span multiple blocks.
-        if sub_block_size is None and envs.VLLM_RBLN_SUB_BLOCK_CACHE:
+        if sub_block_size is None and get_rbln_config().sub_block_cache:
             sub_block_size = self.scheduler_config.max_num_batched_tokens
         if (
             self.cache_config.enable_prefix_caching

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -110,6 +110,7 @@ from vllm_rbln.compilation import (
     create_compile_context,
     set_compile_stage,
 )
+from vllm_rbln.config import get_rbln_config
 from vllm_rbln.forward_context import set_forward_context
 from vllm_rbln.logger import init_logger
 from vllm_rbln.platform import HAS_TORCH_RBLN, USE_DEVICE_TENSOR
@@ -544,7 +545,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         # phase classification. Instead, we perform a stable sort by current sequence
         # length (num_tokens_no_spec, descending).
         if (
-            not envs.VLLM_RBLN_SORT_BATCH
+            not get_rbln_config().sort_batch
             or len(self.kv_cache_config.kv_cache_groups) == 0
         ):
             return

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -75,6 +75,7 @@ from vllm.v1.worker.worker_base import CompilationTimes, WorkerBase
 
 import vllm_rbln.envs as envs
 from vllm_rbln.compilation.backends import set_compile_stage
+from vllm_rbln.config import build_rbln_config, set_rbln_config
 from vllm_rbln.distributed.kv_transfer.kv_connector.v1.utils import (
     finalize_kv_cache_registrations,
 )
@@ -172,6 +173,9 @@ class RBLNWorker(WorkerBase):
             distributed_init_method=distributed_init_method,
             is_driver_worker=is_driver_worker,
         )
+
+        # Before _init_device_env(), which reads device-count options.
+        set_rbln_config(build_rbln_config(vllm_config.additional_config))
 
         self._init_device_env()
 


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

RBLN options on the vLLM-native path get a real config. `RBLNConfig` holds 23 fields, each fields makes one `--rbln-<field>` flag, and `additional_config` is how a value gets in.

`envs.py` still works and is still the live source. Only two read sites moved, so this PR does not change what any option does. It adds the surface.

**One design choice needs a look.** On the native path `additional_config` *is* the `RBLNConfig`, not a dict with an `"rbln"` key inside it.
`check_and_update_config` replaces what it was given with the resolved object. The proposal assumed we could not do that, because `additional_config` holds the optimum path's keys. That is not true on the native path: every optimum key is written under `sync_vllm_and_optimum`, which the native path never calls. The one exception was `user_max_num_batched_tokens`, which is ours, so a path gate removes it.

Making it the object solves two problems the proposal left open:

- **It reaches the other processes.** It is a `VllmConfig` field, so it is pickled to the worker and to EngineCore. No copy-back, no re-resolving.
- **The cache key works without a workaround.** `VllmConfig.compute_hash()` calls `additional_config.compute_hash()` when it is not a dict, so `ignored_factors` takes effect. The proposal needed a strip-and-restore trick for this. That trick is gone.

`RBLNConfig.compute_hash()` leaves out the five fields that do not change the compiled artifact, so turning one of them on keeps the mega-cache bundle.

Two smaller decisions worth knowing:

- `RBLNConfig` uses `vllm.config.utils.config`, like all 27 config classes in `vllm/config/`. That converts the types that arrive as JSON. `{"use_w8a8": "false"}` used to be a true string and is now `False`, and an invalid `decode_batch_bucket_strategy` u;sed  to pass silently.
- `get_rbln_config()` raises instead of falling back to the environment. A child process inherits env vars but not `--rbln-*` values, so a fallback would be right when the option came from the environment and wrong when it came from the command line. That is the one failure this change has to avoid.

**Two limits this brings.** On the native path `additional_config` is ours alone, so a user cannot put an unrelated key there. And `--gdn-prefill-backend` stops working: upstream writes that flag into `additional_config` without a guard, so it arrives as a field we do not have. It fails with our own message. It is the only upstream flag that writes there, and RBLN does not use it.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Related to #1047 

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [x] ✨ Feature (`feature`)
* [x] 🧬 Core engine changes (`core`)

---

### 🧪 How to Test

1. `uv run --no-sync pytest testse/native/test_rbln_config.py -x`

17 tests: flag generation, the priority order, type conversion, unknown-key rejection, and which fields change the hash.

2. `uv run --no-sync pytest test/native -q`

1799 passed, 25 skipped

3. `vllm serve --help=rblnconfig` shows 23 flags with `VLLM_RBLN_USE_VLLM_MODEL=1`, and no `RBLNConfig` group without it.

4. The two moved read sites, one per process type:
  - `VLLM_RBLN_SORT_BATCH=1 vllm serve ...` and `vllm serve --rbln-sort-batch ...` must behave the same. The value is read in the worker process.
  - same for `--rbln-sub-block-cache`, which is read in EngineCore.
  Each process logs its resolved config as `RBLN config: {...}`, so you can see the value arriave.

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

Look at these three:

1. **We take over `additional_config` on the native path.** Upstream calls that field an "opaque config ... for out of tree config registration", so we give up something upstream offers.
2. **The env vars print no deprecation warning yet.** `envs.py` is still the live source, so calling it deprecated would not be true. The warning belongs with the read-site migration.
3. **The two moved read sites are there on purpose.** Without a reader there is no way to see whether the config reaches the worker. If you would rather have zero behavior change, I can move them to the next PR.

Not done here: the other 93 read sites, the `tests/native/` env harness, the docs, and removing the promoted names from `RBLN_COMPILE_ENV`.

---
