### PR TITLE
perf(sampler): trim the host work around the rejection-sample graph

### DIFF
--- a/tests/native/v1/worker/test_rbln_model_runner.py
+++ b/tests/native/v1/worker/test_rbln_model_runner.py
@@ -355,8 +355,17 @@ def test_rejection_sampler_warmup_uses_per_stage_batch_bound(monkeypatch):
 
     runner._warmup_sampler_decode_batches()
 
-    assert rejection_sample.call_count == 1
-    assert len(rejection_sample.call_args.args[1]) == 4
+    # One call per bonus-token graph: the argmax-in-graph one an all-greedy
+    # step without logprobs takes, and the pre-sampled-ids one every other
+    # step takes. Both are warmed at the same batch bound.
+    assert rejection_sample.call_count == 2
+    for call in rejection_sample.call_args_list:
+        assert len(call.args[1]) == 4
+    variants = [
+        (call.args[6] is None, call.kwargs["bonus_logits"] is None)
+        for call in rejection_sample.call_args_list
+    ]
+    assert sorted(variants) == [(False, True), (True, False)]
 
 
 class TestPredicates:

--- a/tests/torch_compile/unit/v1/sample/test_rbln_rejection_sampler.py
+++ b/tests/torch_compile/unit/v1/sample/test_rbln_rejection_sampler.py
@@ -377,10 +377,13 @@ def run_rejection_sample(
     bonus_token_ids: list[int],
     metadata: SamplingMetadata,
     num_draft_tokens: list[int] | None = None,
+    bonus_from_logits: bool = False,
 ) -> torch.Tensor:
     """Run the impl on a batch of drafts packed in `draft_token_ids` order.
 
     `num_draft_tokens` defaults to every request holding NUM_SPEC_TOKENS drafts.
+    `bonus_from_logits` hands the graph bonus logits peaked at `bonus_token_ids`
+    instead of the ids, the way a greedy step does.
     """
     if num_draft_tokens is None:
         num_draft_tokens = [NUM_SPEC_TOKENS] * (len(draft_token_ids) // NUM_SPEC_TOKENS)
@@ -393,8 +396,11 @@ def run_rejection_sample(
         ),
         draft_probs=None,
         target_logits=make_target_probs(target_argmax_token_ids),
-        bonus_token_ids=torch.tensor(bonus_token_ids, dtype=torch.int64).unsqueeze(-1),
+        bonus_token_ids=None
+        if bonus_from_logits
+        else torch.tensor(bonus_token_ids, dtype=torch.int64).unsqueeze(-1),
         sampling_metadata=metadata,
+        bonus_logits=make_target_probs(bonus_token_ids) if bonus_from_logits else None,
     )
 
 
@@ -432,6 +438,35 @@ def test_greedy_rows_accept_exactly_the_target_argmax(impl, trial):
             [3, 5, 10],  # all accepted -> bonus token
             [2, 7, PLACEHOLDER_TOKEN_ID],  # accept one, then recover the argmax
             [6, 1, 12],  # top_k=1 row behaves like the greedy rows
+        ],
+        dtype=torch.int32,
+    )
+    assert torch.equal(output, expected)
+
+
+def test_greedy_bonus_token_is_the_argmax_of_its_logits(impl):
+    """A greedy step hands the graph the bonus rows' logits; their argmax lands
+    where the bonus token id would."""
+    metadata = make_sampling_metadata(
+        temperature=None,
+        all_greedy=True,
+        all_random=False,
+    )
+
+    output = run_rejection_sample(
+        impl,
+        # Row 0 matches both argmaxes; row 1 mismatches at position 1.
+        draft_token_ids=[3, 5, 2, 4],
+        target_argmax_token_ids=[3, 5, 2, 7],
+        bonus_token_ids=[6, 1],
+        metadata=metadata,
+        bonus_from_logits=True,
+    )
+
+    expected = torch.tensor(
+        [
+            [3, 5, 6],  # all accepted -> the bonus row's argmax
+            [2, 7, PLACEHOLDER_TOKEN_ID],
         ],
         dtype=torch.int32,
     )

