### PR TITLE
other(test): cover the FP8 and WNA16 linear kernels and models

### DIFF
--- a/tests/native/basic_correctness/test_basic_correctness.py
+++ b/tests/native/basic_correctness/test_basic_correctness.py
@@ -26,6 +26,7 @@ MODELS = [
     # SWA models are incompatible with sub-block prefix caching.
     CompileModelSpec("google/gemma-3-1b-it", envs={"VLLM_RBLN_SUB_BLOCK_CACHE": "0"}),
     CompileModelSpec("Qwen/Qwen3-0.6B-FP8", envs={"VLLM_RBLN_USE_W8A16": "1"}),
+    CompileModelSpec("RedHatAI/Qwen2.5-0.5B-quantized.w8a16"),
 ]
 
 MAX_TOKENS = 5

--- a/tests/native/basic_correctness/test_basic_correctness.py
+++ b/tests/native/basic_correctness/test_basic_correctness.py
@@ -25,7 +25,8 @@ MODELS = [
     CompileModelSpec("Qwen/Qwen3-0.6B"),
     # SWA models are incompatible with sub-block prefix caching.
     CompileModelSpec("google/gemma-3-1b-it", envs={"VLLM_RBLN_SUB_BLOCK_CACHE": "0"}),
-    CompileModelSpec("Qwen/Qwen3-0.6B-FP8", envs={"VLLM_RBLN_USE_W8A16": "1"}),
+    # Quantization schemes
+    CompileModelSpec("Qwen/Qwen3-0.6B-FP8"),
     CompileModelSpec("RedHatAI/Qwen2.5-0.5B-quantized.w8a16"),
 ]
 

--- a/tests/native/basic_correctness/test_basic_correctness.py
+++ b/tests/native/basic_correctness/test_basic_correctness.py
@@ -25,6 +25,7 @@ MODELS = [
     CompileModelSpec("Qwen/Qwen3-0.6B"),
     # SWA models are incompatible with sub-block prefix caching.
     CompileModelSpec("google/gemma-3-1b-it", envs={"VLLM_RBLN_SUB_BLOCK_CACHE": "0"}),
+    CompileModelSpec("Qwen/Qwen3-0.6B-FP8", envs={"VLLM_RBLN_USE_W8A16": "1"}),
 ]
 
 MAX_TOKENS = 5

--- a/tests/native/conftest.py
+++ b/tests/native/conftest.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import contextlib
-import functools
 import json
 import os
 import warnings
@@ -26,6 +25,7 @@ from tests.native.utils import (
     LAYERS_PINNABLE_ENV,
     NATIVE_ENV,
     ModuleSpawn,
+    host_chip,
     read_log_tail,
     scrub_env,
 )
@@ -145,22 +145,6 @@ def pytest_addoption(parser):
     )
 
 
-@functools.cache
-def _host_chip() -> str | None:
-    """The chip this host reports, or None when it cannot be resolved (an
-    NPU-less host) -- filter nothing then, rather than skip everything.
-
-    Safe to call in the parent, unlike opening a device: a name query leaves no
-    /dev/rbln* fd behind, and a child still resolves it afterwards. Resolving it
-    here is what keeps a wrong-chip spec from ever spawning."""
-    from vllm_rbln.platform import RblnPlatform
-
-    try:
-        return RblnPlatform.get_device_name().strip().upper()
-    except Exception:
-        return None
-
-
 def _item_spec(item):
     """The CompileModelSpec this item is parametrized with, under whatever name
     (test_dp_e2e parametrizes a fixture, not the test), or None."""
@@ -178,7 +162,7 @@ def _item_spec(item):
 def _skip_other_chips(items) -> None:
     """Skip specs this host's chip is not in. Only whole-model items: a spec also
     feeds unit tests (test_dp_specs) that assert on it without touching an NPU."""
-    chip = _host_chip()
+    chip = host_chip()
     if chip is None:
         return
     for item in items:
@@ -459,7 +443,7 @@ def pytest_report_header(config):
     )
     # Which chip a job landed on decides which specs run, and a step may request
     # several -- so the run has to say which one it got.
-    header.append(f"native: chip={_host_chip() or 'unknown'}")
+    header.append(f"native: chip={host_chip() or 'unknown'}")
     if _scrubbed:
         header.append(f"native: scrubbed {', '.join(sorted(_scrubbed))}")
     return header

