### PR TITLE
other(ci): drop CA25 from PR CI and reseat its nightly lanes

### DIFF
--- a/.buildkite/pipelines/vllm-rbln/pipeline-pr.yml
+++ b/.buildkite/pipelines/vllm-rbln/pipeline-pr.yml
@@ -38,21 +38,6 @@ _sync: &sync |
   bash .buildkite/scripts/rebel-compiler-override.sh
 
 steps:
-  - label: ":pytest: [CA25] pytest"
-    key: "vllm-rbln-pytest-ca25"
-    if_changed: *if_changed
-    agents:
-      queue: r18s
-      resource_class: "RBLN-CA25-32"
-    image: "${DEVTOOLS_DOCKER_IMAGE}"
-    secrets: *secrets
-    timeout_in_minutes: 60
-    command:
-      - *sync
-      - "echo '--- :pytest: pytest (sampler)' && uv run --no-sync pytest tests/torch_compile/unit/v1/sample -v"
-      - "bash .buildkite/pipelines/vllm-rbln/scripts/run-t0-unit.sh"
-      - "bash .buildkite/pipelines/vllm-rbln/scripts/run-t1-compile.sh"
-
   - label: ":pytest: [CR13] pytest"
     key: "vllm-rbln-pytest-cr13"
     if_changed: *if_changed

--- a/.buildkite/vllm-rbln-nightly.yml
+++ b/.buildkite/vllm-rbln-nightly.yml
@@ -14,6 +14,14 @@ _secrets: &secrets
   HF_TOKEN: FSW_HF_TOKEN
   HF_HOME: FSW_HF_HOME
 
+_secrets_k8s: &secrets_k8s
+  UV_INDEX_RBLN_NEXUS_NIGHTLY_USERNAME: MGMT_NEXUS_USERNAME
+  UV_INDEX_RBLN_NEXUS_NIGHTLY_PASSWORD: MGMT_NEXUS_PASSWORD
+  UV_INDEX_REBELLIONS_USERNAME: REBEL_SW_DEV_USERNAME
+  UV_INDEX_REBELLIONS_PASSWORD: REBEL_SW_DEV_PASSWORD
+  HF_TOKEN: HF_TOKEN
+  HF_HOME: HF_HOME
+
 
 _sync: &sync "echo '--- :package: uv sync' && uv sync --locked --python 3.12 --extra test --extra dev --extra runtime"
 
@@ -28,24 +36,30 @@ _lm_eval: &lm_eval
 steps:
   - label: ":pytest: [CA25] pytest (T0)"
     key: "nightly-t0-ca25"
-    agents:
-      queue: r18s
-      resource_class: "RBLN-CA25-4"
     image: "${DEVTOOLS_DOCKER_IMAGE}"
-    secrets: *secrets
+    resources:
+      npu:
+        count: 4
+        product: "RBLN-CA25"
+    secrets: *secrets_k8s
+    env:
+      UV_CACHE_DIR: "/mnt/uv_cache"
     timeout_in_minutes: 60
     command:
       - *sync
+      - "echo '--- :pytest: pytest (sampler)' && uv run --no-sync pytest tests/torch_compile/unit/v1/sample -v"
       - "bash .buildkite/pipelines/vllm-rbln/scripts/run-t0-unit.sh"
 
   - label: ":pytest: [CA25] pytest (T2)"
     key: "nightly-t2-ca25"
-    agents:
-      queue: r18s
-      resource_class: "RBLN-CA25-32"
     image: "${DEVTOOLS_DOCKER_IMAGE}"
-    secrets: *secrets
+    resources:
+      npu:
+        count: 32
+        product: "RBLN-CA25"
+    secrets: *secrets_k8s
     env:
+      UV_CACHE_DIR: "/mnt/uv_cache"
       VLLM_RBLN_TEST_COMPILE_TIMEOUT_S: "3600"
       VLLM_RBLN_TEST_DP_TIMEOUT_S: "3600"
     timeout_in_minutes: 120


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

- Drops the `[CA25] pytest` step from the vllm-rbln PR pipeline
- Reseat the nightly CA25 lanes onto the NPU pool the optimum-pr steps use
- Move the sampler suite that only the removed step ran into nightly T0.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [x] ❓ Other (`other`): CI pipeline configuration

---

### 🧪 How to Test

N/A

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
