### PR TITLE
fix(kv-connector): let MultiConnector collect KV events from its children

### DIFF
--- a/tests/native/patches/test_multi_connector_kv_events.py
+++ b/tests/native/patches/test_multi_connector_kv_events.py
@@ -1,0 +1,82 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+from vllm_rbln.patches import multi_connector_kv_events as mod
+from vllm_rbln.patches.multi_connector_kv_events import (
+    patched_get_kv_connector_kv_cache_events,
+)
+
+
+class _Events:
+    def __init__(self, tag: str) -> None:
+        self.tag = tag
+
+
+class _Connector:
+    """A sub-connector that reports ``events`` and counts the calls."""
+
+    def __init__(self, events: _Events | None) -> None:
+        self.events = events
+        self.calls = 0
+
+    def get_kv_connector_kv_cache_events(self) -> _Events | None:
+        self.calls += 1
+        return self.events
+
+
+def _multi(*connectors: _Connector):
+    return SimpleNamespace(_connectors=list(connectors))
+
+
+def test_returns_none_when_no_child_produces_events():
+    a, b = _Connector(None), _Connector(None)
+
+    assert patched_get_kv_connector_kv_cache_events(_multi(a, b)) is None
+    assert (a.calls, b.calls) == (1, 1)
+
+
+def test_returns_the_only_child_that_produces_events():
+    # The deployed shape: NIXL reports nothing, the offload connector reports.
+    events = _Events("offload")
+    nixl, offload = _Connector(None), _Connector(events)
+
+    got = patched_get_kv_connector_kv_cache_events(_multi(nixl, offload))
+
+    assert got is events
+
+
+def test_every_child_is_asked_even_after_one_reports(monkeypatch):
+    # Asking all children keeps their internal queues drained; a child that
+    # accumulates events must not be skipped just because an earlier one won.
+    monkeypatch.setattr(mod, "_warned_multiple", False, raising=False)
+    first, second = _Connector(_Events("first")), _Connector(_Events("second"))
+
+    got = patched_get_kv_connector_kv_cache_events(_multi(first, second))
+
+    assert got is first.events
+    assert (first.calls, second.calls) == (1, 1)
+
+
+def test_multiple_producers_warn_once(monkeypatch, caplog):
+    monkeypatch.setattr(mod, "_warned_multiple", False, raising=False)
+    multi = _multi(_Connector(_Events("a")), _Connector(_Events("b")))
+
+    with caplog.at_level("WARNING", logger=mod.__name__):
+        patched_get_kv_connector_kv_cache_events(multi)
+        patched_get_kv_connector_kv_cache_events(multi)
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warnings) == 1