--- a/tests/native/model_executor/kernels/linear/mixed_precision/test_unpacked_wna16.py
+++ b/tests/native/model_executor/kernels/linear/mixed_precision/test_unpacked_wna16.py
@@ -1,0 +1,215 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Pure tensor math, no NPU. The device-side arithmetic is covered by
+# test_unpacked_wna16_compile_parity.py.
+
+import os
+from unittest.mock import patch
+
+import pytest
+import torch
+from vllm.model_executor.kernels.linear import MPLinearLayerConfig
+from vllm.scalar_type import scalar_types
+
+from vllm_rbln.model_executor.kernels.linear.mixed_precision.unpacked_wna16 import (
+    RBLNUnpackedwNa16LinearKernel,
+)
+
+_UNPACK = (
+    "vllm_rbln.model_executor.kernels.linear.mixed_precision."
+    "unpacked_wna16.unpack_from_int32"
+)
+
+
+def _config(
+    *,
+    weight_type=scalar_types.uint8b128,
+    group_size=-1,
+    zero_points=False,
+    has_g_idx=False,
+    in_features=128,
+    out_features=64,
+):
+    return MPLinearLayerConfig(
+        # [in, out]; the kernel hands the transpose to the unpacker, and
+        # swapping the two silently mis-shapes every weight.
+        full_weight_shape=(in_features, out_features),
+        partition_weight_shape=(in_features, out_features),
+        weight_type=weight_type,
+        act_type=torch.float16,
+        group_size=group_size,
+        zero_points=zero_points,
+        has_g_idx=has_g_idx,
+    )
+
+
+def _kernel(config):
+    return RBLNUnpackedwNa16LinearKernel(
+        config, w_q_param_name="weight_packed", w_s_param_name="weight_scale"
+    )
+
+
+@pytest.fixture(autouse=True)
+def _contain_quant_bits(monkeypatch):
+    # process_weights_after_loading writes RBLN_QUANT_BITS straight into
+    # os.environ, which would otherwise leak into the rest of the session.
+    monkeypatch.delenv("RBLN_QUANT_BITS", raising=False)
+
+
+def _layer(w_q, w_s):
+    layer = torch.nn.Module()
+    layer.weight_packed = torch.nn.Parameter(w_q, requires_grad=False)
+    layer.weight_scale = torch.nn.Parameter(w_s, requires_grad=False)
+    return layer
+
+
+class TestCanImplement:
+    @pytest.mark.parametrize(
+        "weight_type", [scalar_types.uint4b8, scalar_types.uint8b128]
+    )
+    def test_accepts_the_two_symmetric_int_types(self, weight_type):
+        assert RBLNUnpackedwNa16LinearKernel.can_implement(
+            _config(weight_type=weight_type)
+        ) == (True, None)
+
+    def test_rejects_another_weight_type(self):
+        ok, reason = RBLNUnpackedwNa16LinearKernel.can_implement(
+            _config(weight_type=scalar_types.uint8)
+        )
+        assert not ok
+        assert "not supported" in reason
+
+    def test_rejects_asymmetric_quantization(self):
+        ok, reason = RBLNUnpackedwNa16LinearKernel.can_implement(
+            _config(zero_points=True)
+        )
+        assert not ok
+        assert "Asymmetric" in reason
+
+    @pytest.mark.parametrize("group_size", [-1, 64, 128])
+    def test_accepts_the_supported_group_sizes(self, group_size):
+        assert RBLNUnpackedwNa16LinearKernel.can_implement(
+            _config(group_size=group_size)
+        ) == (True, None)
+
+    def test_rejects_another_group_size(self):
+        ok, reason = RBLNUnpackedwNa16LinearKernel.can_implement(_config(group_size=32))
+        assert not ok
+        assert "group_size=32" in reason
+
+    def test_rejects_activation_ordering(self):
+        ok, reason = RBLNUnpackedwNa16LinearKernel.can_implement(
+            _config(has_g_idx=True)
+        )
+        assert not ok
+        assert "ordering" in reason
+
+
+class TestProcessWeightsAfterLoading:
+    @pytest.mark.parametrize(
+        ("weight_type", "bits"),
+        [(scalar_types.uint4b8, "4"), (scalar_types.uint8b128, "8")],
+    )
+    def test_publishes_the_bit_width_to_the_compiler(self, weight_type, bits):
+        # The graph carries int8 either way, so this env var is the only thing
+        # that tells rebel_compiler a weight is 4-bit.
+        kernel = _kernel(_config(weight_type=weight_type))
+        layer = _layer(torch.zeros(64, 32, dtype=torch.int32), torch.ones(64, 1))
+        with patch(_UNPACK, return_value=torch.zeros(64, 128, dtype=torch.int8)):
+            kernel.process_weights_after_loading(layer)
+        assert os.environ["RBLN_QUANT_BITS"] == bits
+
+    def test_unpacks_to_the_transpose_of_the_full_weight_shape(self):
+        kernel = _kernel(_config(in_features=128, out_features=64))
+        layer = _layer(torch.zeros(64, 32, dtype=torch.int32), torch.ones(64, 1))
+        with patch(
+            _UNPACK, return_value=torch.zeros(64, 128, dtype=torch.int8)
+        ) as unpack:
+            kernel.process_weights_after_loading(layer)
+        _, num_bits, shape = unpack.call_args.args
+        assert num_bits == 8
+        assert shape == torch.Size((64, 128))
+
+    @pytest.mark.parametrize(
+        ("group_size", "expected_columns"), [(-1, 2), (64, 2), (128, 4)]
+    )
+    def test_only_a_128_group_is_split_into_two_64_groups(
+        self, group_size, expected_columns
+    ):
+        # apply_weights always reads 64-wide groups.
+        kernel = _kernel(_config(group_size=group_size))
+        layer = _layer(
+            torch.zeros(64, 32, dtype=torch.int32), torch.tensor([[1.0, 2.0]] * 64)
+        )
+        with patch(_UNPACK, return_value=torch.zeros(64, 128, dtype=torch.int8)):
+            kernel.process_weights_after_loading(layer)
+        assert layer.weight_scale.shape == (64, expected_columns)
+        if group_size == 128:
+            assert torch.equal(
+                layer.weight_scale[0], torch.tensor([1.0, 1.0, 2.0, 2.0])
+            )
+
+
+class TestApplyWeights:
+    def test_channelwise_scales_every_row_by_one_value(self):
+        kernel = _kernel(_config(group_size=-1, in_features=128, out_features=64))
+        w_q = torch.full((64, 128), 3, dtype=torch.int8)
+        w_s = torch.arange(1, 65, dtype=torch.float16).reshape(64, 1)
+        x = torch.ones(1, 128, dtype=torch.float16)
+        out = kernel.apply_weights(_layer(w_q, w_s), x)
+        # Each output is 128 terms of 3 * that row's scale.
+        assert torch.allclose(out, (3 * 128 * w_s).reshape(1, 64))
+
+    @pytest.mark.parametrize("group_size", [64, 128])
+    def test_grouped_scales_each_64_wide_group_separately(self, group_size):
+        # 64 and 128 differ only upstream: by the time apply_weights sees them
+        # the scale already has one column per 64-wide group either way.
+        kernel = _kernel(
+            _config(group_size=group_size, in_features=128, out_features=64)
+        )
+        w_q = torch.full((64, 128), 2, dtype=torch.int8)
+        w_s = torch.tensor([[1.0, 10.0]] * 64, dtype=torch.float16)
+        x = torch.ones(1, 128, dtype=torch.float16)
+        out = kernel.apply_weights(_layer(w_q, w_s), x)
+        # 64 terms of 2*1 in the first group, 64 of 2*10 in the second.
+        expected = torch.full((1, 64), 64 * 2.0 + 64 * 20.0, dtype=torch.float16)
+        assert torch.allclose(out, expected)
+
+    def test_bias_is_added(self):
+        kernel = _kernel(_config(group_size=-1, in_features=128, out_features=64))
+        layer = _layer(
+            torch.zeros(64, 128, dtype=torch.int8),
+            torch.ones(64, 1, dtype=torch.float16),
+        )
+        bias = torch.arange(64, dtype=torch.float16)
+        out = kernel.apply_weights(layer, torch.ones(1, 128, dtype=torch.float16), bias)
+        assert torch.equal(out, bias.reshape(1, 64))
+
+
+class TestRegistration:
+    def test_kernel_is_registered_for_the_oot_platform(self):
+        from vllm.model_executor.kernels import linear
+        from vllm.platforms import PlatformEnum
+
+        assert (
+            RBLNUnpackedwNa16LinearKernel in linear._POSSIBLE_KERNELS[PlatformEnum.OOT]
+        )
+
+    def test_kernel_is_the_one_chosen_for_a_w8a16_layer(self):
+        # Being in the list is not the same as winning the pick. The config is
+        # what RedHatAI/Qwen2.5-0.5B-quantized.w8a16 resolves to.
+        from vllm.model_executor.kernels.linear import choose_mp_linear_kernel
+
+        assert choose_mp_linear_kernel(_config()) is RBLNUnpackedwNa16LinearKernel