--- a/vllm_rbln/v1/sample/rbln_rejection_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_rejection_sampler.py
@@ -29,6 +29,7 @@ from vllm_rbln.logger import init_logger
 from vllm_rbln.platform import HAS_TORCH_RBLN, USE_DEVICE_TENSOR
 from vllm_rbln.v1.sample.ops.top_k_top_p import (
     GREEDY_TEMPERATURE,
+    GREEDY_TOP_K,
     build_op_top_k_top_p,
 )
 
@@ -238,6 +239,9 @@ class TorchRejectionSamplerImpl(RejectionSamplerImpl):
         bonus_logits: torch.Tensor | None = None,
     ) -> torch.Tensor:
         assert bonus_token_ids is not None
+        # The runner hands the draft ids over on the host; this impl samples
+        # wherever the logits are.
+        draft_token_ids = draft_token_ids.to(target_logits.device)
         target_logits = self.apply_sampling_constraints(
             target_logits,
             cu_num_draft_tokens,
@@ -351,6 +355,10 @@ class RBLNRejectionSamplerImpl(RejectionSamplerImpl):
             # sampler off misses this op and forces a partial compile.
             use_cache=False,
         )
+        # The graph's small inputs, one set per input shape: handing the same
+        # tensors over every step keeps the runtime's input bindings warm --
+        # a fresh address re-validates and re-binds the input.
+        self._graph_inputs: dict[tuple, dict[str, torch.Tensor]] = {}
 
     def rejection_sample(
         self,
@@ -406,40 +414,58 @@ class RBLNRejectionSamplerImpl(RejectionSamplerImpl):
         assert target_logits.shape == (num_tokens, vocab_size)
 
         device = target_logits.device
+        dtype = target_logits.dtype
+        key = (batch_size, vocab_size, dtype, device)
+        if (bufs := self._graph_inputs.get(key)) is None:
+            # Every length is the config-fixed `num_spec_tokens` the op's
+            # inputs are padded to just above, not the batch's own longest run.
+            buf_len = batch_size * self.num_spec_tokens
+            bufs = self._graph_inputs[key] = {
+                "draft_token_ids": torch.zeros(
+                    buf_len, dtype=torch.int32, device=device
+                ),
+                "draft_per_batch": torch.full(
+                    (batch_size, self.num_spec_tokens),
+                    PLACEHOLDER_TOKEN_ID,
+                    dtype=torch.int32,
+                    device=device,
+                ),
+                "temperature": torch.ones(buf_len, dtype=dtype, device=device),
+                "ones": torch.ones(buf_len, dtype=dtype, device=device),
+                "greedy_top_k": torch.full(
+                    (batch_size,), GREEDY_TOP_K, dtype=torch.int32, device=device
+                ),
+                "cu_num_draft_tokens": torch.zeros(
+                    batch_size, dtype=torch.int32, device=device
+                ),
+                "counts": torch.zeros(batch_size, dtype=torch.int32, device=device),
+            }
 
-        # Pad the packed inputs to the fixed [B*K] length the op wants.
+        # Pad the packed inputs to the fixed [B*K] length the op wants. Rows past
+        # the packed length carry an earlier step's values, which the op reads
+        # only into slots its acceptance count clips.
         N = num_tokens  # = sum(num_draft_tokens)
         padded_len = batch_size * max_spec_len
+        reshaped_draft_token_ids = bufs["draft_token_ids"]
+        draft_per_batch = bufs["draft_per_batch"]
         if padded_len == N:
             # Full K drafts everywhere: already packed and padded, and request
             # r's draft c sits at r * K + c. Two graph inputs must not alias one
             # buffer, so the per-batch view is its own copy.
-            reshaped_draft_token_ids = draft_token_ids.to(device)
+            reshaped_draft_token_ids.copy_(draft_token_ids)
             reshaped_target_logits = target_logits
-            draft_per_batch = draft_token_ids.view(batch_size, max_spec_len).to(
-                device, copy=True
-            )
+            draft_per_batch.copy_(draft_token_ids.view(batch_size, max_spec_len))
         else:
-            reshaped_draft_token_ids = torch.zeros(
-                padded_len,
-                dtype=torch.int32,
-                device=device,
-            )
-            reshaped_target_logits = torch.zeros(
-                padded_len,
-                vocab_size,
-                dtype=target_logits.dtype,
-                device=device,
-            )
+            # Only a partial-draft step needs the padded logits block, and it
+            # is the one big buffer here, so it is allocated on first use.
+            if (reshaped_target_logits := bufs.get("target_logits")) is None:
+                reshaped_target_logits = bufs["target_logits"] = torch.zeros(
+                    padded_len, vocab_size, dtype=dtype, device=device
+                )
             reshaped_draft_token_ids[:N] = draft_token_ids
             reshaped_target_logits[:N] = target_logits
 
-            draft_per_batch = torch.full(
-                (batch_size, max_spec_len),
-                PLACEHOLDER_TOKEN_ID,
-                dtype=torch.int32,
-                device=device,
-            )
+            draft_per_batch.fill_(PLACEHOLDER_TOKEN_ID)
             src_offset = 0
             for i, n in enumerate(num_draft_tokens):
                 if n == 0:
@@ -447,22 +473,22 @@ class RBLNRejectionSamplerImpl(RejectionSamplerImpl):
                 draft_per_batch[i, :n] = draft_token_ids[src_offset : src_offset + n]
                 src_offset += n
 
-        top_k, top_p = build_op_top_k_top_p(
-            sampling_metadata,
-            batch_size,
-            vocab_size,
-            device,
-        )
+        if sampling_metadata.all_greedy:
+            top_k, top_p = bufs["greedy_top_k"], None
+        else:
+            top_k, top_p = build_op_top_k_top_p(
+                sampling_metadata,
+                batch_size,
+                vocab_size,
+                device,
+            )
 
         # NOTE(RBLN): Per-row temperature for the divide inside the graph. Padding
         # and greedy rows must carry 1.0 -- a 0 would divide by zero.
-        reshaped_temperature = torch.ones(
-            padded_len,
-            dtype=target_logits.dtype,
-            device=device,
-        )
+        reshaped_temperature = bufs["ones"]
         temperature = sampling_metadata.temperature
         if not sampling_metadata.all_greedy and temperature is not None:
+            reshaped_temperature = bufs["temperature"]
             if not sampling_metadata.all_random:
                 temperature = torch.where(
                     temperature == GREEDY_TEMPERATURE,
@@ -477,17 +503,19 @@ class RBLNRejectionSamplerImpl(RejectionSamplerImpl):
                     temperature.unsqueeze(1)
                 )
             else:
+                reshaped_temperature.fill_(1)
                 reshaped_temperature[:N] = expand_batch_to_tokens(
                     temperature, cu_num_draft_tokens, num_tokens
                 )
 
-        num_draft_tokens_t = torch.tensor(
-            num_draft_tokens, dtype=torch.int32, device=device
-        )
+        cu_num_draft_tokens_t = bufs["cu_num_draft_tokens"]
+        cu_num_draft_tokens_t.copy_(cu_num_draft_tokens)
+        num_draft_tokens_t = bufs["counts"]
+        num_draft_tokens_t.copy_(torch.tensor(num_draft_tokens, dtype=torch.int32))
         return self._compiled_rejection_sample(
             reshaped_draft_token_ids,
             reshaped_target_logits,
-            cu_num_draft_tokens.to(device),
+            cu_num_draft_tokens_t,
             top_k,
             top_p,
             reshaped_temperature,

--- a/vllm_rbln/v1/sample/rbln_rejection_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_rejection_sampler.py
@@ -124,19 +124,35 @@ class RBLNRejectionSampler(RejectionSampler):
         # logprobs; asking for them widens the rows to float32, which on the
         # device is a host round trip, so ask only when logprobs are requested.
         wants_logprobs = sampling_metadata.max_num_logprobs is not None
-        bonus_sampler_output = self.sampler(
-            logits=bonus_logits,
-            sampling_metadata=replace(sampling_metadata, max_num_logprobs=-1)
-            if wants_logprobs
-            else sampling_metadata,
-            predict_bonus_token=True,
-            logprobs_mode_override=(
-                "processed_logits" if self.is_processed_logprobs_mode else "raw_logits"
+        bonus_token_ids = None
+        if (
+            sampling_metadata.all_greedy
+            and not wants_logprobs
+            and not sampling_metadata.logprob_token_ids
+            and isinstance(self.impl, RBLNRejectionSamplerImpl)
+        ):
+            # A greedy bonus token is its row's argmax; the rejection graph
+            # takes it there instead of a separate sampler launch.
+            bonus_logits = self.sampler.apply_logits_processors(
+                bonus_logits, sampling_metadata, predict_bonus_token=True
             )
-            if wants_logprobs
-            else None,
-        )
-        bonus_token_ids = bonus_sampler_output.sampled_token_ids
+        else:
+            bonus_sampler_output = self.sampler(
+                logits=bonus_logits,
+                sampling_metadata=replace(sampling_metadata, max_num_logprobs=-1)
+                if wants_logprobs
+                else sampling_metadata,
+                predict_bonus_token=True,
+                logprobs_mode_override=(
+                    "processed_logits"
+                    if self.is_processed_logprobs_mode
+                    else "raw_logits"
+                )
+                if wants_logprobs
+                else None,
+            )
+            bonus_token_ids = bonus_sampler_output.sampled_token_ids
+            bonus_logits = None
 
         # [num_tokens, vocab_size]
         target_logits = self.apply_logits_processors(
@@ -154,6 +170,7 @@ class RBLNRejectionSampler(RejectionSampler):
             sampling_metadata,
             synthetic_mode=self.synthetic_mode,
             synthetic_conditional_rates=self.synthetic_conditional_rates,
+            bonus_logits=bonus_logits,
         )
 
         logprobs_tensors = None
@@ -186,10 +203,11 @@ class RejectionSamplerImpl:
         cu_num_draft_tokens: torch.Tensor,
         draft_probs: torch.Tensor | None,
         target_logits: torch.Tensor,
-        bonus_token_ids: torch.Tensor,
+        bonus_token_ids: torch.Tensor | None,
         sampling_metadata: SamplingMetadata,
         synthetic_mode: bool = False,
         synthetic_conditional_rates: torch.Tensor | None = None,
+        bonus_logits: torch.Tensor | None = None,
     ) -> torch.Tensor:
         raise NotImplementedError
 
@@ -213,11 +231,13 @@ class TorchRejectionSamplerImpl(RejectionSamplerImpl):
         cu_num_draft_tokens: torch.Tensor,
         draft_probs: torch.Tensor | None,
         target_logits: torch.Tensor,
-        bonus_token_ids: torch.Tensor,
+        bonus_token_ids: torch.Tensor | None,
         sampling_metadata: SamplingMetadata,
         synthetic_mode: bool = False,
         synthetic_conditional_rates: torch.Tensor | None = None,
+        bonus_logits: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        assert bonus_token_ids is not None
         target_logits = self.apply_sampling_constraints(
             target_logits,
             cu_num_draft_tokens,
@@ -340,10 +360,11 @@ class RBLNRejectionSamplerImpl(RejectionSamplerImpl):
         cu_num_draft_tokens: torch.Tensor,
         draft_probs: torch.Tensor | None,
         target_logits: torch.Tensor,
-        bonus_token_ids: torch.Tensor,
+        bonus_token_ids: torch.Tensor | None,
         sampling_metadata: SamplingMetadata,
         synthetic_mode: bool = False,
         synthetic_conditional_rates: torch.Tensor | None = None,
+        bonus_logits: torch.Tensor | None = None,
     ) -> torch.Tensor:
         target_logits = self.apply_sampling_constraints(
             target_logits,
@@ -379,7 +400,9 @@ class RBLNRejectionSamplerImpl(RejectionSamplerImpl):
         assert draft_token_ids.is_contiguous()
         assert draft_probs is None or draft_probs.is_contiguous()
         assert target_logits.is_contiguous()
-        assert bonus_token_ids.is_contiguous()
+        assert (bonus_token_ids is None) != (bonus_logits is None)
+        assert bonus_token_ids is None or bonus_token_ids.is_contiguous()
+        assert bonus_logits is None or bonus_logits.is_contiguous()
         assert target_logits.shape == (num_tokens, vocab_size)
 
         device = target_logits.device
@@ -471,6 +494,7 @@ class RBLNRejectionSamplerImpl(RejectionSamplerImpl):
             draft_per_batch,
             bonus_token_ids,
             num_draft_tokens_t,
+            bonus_logits,
         )
 
     def apply_sampling_constraints(
@@ -497,8 +521,9 @@ def rbln_rejection_sample(
     top_p: torch.Tensor | None,
     temperature: torch.Tensor,
     draft_per_batch: torch.Tensor,
-    bonus_token_ids: torch.Tensor,
+    bonus_token_ids: torch.Tensor | None,
     num_draft_tokens: torch.Tensor,
+    bonus_logits: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Sample, then build the output token ids.
 
@@ -574,7 +599,13 @@ def rbln_rejection_sample(
     bonus_mask = all_accepted.unsqueeze(1) & (
         positions_k1 == num_draft_tokens.unsqueeze(1)
     )
-    return torch.where(bonus_mask, bonus_token_ids.to(dtype=out.dtype), out)
+    if bonus_logits is not None:
+        # `rbln::argmax` returns [B]; `bonus_token_ids` already comes as [B, 1].
+        bonus = torch.ops.rbln.argmax(bonus_logits).unsqueeze(1)
+    else:
+        assert bonus_token_ids is not None
+        bonus = bonus_token_ids
+    return torch.where(bonus_mask, bonus.to(dtype=out.dtype), out)
 
 
 def torch_rejection_sample(

--- a/vllm_rbln/v1/sample/rbln_rejection_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_rejection_sampler.py
@@ -120,18 +120,21 @@ class RBLNRejectionSampler(RejectionSampler):
         bonus_logits = logits[bonus_logits_indices]
         raw_target_logits = logits[target_logits_indices]
 
+        # The bonus logits are wanted back only to compute the accepted-token
+        # logprobs; asking for them widens the rows to float32, which on the
+        # device is a host round trip, so ask only when logprobs are requested.
+        wants_logprobs = sampling_metadata.max_num_logprobs is not None
         bonus_sampler_output = self.sampler(
             logits=bonus_logits,
-            sampling_metadata=replace(
-                sampling_metadata,
-                max_num_logprobs=-1,
-            ),
+            sampling_metadata=replace(sampling_metadata, max_num_logprobs=-1)
+            if wants_logprobs
+            else sampling_metadata,
             predict_bonus_token=True,
-            # Override the logprobs mode to return logits because they are
-            # needed later to compute the accepted token logprobs.
-            logprobs_mode_override="processed_logits"
-            if self.is_processed_logprobs_mode
-            else "raw_logits",
+            logprobs_mode_override=(
+                "processed_logits" if self.is_processed_logprobs_mode else "raw_logits"
+            )
+            if wants_logprobs
+            else None,
         )
         bonus_token_ids = bonus_sampler_output.sampled_token_ids
 
@@ -384,32 +387,42 @@ class RBLNRejectionSamplerImpl(RejectionSamplerImpl):
         # Pad the packed inputs to the fixed [B*K] length the op wants.
         N = num_tokens  # = sum(num_draft_tokens)
         padded_len = batch_size * max_spec_len
-        reshaped_draft_token_ids = torch.zeros(
-            padded_len,
-            dtype=torch.int32,
-            device=device,
-        )
-        reshaped_target_logits = torch.zeros(
-            padded_len,
-            vocab_size,
-            dtype=target_logits.dtype,
-            device=device,
-        )
-        reshaped_draft_token_ids[:N] = draft_token_ids
-        reshaped_target_logits[:N] = target_logits
+        if padded_len == N:
+            # Full K drafts everywhere: already packed and padded, and request
+            # r's draft c sits at r * K + c. Two graph inputs must not alias one
+            # buffer, so the per-batch view is its own copy.
+            reshaped_draft_token_ids = draft_token_ids.to(device)
+            reshaped_target_logits = target_logits
+            draft_per_batch = draft_token_ids.view(batch_size, max_spec_len).to(
+                device, copy=True
+            )
+        else:
+            reshaped_draft_token_ids = torch.zeros(
+                padded_len,
+                dtype=torch.int32,
+                device=device,
+            )
+            reshaped_target_logits = torch.zeros(
+                padded_len,
+                vocab_size,
+                dtype=target_logits.dtype,
+                device=device,
+            )
+            reshaped_draft_token_ids[:N] = draft_token_ids
+            reshaped_target_logits[:N] = target_logits
 
-        draft_per_batch = torch.full(
-            (batch_size, max_spec_len),
-            PLACEHOLDER_TOKEN_ID,
-            dtype=torch.int32,
-            device=device,
-        )
-        src_offset = 0
-        for i, n in enumerate(num_draft_tokens):
-            if n == 0:
-                continue
-            draft_per_batch[i, :n] = draft_token_ids[src_offset : src_offset + n]
-            src_offset += n
+            draft_per_batch = torch.full(
+                (batch_size, max_spec_len),
+                PLACEHOLDER_TOKEN_ID,
+                dtype=torch.int32,
+                device=device,
+            )
+            src_offset = 0
+            for i, n in enumerate(num_draft_tokens):
+                if n == 0:
+                    continue
+                draft_per_batch[i, :n] = draft_token_ids[src_offset : src_offset + n]
+                src_offset += n
 
         top_k, top_p = build_op_top_k_top_p(
             sampling_metadata,

--- a/vllm_rbln/v1/sample/rbln_rejection_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_rejection_sampler.py
@@ -121,19 +121,14 @@ class RBLNRejectionSampler(RejectionSampler):
         bonus_logits = logits[bonus_logits_indices]
         raw_target_logits = logits[target_logits_indices]
 
-        # The bonus logits are wanted back only to compute the accepted-token
-        # logprobs; asking for them widens the rows to float32, which on the
-        # device is a host round trip, so ask only when logprobs are requested.
-        wants_logprobs = sampling_metadata.max_num_logprobs is not None
+        output_logprobs_requested = sampling_metadata.max_num_logprobs is not None
         bonus_token_ids = None
         if (
             sampling_metadata.all_greedy
-            and not wants_logprobs
+            and not output_logprobs_requested
             and not sampling_metadata.logprob_token_ids
             and isinstance(self.impl, RBLNRejectionSamplerImpl)
         ):
-            # A greedy bonus token is its row's argmax; the rejection graph
-            # takes it there instead of a separate sampler launch.
             bonus_logits = self.sampler.apply_logits_processors(
                 bonus_logits, sampling_metadata, predict_bonus_token=True
             )
@@ -141,7 +136,7 @@ class RBLNRejectionSampler(RejectionSampler):
             bonus_sampler_output = self.sampler(
                 logits=bonus_logits,
                 sampling_metadata=replace(sampling_metadata, max_num_logprobs=-1)
-                if wants_logprobs
+                if output_logprobs_requested
                 else sampling_metadata,
                 predict_bonus_token=True,
                 logprobs_mode_override=(
@@ -149,7 +144,7 @@ class RBLNRejectionSampler(RejectionSampler):
                     if self.is_processed_logprobs_mode
                     else "raw_logits"
                 )
-                if wants_logprobs
+                if output_logprobs_requested
                 else None,
             )
             bonus_token_ids = bonus_sampler_output.sampled_token_ids
@@ -239,8 +234,6 @@ class TorchRejectionSamplerImpl(RejectionSamplerImpl):
         bonus_logits: torch.Tensor | None = None,
     ) -> torch.Tensor:
         assert bonus_token_ids is not None
-        # The runner hands the draft ids over on the host; this impl samples
-        # wherever the logits are.
         draft_token_ids = draft_token_ids.to(target_logits.device)
         target_logits = self.apply_sampling_constraints(
             target_logits,
@@ -355,10 +348,9 @@ class RBLNRejectionSamplerImpl(RejectionSamplerImpl):
             # sampler off misses this op and forces a partial compile.
             use_cache=False,
         )
-        # The graph's small inputs, one set per input shape: handing the same
-        # tensors over every step keeps the runtime's input bindings warm --
-        # a fresh address re-validates and re-binds the input.
-        self._graph_inputs: dict[tuple, dict[str, torch.Tensor]] = {}
+        # The graph's small inputs, one set per shape. The same tensors every
+        # step keep the runtime's bindings; a fresh address is re-bound.
+        self._graph_input_buffers: dict[tuple, dict[str, torch.Tensor]] = {}
 
     def rejection_sample(
         self,
@@ -416,11 +408,9 @@ class RBLNRejectionSamplerImpl(RejectionSamplerImpl):
         device = target_logits.device
         dtype = target_logits.dtype
         key = (batch_size, vocab_size, dtype, device)
-        if (bufs := self._graph_inputs.get(key)) is None:
-            # Every length is the config-fixed `num_spec_tokens` the op's
-            # inputs are padded to just above, not the batch's own longest run.
+        if (bufs := self._graph_input_buffers.get(key)) is None:
             buf_len = batch_size * self.num_spec_tokens
-            bufs = self._graph_inputs[key] = {
+            bufs = self._graph_input_buffers[key] = {
                 "draft_token_ids": torch.zeros(
                     buf_len, dtype=torch.int32, device=device
                 ),
@@ -442,22 +432,18 @@ class RBLNRejectionSamplerImpl(RejectionSamplerImpl):
             }
 
         # Pad the packed inputs to the fixed [B*K] length the op wants. Rows past
-        # the packed length carry an earlier step's values, which the op reads
-        # only into slots its acceptance count clips.
+        # N keep an earlier step's values: the op reads them only into slots
+        # its acceptance count clips.
         N = num_tokens  # = sum(num_draft_tokens)
         padded_len = batch_size * max_spec_len
         reshaped_draft_token_ids = bufs["draft_token_ids"]
         draft_per_batch = bufs["draft_per_batch"]
         if padded_len == N:
-            # Full K drafts everywhere: already packed and padded, and request
-            # r's draft c sits at r * K + c. Two graph inputs must not alias one
-            # buffer, so the per-batch view is its own copy.
+            # A copy, not a view: two graph inputs must not alias one buffer.
             reshaped_draft_token_ids.copy_(draft_token_ids)
             reshaped_target_logits = target_logits
             draft_per_batch.copy_(draft_token_ids.view(batch_size, max_spec_len))
         else:
-            # Only a partial-draft step needs the padded logits block, and it
-            # is the one big buffer here, so it is allocated on first use.
             if (reshaped_target_logits := bufs.get("target_logits")) is None:
                 reshaped_target_logits = bufs["target_logits"] = torch.zeros(
                     padded_len, vocab_size, dtype=dtype, device=device

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -3378,18 +3378,14 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             logitsprocs=LogitsProcessors(),
             spec_token_ids=[[] for _ in range(batch_size)],
         )
-        # int32, as the bonus sampler's ops return, so the warmed graph is the
-        # one a random step then hits.
+        # int32, as the bonus sampler's ops return it.
         bonus_token_ids = torch.zeros(
             batch_size, 1, dtype=torch.int32, device=self.device
         )
         logger.info("Warm-up: rejection sampler (decode_batch=%d)", batch_size)
-        # Two graphs: one takes the bonus rows' logits and argmaxes them (an
-        # all-greedy step without logprobs), the other takes the ids the bonus
-        # sampler already produced. Either can come first at run time.
-        for bonus_kwargs in (
-            {"bonus_logits": bonus_logits},
-            {"bonus_token_ids": bonus_token_ids},
+        for bonus_token_ids_in, bonus_logits_in in (
+            (None, bonus_logits),
+            (bonus_token_ids, None),
         ):
             self.rejection_sampler.impl.rejection_sample(
                 draft_token_ids,
@@ -3398,9 +3394,9 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 cu_num_draft_tokens,
                 None,
                 target_logits,
-                bonus_kwargs.get("bonus_token_ids"),
+                bonus_token_ids_in,
                 dummy_sampling_metadata,
-                bonus_logits=bonus_kwargs.get("bonus_logits"),
+                bonus_logits=bonus_logits_in,
             )
 
     def warmup_model(self) -> None:

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -3355,8 +3355,8 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             dtype=torch.int32,
             device=self.device,
         )
-        bonus_token_ids = torch.zeros(
-            batch_size, 1, dtype=torch.int64, device=self.device
+        bonus_logits = torch.zeros(
+            batch_size, vocab_size, dtype=self.dtype, device=self.device
         )
         dummy_sampling_metadata = SamplingMetadata(
             temperature=None,
@@ -3377,17 +3377,30 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             logitsprocs=LogitsProcessors(),
             spec_token_ids=[[] for _ in range(batch_size)],
         )
-        logger.info("Warm-up: rejection sampler (decode_batch=%d)", batch_size)
-        self.rejection_sampler.impl.rejection_sample(
-            draft_token_ids,
-            num_draft_tokens,
-            num_spec,
-            cu_num_draft_tokens,
-            None,
-            target_logits,
-            bonus_token_ids,
-            dummy_sampling_metadata,
+        # int32, as the bonus sampler's ops return, so the warmed graph is the
+        # one a random step then hits.
+        bonus_token_ids = torch.zeros(
+            batch_size, 1, dtype=torch.int32, device=self.device
         )
+        logger.info("Warm-up: rejection sampler (decode_batch=%d)", batch_size)
+        # Two graphs: one takes the bonus rows' logits and argmaxes them (an
+        # all-greedy step without logprobs), the other takes the ids the bonus
+        # sampler already produced. Either can come first at run time.
+        for bonus_kwargs in (
+            {"bonus_logits": bonus_logits},
+            {"bonus_token_ids": bonus_token_ids},
+        ):
+            self.rejection_sampler.impl.rejection_sample(
+                draft_token_ids,
+                num_draft_tokens,
+                num_spec,
+                cu_num_draft_tokens,
+                None,
+                target_logits,
+                bonus_kwargs.get("bonus_token_ids"),
+                dummy_sampling_metadata,
+                bonus_logits=bonus_kwargs.get("bonus_logits"),
+            )
 
     def warmup_model(self) -> None:
         # NOTE(RBLN): Warm-up must not route through execute_model() while a

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1097,8 +1097,9 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
 
         # Compute the draft token ids.
         # draft_token_indices:      [  1,   2,   3, 105, 106, 208]
+        # Host tensor; the rejection sampler copies it into its graph inputs.
         draft_token_ids = self.input_ids[logits_indices]
-        draft_token_ids = draft_token_ids[target_logits_indices + 1].to(self.device)
+        draft_token_ids = draft_token_ids[target_logits_indices + 1]
 
         return SpecDecodeMetadata(
             draft_token_ids=draft_token_ids,


### PR DESCRIPTION
### 🚀 Summary of Changes

Follow-up to #1042: cuts the rejection sampler's per-step host work under `VLLM_RBLN_USE_DEVICE_TENSOR=1`.

**Problem** -- #1042 folded `rbln::rejection_sample` and the `[B, K+1]` output composition into one compiled graph. The host still did work around that graph on every speculative step: it launched a second graph for the bonus token, asked for float32 logits it rarely read, copied already-packed rows into zeroed buffers, and allocated the graph's small inputs anew, so the runtime re-validated and re-bound them each step.

**Solution** -- Three changes.

1. **Skip what is not needed.** Ask the bonus sampler for its logits only when logprobs are requested; the float32 widening is a host round trip on the device. A step whose requests all carry K drafts is already packed and padded for the op, so its rows are handed over as they are. The per-batch draft view gets its own buffer: two graph inputs aliasing one allocation lost the accepted drafts past the first.
2. **Greedy bonus token inside the graph.** An all-greedy step without logprobs hands the graph the bonus rows instead of sampled ids, and the graph takes their argmax with `rbln::argmax`. One launch instead of two. Every other step -- random or mixed rows, logprobs, the torch impl -- passes the ids as before. Warm-up compiles both variants, with int32 ids as the sampler's ops return them, so the first non-greedy step no longer recompiles.
3. **Reuse the graph's small inputs.** The `[B*K]` draft ids, `[B, K]` per-batch view, temperature, cu and count tensors are kept per batch size and handed over at the same addresses every step. Rows past the packed length keep an earlier step's values; the op reads them only into slots its acceptance count clips. The runner hands the draft ids over on the host and each impl brings them where it samples. A static output buffer was tried too and measured at noise, so it is not included.

vLLM-native path only.

---

### 📌 Related Issues / Tickets

* Related to [fsw-efficiency#27](https://github.com/rebellions-sw/fsw-efficiency/issues/27)
* Follow-up to #1042

---

### ✅ Type of Change

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [x] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

MiniMax-M2.7 + Eagle3 spec decode, dp4: output tokens match device-tensor mode, `_sample` is about a fifth faster, tpot improves. Unit tests: `tests/torch_compile/unit/v1/sample/test_rbln_rejection_sampler.py`, `tests/native/v1/worker/test_rbln_model_runner.py`.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