--- a/vllm_rbln/patches/__init__.py
+++ b/vllm_rbln/patches/__init__.py
@@ -40,6 +40,7 @@ from . import (
     mla,
     models_utils,
     multi_connector,
+    multi_connector_kv_events,
     oot,
     profiler,
     qwen2_moe,

--- a/vllm_rbln/patches/multi_connector_kv_events.py
+++ b/vllm_rbln/patches/multi_connector_kv_events.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Let ``MultiConnector`` collect KV-cache events from its children.
+
+``MultiConnector`` never implements ``get_kv_connector_kv_cache_events``, so it
+inherits the base method that returns ``None``. A child connector's own
+implementation is therefore never called, and its events never reach vLLM's
+event publisher. Upstream knows -- ``multi_connector.py`` carries the TODO:
+
+    # TODO: Add a generic implementation of 'get_kv_connector_kv_cache_events'
+    # method for the MultiConnector. It should be able to get events from
+    # multiple connectors, handling the case where only a subset of the
+    # requested connectors implements the ...
+    # WIP: https://github.com/vllm-project/vllm/pull/31811
+
+That WIP PR was closed without being merged (2026-02-16) and ``main`` still has
+the TODO, so there is nothing to wait for.
+
+The neighbouring methods on the same class already fan out to the children --
+``update_connector_output`` and ``take_events`` both iterate ``_connectors`` --
+so only this one is missing. Everything downstream of it is already wired:
+
+    kv_connector_model_runner_mixin.py  calls this method after model execution
+    MultiConnector.update_connector_output  hands the worker output to children
+    MultiConnector.take_events              collects from children
+    Scheduler.update_from_output            merges and publishes
+
+Deployed impact: with ``MultiConnector`` wrapping NIXL plus an offload
+connector (PD disaggregation needs NIXL, so this is the normal shape), the
+offload tier's KV events are dropped wholesale. Measured on a PD-disaggregated
+MiniMax-M2.7 deployment: the endpoint picker's KV-block index admitted 0 blocks
+before this patch and 640 blocks per request after it, matching the number of
+blocks the offload tier actually stored.
+
+Scope: this returns the first child that produces events rather than merging
+across children, because the event container is connector-specific and cannot
+be combined generically. That covers the "only a subset implements it" case the
+upstream TODO describes, which is the shape we deploy. If a second child ever
+produces events too, we log once and keep the first -- a generic merge belongs
+upstream.
+"""
+
+import logging
+from typing import TYPE_CHECKING
+
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorBase_V1
+from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import MultiConnector
+
+from vllm_rbln.patches import register_patch
+
+if TYPE_CHECKING:
+    from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorKVEvents
+
+logger = logging.getLogger(__name__)
+
+# Fails loudly on the upgrade that makes this patch redundant.
+assert (
+    MultiConnector.get_kv_connector_kv_cache_events
+    is KVConnectorBase_V1.get_kv_connector_kv_cache_events
+), (
+    "upstream MultiConnector now implements get_kv_connector_kv_cache_events; "
+    "delete this module, its entry in vllm_rbln/patches/__init__.py and "
+    "tests/native/patches/test_multi_connector_kv_events.py."
+)
+
+_warned_multiple = False
+
+
+@register_patch(
+    target=(
+        "vllm.distributed.kv_transfer.kv_connector.v1."
+        "multi_connector.MultiConnector.get_kv_connector_kv_cache_events"
+    ),
+    reason=(
+        "MultiConnector inherits the base no-op, so a child connector's KV events "
+        "never reach the publisher. Upstream TODO with no merged fix "
+        "(vllm#31811 closed unmerged). TODO: delete once upstream implements it."
+    ),
+)
+def patched_get_kv_connector_kv_cache_events(
+    self: MultiConnector,
+) -> "KVConnectorKVEvents | None":
+    global _warned_multiple
+    found = None
+    for connector in self._connectors:
+        events = connector.get_kv_connector_kv_cache_events()
+        if events is None:
+            continue
+        if found is None:
+            found = events
+            continue
+        if not _warned_multiple:
+            _warned_multiple = True
+            logger.warning(
+                "More than one sub-connector produced KV cache events; keeping "
+                "the first (%s) and dropping %s. Merging across connectors needs "
+                "an upstream generic implementation.",
+                type(found).__name__,
+                type(events).__name__,
+            )
+    return found


### PR DESCRIPTION
## Problem

`MultiConnector` never implements `get_kv_connector_kv_cache_events`, so it inherits the base method that returns `None`:

```python
# vllm/distributed/kv_transfer/kv_connector/v1/base.py
def get_kv_connector_kv_cache_events(self) -> "KVConnectorKVEvents | None":
    return None

>>> MultiConnector.get_kv_connector_kv_cache_events is KVConnectorBase_V1.get_kv_connector_kv_cache_events
True
```

A child connector's own implementation is therefore never called and its events never reach vLLM's publisher.

Upstream knows — `multi_connector.py` carries the TODO:
https://github.com/vllm-project/vllm/pull/31811
```
# TODO: Add a generic implementation of 'get_kv_connector_kv_cache_events'
# method for the MultiConnector. It should be able to get events from
# multiple connectors, handling the case where only a subset of the
# requested connectors implements the ...
# WIP: https://github.com/vllm-project/vllm/pull/31811
```

**That WIP PR was closed without being merged (2026-02-16) and `main` still carries the TODO**, so there is nothing to wait for.

The neighbouring methods on the same class already fan out to the children — `update_connector_output` and `take_events` both iterate `_connectors`. Only this one is missing.

## Why it matters for us

PD disaggregation requires NIXL, so any offload connector runs as a *child* of `MultiConnector`. That means the offload tier's KV events are dropped wholesale, and the endpoint picker cannot see which pod holds which blocks on that tier.

Measured on a PD-disaggregated MiniMax-M2.7 deployment (prefill `PP=4`, decode `DP=4`+EP, `MultiConnector` = NIXL + LMCache/RDS), with an EPP configured as a `precise-prefix-cache-producer`:

Full write-up: https://github.com/rebellions-sw/fsw-inference/issues/565

## Change

New patch module `vllm_rbln/patches/multi_connector_kv_events.py`, registered in `patches/__init__.py`, following the shape of the existing `multi_connector` patch.

It asks every child and returns the first that produced events:

```python
found = None
for connector in self._connectors:
    events = connector.get_kv_connector_kv_cache_events()
    if events is None:
        continue
    if found is None:
        found = events
        continue
    # warn once; a generic merge belongs upstream
```

## Why this is a draft

**Deliberately kept as a draft until we can test it properly on the new hardware being installed soon**. The evidence above comes from a runtime injection of this same logic on the current cluster, which is enough to establish the failure mode and that this change fixes it, but not enough for a merge: it was a single shape (prefill `PP=4`, one offload connector) and a single model. Once the new hardware is in place we want a fuller pass — more parallelism shapes, and the eviction path (`BlockRemoved`), which never fired in our runs because neither tier filled up.

Will mark ready for review after that. Reviews on the approach are welcome in the meantime.

## Notes

- Verified in deployment by injecting this same logic into the installed `MultiConnector` at container start; this PR is that change in its proper place.
- I have not run the repo's native test suite locally yet.
- The assert's deletion note should be revisited if upstream reopens a generic implementation.