--- a/tests/native/model_executor/kernels/linear/mixed_precision/test_unpacked_wna16_compile_parity.py
+++ b/tests/native/model_executor/kernels/linear/mixed_precision/test_unpacked_wna16_compile_parity.py
@@ -1,0 +1,170 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Compile parity for the unpacked WNA16 kernel: CPU eager is the oracle, and the
+# rbln-compiled graph (plus device eager on the device lane) must agree. The
+# kernel dequantizes an int8 weight and runs a linear; rebel_compiler is expected
+# to recognise that pattern and map it to its quantized kernel, so a divergence
+# here means the mapping changed the arithmetic.
+#
+# The int8 weight is a module buffer, never a graph argument: a 1-byte dtype
+# cannot be a graph input at all. It is also what a real model holds.
+#
+# Channelwise is what RedHatAI/Qwen2.5-0.5B-quantized.w8a16 resolves to; grouped
+# is the other branch through apply_weights, and a 64 and a 128 group reach it
+# through different scale handling upstream.
+
+import pytest
+import torch
+from vllm.model_executor.kernels.linear import MPLinearLayerConfig
+from vllm.platforms import current_platform
+from vllm.scalar_type import scalar_types
+
+from vllm_rbln.compilation.compiler import compile as rbln_compile
+from vllm_rbln.model_executor.kernels.linear.mixed_precision.unpacked_wna16 import (
+    RBLNUnpackedwNa16LinearKernel,
+)
+
+pytestmark = pytest.mark.use_device
+
+_RTOL, _ATOL = 1e-2, 1e-2
+
+# Non-square, so a transposed view would not silently have the right numel.
+_OUT_FEATURES, _IN_FEATURES = 128, 256
+_NUM_TOKENS = 8
+
+_ACT_DTYPES = [torch.float16, torch.bfloat16]
+_ACT_DTYPE_IDS = ["fp16", "bf16"]
+
+# The graph carries int8 for both, and only RBLN_QUANT_BITS says which.
+_WEIGHT_TYPES = [scalar_types.uint8b128, scalar_types.uint4b8]
+_WEIGHT_TYPE_IDS = ["int8", "int4"]
+
+_GROUP_SIZES = [-1, 64, 128]
+_GROUP_IDS = ["channelwise", "group64", "group128"]
+
+# apply_weights always reshapes a grouped weight to 64-wide groups; a 128 group
+# arrives as two of them, doubled by process_weights_after_loading.
+_SCALE_GROUP = 64
+
+
+# Each of the three on its own is fine, and the channelwise branch takes all
+# three.
+_GROUPED_BIAS_XFAIL = pytest.mark.xfail(
+    reason="TODO(rbln-wna16-grouped-bias): grouped WNA16 with a bias does not "
+    "compile for more than one token.",
+)
+
+
+@pytest.fixture(autouse=True)
+def _quant_bits(request, monkeypatch):
+    # Production sets this in process_weights_after_loading, which these tests
+    # start downstream of.
+    weight_type = request.node.callspec.params["weight_type"]
+    monkeypatch.setenv("RBLN_QUANT_BITS", str(weight_type.mantissa))
+
+
+def _agrees(actual, reference) -> bool:
+    return torch.allclose(
+        actual.cpu().float(), reference.float(), rtol=_RTOL, atol=_ATOL
+    )
+
+
+def _assert_parity(build, activation):
+    # Each step gets its own module: a weight-free compile relays the weight
+    # buffer into the hardware layout in place -- that buffer is the weight pool,
+    # not a copy -- so a compiled module no longer reads back as a plain tensor.
+    dev = current_platform.device_type
+    # 1. CPU eager oracle.
+    ref = build()(activation)
+    # 2. rbln-compiled, on whichever tensors the lane selects.
+    dev_activation = activation.to(dev)
+    assert _agrees(rbln_compile(build().to(dev), fullgraph=True)(dev_activation), ref)
+    # 3. device eager, only when device tensors are on (--device-tensor 1).
+    if dev == "rbln":
+        assert _agrees(build().to(dev)(dev_activation), ref)
+
+
+def _quantized_weight():
+    # -8..7 repeating: the whole int4 range, exact in every dtype here, so a byte
+    # read out of place is a different number rather than a rounding difference.
+    marker = (torch.arange(_IN_FEATURES) % 16) - 8
+    return marker.unsqueeze(0).expand(_OUT_FEATURES, _IN_FEATURES).to(torch.int8)
+
+
+def _scale(group_size, act_dtype):
+    columns = 1 if group_size < 0 else _IN_FEATURES // _SCALE_GROUP
+    return (
+        ((torch.arange(_OUT_FEATURES * columns) % 4) + 1)
+        .reshape(_OUT_FEATURES, columns)
+        .to(act_dtype)
+    )
+
+
+class _Apply(torch.nn.Module):
+    def __init__(self, group_size, act_dtype, weight_type, bias=None):
+        super().__init__()
+        self.kernel = RBLNUnpackedwNa16LinearKernel(
+            MPLinearLayerConfig(
+                full_weight_shape=(_IN_FEATURES, _OUT_FEATURES),
+                partition_weight_shape=(_IN_FEATURES, _OUT_FEATURES),
+                weight_type=weight_type,
+                act_type=act_dtype,
+                group_size=group_size,
+                zero_points=False,
+                has_g_idx=False,
+            ),
+            w_q_param_name="weight_packed",
+            w_s_param_name="weight_scale",
+        )
+        self.register_buffer("weight_packed", _quantized_weight())
+        self.register_buffer("weight_scale", _scale(group_size, act_dtype))
+        self.register_buffer("bias", bias)
+
+    def forward(self, activation):
+        return self.kernel.apply_weights(self, activation, self.bias)
+
+
+@pytest.mark.parametrize("weight_type", _WEIGHT_TYPES, ids=_WEIGHT_TYPE_IDS)
+@pytest.mark.parametrize("act_dtype", _ACT_DTYPES, ids=_ACT_DTYPE_IDS)
+@pytest.mark.parametrize("group_size", _GROUP_SIZES, ids=_GROUP_IDS)
+def test_dequantized_weight_matches_rbln_compiled(group_size, act_dtype, weight_type):
+    # The identity readout makes every output element one dequantized weight
+    # element, so nothing accumulates over a misplaced byte.
+    _assert_parity(
+        lambda: _Apply(group_size, act_dtype, weight_type),
+        torch.eye(_IN_FEATURES, dtype=act_dtype),
+    )
+
+
+@pytest.mark.parametrize("weight_type", _WEIGHT_TYPES, ids=_WEIGHT_TYPE_IDS)
+@pytest.mark.parametrize("act_dtype", _ACT_DTYPES, ids=_ACT_DTYPE_IDS)
+@pytest.mark.parametrize(
+    "group_size",
+    [
+        -1,
+        pytest.param(64, marks=_GROUPED_BIAS_XFAIL),
+        pytest.param(128, marks=_GROUPED_BIAS_XFAIL),
+    ],
+    ids=_GROUP_IDS,
+)
+def test_apply_weights_matches_rbln_compiled(group_size, act_dtype, weight_type):
+    # Many tokens and a bias, the way a real decoder layer calls this.
+    activation = (
+        torch.linspace(0.5, 3.0, _NUM_TOKENS * _IN_FEATURES)
+        .reshape(_NUM_TOKENS, _IN_FEATURES)
+        .to(act_dtype)
+    )
+    bias = (torch.arange(_OUT_FEATURES) / 8).to(act_dtype)
+    _assert_parity(lambda: _Apply(group_size, act_dtype, weight_type, bias), activation)

--- a/tests/native/model_executor/kernels/linear/mixed_precision/test_unpacked_wna16_compile_parity.py
+++ b/tests/native/model_executor/kernels/linear/mixed_precision/test_unpacked_wna16_compile_parity.py
@@ -31,6 +31,8 @@ from vllm.model_executor.kernels.linear import MPLinearLayerConfig
 from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
 
+from tests.native.model_specs import REBEL
+from tests.native.utils import host_chip
 from vllm_rbln.compilation.compiler import compile as rbln_compile
 from vllm_rbln.model_executor.kernels.linear.mixed_precision.unpacked_wna16 import (
     RBLNUnpackedwNa16LinearKernel,
@@ -38,7 +40,14 @@ from vllm_rbln.model_executor.kernels.linear.mixed_precision.unpacked_wna16 impo
 
 pytestmark = pytest.mark.use_device
 
-_RTOL, _ATOL = 1e-2, 1e-2
+# How much room the device needs against the CPU eager oracle is not the same for
+# every activation dtype or every target.
+# TODO(rbln-bf16-parity-tol): revisit the REBEL entry.
+_RTOL = {
+    torch.float16: 1e-2,
+    torch.bfloat16: 3e-2 if host_chip() in REBEL else 1e-2,
+}
+_ATOL = 1e-2
 
 # Non-square, so a transposed view would not silently have the right numel.
 _OUT_FEATURES, _IN_FEATURES = 128, 256
@@ -51,7 +60,20 @@ _ACT_DTYPE_IDS = ["fp16", "bf16"]
 _WEIGHT_TYPES = [scalar_types.uint8b128, scalar_types.uint4b8]
 _WEIGHT_TYPE_IDS = ["int8", "int4"]
 
-_GROUP_SIZES = [-1, 64, 128]
+# Grouped WNA16 does not compile on REBEL today; channelwise does. Not a group
+# size constraint -- a directly built 128 group is rejected the same way.
+_REBEL_GROUPED_XFAIL = pytest.mark.xfail(
+    host_chip() in REBEL,
+    reason="TODO(rbln-wna16-grouped-rebel): grouped WNA16 does not compile on "
+    "REBEL; drop when it does.",
+    strict=True,
+)
+
+_GROUP_SIZES = [
+    -1,
+    pytest.param(64, marks=_REBEL_GROUPED_XFAIL),
+    pytest.param(128, marks=_REBEL_GROUPED_XFAIL),
+]
 _GROUP_IDS = ["channelwise", "group64", "group128"]
 
 # apply_weights always reshapes a grouped weight to 64-wide groups; a 128 group
@@ -77,7 +99,10 @@ def _quant_bits(request, monkeypatch):
 
 def _agrees(actual, reference) -> bool:
     return torch.allclose(
-        actual.cpu().float(), reference.float(), rtol=_RTOL, atol=_ATOL
+        actual.cpu().float(),
+        reference.float(),
+        rtol=_RTOL[reference.dtype],
+        atol=_ATOL,
     )
 
 

--- a/tests/native/model_executor/kernels/linear/test_block_fp8_compile_parity.py
+++ b/tests/native/model_executor/kernels/linear/test_block_fp8_compile_parity.py
@@ -13,8 +13,17 @@
 # limitations under the License.
 
 # Compile parity for the W8A16 block-FP8 kernel: CPU eager is the oracle, and the
-# rbln-compiled graph (plus device eager on the device lane) must agree. Inputs use
-# production-sized 128-blocks because toy shapes trip an rbln-compiler edge case.
+# rbln-compiled graph (plus device eager on the device lane) must agree.
+#
+# Three shapes here are dictated by what the compiler accepts, not by taste:
+#
+#   - The fp8 weight is a module buffer, never a graph argument: a 1-byte dtype
+#     cannot be a graph input at all. It is also what a real model holds.
+#   - Every graph ends in the linear; a dequant with no matmul is rejected. The
+#     dequant test therefore reads out through F.linear(I, W), which is W
+#     transposed -- one output element per weight element, nothing to hide in.
+#   - The weight spans more than one block per axis: a 128x128 weight, a 1x1
+#     scale grid, fails to compile.
 
 from typing import Any
 
@@ -27,28 +36,20 @@ from vllm_rbln.model_executor.kernels.linear.block_fp8 import (
     RBLNW8A16BlockFp8LinearKernel,
 )
 
-# TODO(rbln-fp8-compile): the whole file is skipped -- the rbln-compiled kernel
-# diverges from CPU eager on fp8 weights (a bare fp8->float dequant already gives
-# alternating ~2x values), which looks like a 1-byte .view()/reshape layout issue
-# in the compile path. W8A8 shares the root cause; extend the parity here to its
-# forward once resolved.
-pytestmark = [
-    pytest.mark.use_device,
-    pytest.mark.skip(
-        reason="TODO(rbln-fp8-compile): compiled fp8 dequant diverges "
-        "from eager; see file header."
-    ),
-]
+pytestmark = pytest.mark.use_device
 
-# The compiled/device fp8 paths round differently from CPU eager, so parity is
-# checked within an fp8-sized tolerance rather than exactly.
 _RTOL, _ATOL = 1e-2, 1e-2
 
 # Production-sized fp8 block; toy blocks hit an rbln-compiler reshape edge case.
 _BLOCK_N = _BLOCK_K = 128
+# Non-square, so a transposed view would not silently have the right numel.
+_OUT_FEATURES, _IN_FEATURES = 2 * _BLOCK_N, 4 * _BLOCK_K
+_NUM_TOKENS = 8
+# One scale per (block_n, block_k) tile of the weight.
+_SCALE = [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]]
 
-# The activation (and thus the output) is fp16 on the W8A16 path.
-_ACT_DTYPE = torch.float16
+_ACT_DTYPES = [torch.float16, torch.bfloat16]
+_ACT_DTYPE_IDS = ["fp16", "bf16"]
 
 # Built once outside any compiled region so torch.compile sees weight_group_shape
 # as a constant instead of tracing the (untraceable) object construction.
@@ -67,20 +68,22 @@ def _to_session_device(args):
     return tuple(a.to(dev) if torch.is_tensor(a) else a for a in args)
 
 
-def _assert_parity(run_fn, *cpu_args):
+def _assert_parity(build, *cpu_args):
+    # Each step gets its own module: a weight-free compile relays the weight
+    # buffer into the hardware layout in place -- that buffer is the weight pool,
+    # not a copy -- so a compiled module no longer reads back as a plain tensor.
+    dev = current_platform.device_type
     # 1. CPU eager oracle.
-    ref = run_fn(*cpu_args)
-    # 2. rbln-compiled on the session's tensors (cpu lane -> cpu, device lane ->
-    #    device, matching how the backend runs the compiled graph in production).
+    ref = build()(*cpu_args)
+    # 2. rbln-compiled, on whichever tensors the lane selects.
     dev_args = _to_session_device(cpu_args)
-    assert _agrees(rbln_compile(run_fn, fullgraph=True)(*dev_args), ref)
+    assert _agrees(rbln_compile(build().to(dev), fullgraph=True)(*dev_args), ref)
     # 3. device eager, only when device tensors are on (--device-tensor 1).
-    if current_platform.device_type == "rbln":
-        assert _agrees(run_fn(*dev_args), ref)
+    if dev == "rbln":
+        assert _agrees(build().to(dev)(*dev_args), ref)
 
 
 def _fp8_weight(out_features, in_features):
-    # Block-FP8 weights are stored as fp8; the graph dequantizes them.
     return (
         torch.linspace(0.1, 2.0, out_features * in_features)
         .reshape(out_features, in_features)
@@ -88,28 +91,51 @@ def _fp8_weight(out_features, in_features):
     )
 
 
-def test_dequantize_block_weight_matches_rbln_compiled():
-    def run_dequant(weight, scale):
-        return _KERNEL._dequantize_block_fp8_weight(weight, scale, _ACT_DTYPE)
+class _Dequant(torch.nn.Module):
+    def __init__(self, weight, scale, act_dtype):
+        super().__init__()
+        self.act_dtype = act_dtype
+        self.register_buffer("weight", weight)
+        self.register_buffer("scale", scale)
 
-    # 256x256 fp8 weight over 128-blocks -> a 2x2 block-scale grid.
+    def forward(self, readout):
+        dequantized = _KERNEL._dequantize_block_fp8_weight(
+            self.weight, self.scale, self.act_dtype
+        )
+        return torch.nn.functional.linear(readout, dequantized)
+
+
+class _Apply(torch.nn.Module):
+    def __init__(self, weight, scale):  # act dtype follows the activation
+        super().__init__()
+        self.register_buffer("weight", weight)
+        self.register_buffer("scale", scale)
+
+    def forward(self, activation):
+        return _KERNEL.apply_block_scaled_mm(activation, self.weight, None, self.scale)
+
+
+@pytest.mark.parametrize("act_dtype", _ACT_DTYPES, ids=_ACT_DTYPE_IDS)
+def test_dequantize_block_weight_matches_rbln_compiled(act_dtype):
     _assert_parity(
-        run_dequant,
-        _fp8_weight(256, 256),
-        torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+        lambda: _Dequant(
+            _fp8_weight(_OUT_FEATURES, _IN_FEATURES),
+            torch.tensor(_SCALE),
+            act_dtype,
+        ),
+        torch.eye(_IN_FEATURES, dtype=act_dtype),
     )
 
 
-def test_apply_block_scaled_mm_matches_rbln_compiled():
-    # The W8A16 forward: dequant the fp8 weight and run the fp16 linear, all in
-    # one compiled graph. The activation stays fp16 (A16, not quantized).
-    def run_apply(activation, weight, scale):
-        return _KERNEL.apply_block_scaled_mm(activation, weight, None, scale)
-
-    activation = torch.linspace(0.5, 3.0, 128).reshape(1, 128).to(_ACT_DTYPE)
+@pytest.mark.parametrize("act_dtype", _ACT_DTYPES, ids=_ACT_DTYPE_IDS)
+def test_apply_block_scaled_mm_matches_rbln_compiled(act_dtype):
+    # Many tokens, the way a real decoder layer calls this.
+    activation = (
+        torch.linspace(0.5, 3.0, _NUM_TOKENS * _IN_FEATURES)
+        .reshape(_NUM_TOKENS, _IN_FEATURES)
+        .to(act_dtype)
+    )
     _assert_parity(
-        run_apply,
+        lambda: _Apply(_fp8_weight(_OUT_FEATURES, _IN_FEATURES), torch.tensor(_SCALE)),
         activation,
-        _fp8_weight(128, 128),
-        torch.full((1, 1), 2.0),
     )

--- a/tests/native/model_executor/kernels/linear/test_block_fp8_compile_parity.py
+++ b/tests/native/model_executor/kernels/linear/test_block_fp8_compile_parity.py
@@ -31,6 +31,8 @@ import pytest
 import torch
 from vllm.platforms import current_platform
 
+from tests.native.model_specs import REBEL
+from tests.native.utils import host_chip
 from vllm_rbln.compilation.compiler import compile as rbln_compile
 from vllm_rbln.model_executor.kernels.linear.block_fp8 import (
     RBLNW8A16BlockFp8LinearKernel,
@@ -38,7 +40,14 @@ from vllm_rbln.model_executor.kernels.linear.block_fp8 import (
 
 pytestmark = pytest.mark.use_device
 
-_RTOL, _ATOL = 1e-2, 1e-2
+# How much room the device needs against the CPU eager oracle is not the same for
+# every activation dtype or every target.
+# TODO(rbln-bf16-parity-tol): revisit the REBEL entry.
+_RTOL = {
+    torch.float16: 1e-2,
+    torch.bfloat16: 3e-2 if host_chip() in REBEL else 1e-2,
+}
+_ATOL = 1e-2
 
 # Production-sized fp8 block; toy blocks hit an rbln-compiler reshape edge case.
 _BLOCK_N = _BLOCK_K = 128
@@ -59,7 +68,10 @@ _KERNEL.weight_group_shape = (_BLOCK_N, _BLOCK_K)
 
 def _agrees(actual, reference) -> bool:
     return torch.allclose(
-        actual.cpu().float(), reference.float(), rtol=_RTOL, atol=_ATOL
+        actual.cpu().float(),
+        reference.float(),
+        rtol=_RTOL[reference.dtype],
+        atol=_ATOL,
     )
 
 

--- a/tests/native/test_chip_selection.py
+++ b/tests/native/test_chip_selection.py
@@ -54,7 +54,7 @@ def on_chip(monkeypatch):
     # The resolver, not its cache: patching the lookup keeps the real one's
     # memoization out of the test's way.
     def use(chip):
-        monkeypatch.setattr(conftest, "_host_chip", lambda: chip)
+        monkeypatch.setattr(conftest, "host_chip", lambda: chip)
 
     return use
 

--- a/tests/native/utils.py
+++ b/tests/native/utils.py
@@ -242,6 +242,22 @@ def rbln_device_count() -> int:
     return len(visible) or len(glob.glob(_RBLN_DEVICE_NODES))
 
 
+@functools.cache
+def host_chip() -> str | None:
+    """The chip this host reports, or None when it cannot be resolved (an
+    NPU-less host) -- filter nothing then, rather than skip everything.
+
+    Safe to call in the parent, unlike opening a device: a name query leaves no
+    /dev/rbln* fd behind, and a child still resolves it afterwards. Resolving it
+    here is what keeps a wrong-chip spec from ever spawning."""
+    from vllm_rbln.platform import RblnPlatform
+
+    try:
+        return RblnPlatform.get_device_name().strip().upper()
+    except Exception:
+        return None
+
+
 def devices_needed(engine_kwargs: dict, rsd: int = 1) -> int:
     """NPUs an engine built with ``engine_kwargs`` will occupy. Mirrors
     RBLNWorker._init_device_env: DP ranks do not share, and every rank of


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

This PR adds test coverage for the quantized linear kernels on the vLLM-native path:

1. **Block-FP8.** Reworked the compile-parity tests for `RBLNW8A16BlockFp8LinearKernel`.
2. **WNA16.** New tests for `RBLNUnpackedwNa16LinearKernel`: one file of plain tensor math that needs no NPU, and one compile-parity file that does.
3. **End to end.** Two quantized models in `basic_correctness`: `Qwen/Qwen3-0.6B-FP8` and `RedHatAI/Qwen2.5-0.5B-quantized.w8a16`.

Two expectations turned out to depend on the chip family, so they are keyed on it instead of being written once for every chip:

- Grouped WNA16 (`group_size` 64 and 128) does not compile on REBEL, while channelwise does. Those params `xfail` on REBEL only. The mark is `strict`, so the run will fail and tell us on the day it starts to compile.
  (need to check `RedHatAI/phi-4-quantized.w4a16` model run)
- At bf16 the device needs a wider tolerance on REBEL. `_agrees` now reads the tolerance from the activation dtype and the chip family, so ATOM keeps the old value.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [x] ❓ Other (`other`): tests only, no change under `vllm_rbln/`

---

### 🧪 How to Test

On a REBEL host, with device tensors:

```
uv run --no-sync pytest tests/native/model_executor/kernels/linear -q
```

Expected: 54 passed, 16 xfailed

The two models:

```
uv run --no-sync pytest tests/native/basic_correctness/test_basic_correctness.py -q --model-compile -k "FP8 or w8a16"
```

Expected: 2 passed, 3 deselected

On an ATOM host the grouped cases should pass, because the mark is off there, and the bf16 tolerance stays at the old value.

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
