### PR TITLE
perf(spec-decode): keep the EAGLE drafter's bookkeeping on the host

### DIFF
--- a/tests/native/v1/spec_decode/test_eagle.py
+++ b/tests/native/v1/spec_decode/test_eagle.py
@@ -113,7 +113,13 @@ def _echo_model_exec(hidden_size):
     return executable
 
 
-def _call_propose(proposer, target_hidden_states=None):
+# The last slot of each request in _call_propose's [0, 2, 4] query layout.
+_LAST_SLOTS = torch.tensor([1, 3], dtype=torch.int32)
+
+
+def _call_propose(
+    proposer, target_hidden_states=None, token_indices_to_sample=_LAST_SLOTS
+):
     return proposer.propose(
         target_token_ids=torch.arange(4, dtype=torch.int32),
         target_positions=torch.arange(4, dtype=torch.int64),
@@ -121,7 +127,7 @@ def _call_propose(proposer, target_hidden_states=None):
         if target_hidden_states is None
         else target_hidden_states,
         next_token_ids=torch.tensor([30, 31], dtype=torch.int32),
-        token_indices_to_sample=torch.tensor([1, 3], dtype=torch.int32),
+        token_indices_to_sample=token_indices_to_sample,
         common_attn_metadata=make_cad([0, 2, 4], [10, 11]),
     )
 
@@ -142,27 +148,6 @@ class TestPreprocess:
             target_token_ids=torch.arange(11, 20, dtype=torch.int32),
             next_token_ids=torch.tensor([100, 200, 300], dtype=torch.int32),
         )
-
-    def test_first_pass_shifts_tokens_and_inserts_next(self):
-        # Three requests, query_lens [3, 2, 4]. The target ids shift left by one
-        # (drop the first) and each request's next token lands at its last slot.
-        proposer = make_eagle_proposer()
-        _, _, _, tip = self._first_pass(
-            proposer, torch.tensor([2, 4, 8], dtype=torch.int32)
-        )
-        assert tip.cpu().tolist() == [2, 4, 8]
-        # shifted target [12..19] with next tokens overwritten at [2, 4, 8].
-        assert proposer.input_ids[:9].cpu().tolist() == [
-            12,
-            13,
-            100,
-            15,
-            200,
-            17,
-            18,
-            19,
-            300,
-        ]
 
     def test_first_pass_uses_explicit_token_indices_verbatim(self):
         # Given token indices are used as-is (not recomputed from
@@ -383,6 +368,18 @@ class TestPropose:
         out = _call_propose(proposer)
         assert out.shape == (2, 1)
         assert out.cpu().tolist() == [[42], [60]]
+
+    def test_none_token_indices_default_to_each_requests_last_slot(self, monkeypatch):
+        # With no indices given, propose derives them from query_start_loc:
+        # [0, 2, 4] -> [1, 3], so the next tokens land where _call_propose's
+        # explicit [1, 3] would put them, after the target ids shift left by one.
+        _neutralize(monkeypatch)
+        proposer = make_eagle_proposer(method="eagle", num_speculative_tokens=1)
+        _wire_runner(proposer, num_reqs=2)
+        proposer.model_executable = _fake_model_exec([42, 60], proposer.hidden_size)
+
+        _call_propose(proposer, token_indices_to_sample=None)
+        assert proposer.input_ids[:4].cpu().tolist() == [1, 30, 3, 31]
 
     def test_multi_step_feeds_previous_draft_forward(self, monkeypatch):
         # With the echo model each draft is the previous + 1, so consecutive
@@ -655,18 +652,20 @@ class TestLoadModel:
         # write is the SIGSEGV in KV warm-up. What is checked here is the branch
         # selection -- only a real compile on the device reaches the SIGSEGV, so
         # this guards against someone routing back through compute_logits.
-        d2t = torch.tensor([0, 2, 3], dtype=torch.long)
+        proposer = make_eagle_proposer(num_speculative_tokens=1)
+        # On the device, as a loaded draft model carries it.
+        d2t = torch.tensor([0, 2, 3], dtype=torch.long, device=proposer.device)
         model = self._FakeMappedDraft(d2t)
         self._stub_super_load_model(monkeypatch, model)
-        proposer = make_eagle_proposer(num_speculative_tokens=1)
         monkeypatch.setattr(
             proposer.vllm_config.speculative_config, "enforce_eager", True
         )
         proposer.load_model(target_model=object())
 
         # Taking that branch at all depends on load_model lifting d2t off the
-        # draft model, so this covers the capture too.
-        assert proposer.draft_id_to_target_id is d2t
+        # draft model and onto the host, so this covers the capture too.
+        assert proposer.draft_id_to_target_id.device.type == "cpu"
+        assert torch.equal(proposer.draft_id_to_target_id, d2t.cpu())
 
         h = proposer.hidden_size
         hidden = torch.arange(2 * 3 * h, dtype=torch.float32).view(2, 3, h)

--- a/tests/native/v1/spec_decode/test_eagle.py
+++ b/tests/native/v1/spec_decode/test_eagle.py
@@ -141,15 +141,15 @@ class TestPreprocess:
             token_indices_to_sample=token_indices_to_sample,
             target_token_ids=torch.arange(11, 20, dtype=torch.int32),
             next_token_ids=torch.tensor([100, 200, 300], dtype=torch.int32),
-            cad=make_cad([0, 3, 5, 9], [3, 5, 4]),
         )
 
     def test_first_pass_shifts_tokens_and_inserts_next(self):
         # Three requests, query_lens [3, 2, 4]. The target ids shift left by one
         # (drop the first) and each request's next token lands at its last slot.
         proposer = make_eagle_proposer()
-        # None token indices default to query_start_loc[1:] - 1.
-        _, _, _, tip = self._first_pass(proposer, None)
+        _, _, _, tip = self._first_pass(
+            proposer, torch.tensor([2, 4, 8], dtype=torch.int32)
+        )
         assert tip.cpu().tolist() == [2, 4, 8]
         # shifted target [12..19] with next tokens overwritten at [2, 4, 8].
         assert proposer.input_ids[:9].cpu().tolist() == [
@@ -326,13 +326,11 @@ class TestInitGuards:
 
 class TestToTargetTokenIds:
     def test_applies_d2t_as_an_offset(self):
-        # d2t holds offsets, not absolute target ids: id -> id + d2t[id]. Both
-        # operands sit on the proposer's device, so this is the gather production
-        # runs -- the reason the mapping moved out of the compiled graph.
+        # d2t holds offsets, not absolute target ids: id -> id + d2t[id]. The
+        # ids arrive on the device and d2t sits on the host (load_model puts it
+        # there), so this is the gather production runs.
         proposer = make_eagle_proposer()
-        proposer.draft_id_to_target_id = torch.tensor(
-            [0, 2, 3, 5, 8], dtype=torch.long, device=proposer.device
-        )
+        proposer.draft_id_to_target_id = torch.tensor([0, 2, 3, 5, 8], dtype=torch.long)
         draft_ids = torch.tensor(
             [0, 1, 4, 2], dtype=torch.int64, device=proposer.device
         )
@@ -364,7 +362,7 @@ class TestToTargetTokenIds:
         )
         full_logits[:, target_ids] = draft_logits
         proposer = make_eagle_proposer()
-        proposer.draft_id_to_target_id = d2t.to(proposer.device)
+        proposer.draft_id_to_target_id = d2t
 
         out = proposer._to_target_token_ids(
             draft_logits.argmax(dim=-1).to(proposer.device)
@@ -446,7 +444,7 @@ class TestPropose:
         proposer.model_executable = _fake_model_exec([42, 60], proposer.hidden_size)
         d2t = torch.zeros(128, dtype=torch.long)
         d2t[42], d2t[60] = 5, 7
-        proposer.draft_id_to_target_id = d2t.to(proposer.device)
+        proposer.draft_id_to_target_id = d2t
 
         out = _call_propose(proposer)
 
@@ -461,7 +459,7 @@ class TestPropose:
         _wire_runner(proposer, num_reqs=2)
         d2t = torch.zeros(128, dtype=torch.long)
         d2t[1], d2t[2], d2t[3], d2t[4] = 2, 3, 5, 8
-        proposer.draft_id_to_target_id = d2t.to(proposer.device)
+        proposer.draft_id_to_target_id = d2t
         argmax_per_call = [[1, 3], [2, 4]]
         seen: list[torch.Tensor] = []
 

--- a/vllm_rbln/v1/spec_decode/eagle.py
+++ b/vllm_rbln/v1/spec_decode/eagle.py
@@ -60,8 +60,11 @@ class RBLNEagleProposer(EagleProposer):
         device: torch.device,
         runner: "RBLNModelRunner",
     ):
-        # Bookkeeping on the host: torch-rbln runs int/bool eager ops through a
-        # CPU fallback. The stager still stages the graph inputs onto `device`.
+        # The parent's ctor gets "cpu", so its bookkeeping -- input_ids,
+        # positions, hidden_states, backup ids -- lives on the host: torch-rbln
+        # runs int/bool eager ops through a CPU fallback. Whatever reads
+        # `self.device` afterwards (attention metadata builders, input stager)
+        # still gets the NPU, where the draft model itself keeps running.
         super().__init__(vllm_config, torch.device("cpu"), runner)
         self.device = device
 

--- a/vllm_rbln/v1/spec_decode/eagle.py
+++ b/vllm_rbln/v1/spec_decode/eagle.py
@@ -60,7 +60,10 @@ class RBLNEagleProposer(EagleProposer):
         device: torch.device,
         runner: "RBLNModelRunner",
     ):
-        super().__init__(vllm_config, device, runner)
+        # Bookkeeping on the host: torch-rbln runs int/bool eager ops through a
+        # CPU fallback. The stager still stages the graph inputs onto `device`.
+        super().__init__(vllm_config, torch.device("cpu"), runner)
+        self.device = device
 
         if self.supports_mm_inputs:
             raise NotImplementedError
@@ -76,7 +79,6 @@ class RBLNEagleProposer(EagleProposer):
             )
 
         self.runner = runner
-        self.arange_cpu = torch.arange(self.arange.shape[0], dtype=torch.int32)
         self.input_stager = InputStager(device)
         # Populated from the draft model in `load_model`. None means the draft
         # head shares the target vocabulary, so `propose()` maps no ids.
@@ -100,6 +102,8 @@ class RBLNEagleProposer(EagleProposer):
         assert target_hidden_states.shape[-1] == self.hidden_size
 
         num_tokens = target_token_ids.shape[0]
+        if token_indices_to_sample is None:
+            token_indices_to_sample = common_attn_metadata.query_start_loc[1:] - 1
 
         assert self.runner is not None
         is_prefill = self.runner.is_prefill
@@ -141,7 +145,6 @@ class RBLNEagleProposer(EagleProposer):
                 token_indices_to_sample=token_indices_to_sample,
                 target_token_ids=target_token_ids,
                 next_token_ids=next_token_ids,
-                cad=common_attn_metadata,
             )
         )
         inputs_embeds = None
@@ -167,10 +170,7 @@ class RBLNEagleProposer(EagleProposer):
             draft_tokens_ids = self._to_target_token_ids(draft_ids[:num_reqs])
             return draft_tokens_ids.view(-1, 1)
 
-        assert token_indices_to_sample_padded is not None
-        positions = target_positions[
-            token_indices_to_sample_padded.to(target_positions.device)
-        ]
+        positions = target_positions[token_indices_to_sample]
 
         # `hidden_states` is deliberately not gathered here -- #821 moved
         # that gather inside `model_wrapper`. Doing it again would index an
@@ -195,8 +195,8 @@ class RBLNEagleProposer(EagleProposer):
         common_attn_metadata.seq_lens = common_attn_metadata.seq_lens.clone()
         common_attn_metadata.num_actual_tokens = num_reqs
         common_attn_metadata.max_query_len = 1
-        common_attn_metadata.query_start_loc = self.arange_cpu[: num_reqs + 1]
-        common_attn_metadata.query_start_loc_cpu = self.arange_cpu[: num_reqs + 1]
+        common_attn_metadata.query_start_loc = self.arange[: num_reqs + 1]
+        common_attn_metadata.query_start_loc_cpu = self.arange[: num_reqs + 1]
 
         # In padded drafter batch, we need to adjust the sequence lengths
         # to remove the "padding" (i.e. rejected tokens).
@@ -284,6 +284,8 @@ class RBLNEagleProposer(EagleProposer):
         Equivalent to upstream's scatter-then-argmax for a monotonic mapping:
         both pick the same winner, and on an exact tie both pick the lowest id.
         """
+        # A graph output: the one D2H of a draft pass, the rest stays on the host.
+        draft_token_ids = draft_token_ids.cpu()
         d2t = self.draft_id_to_target_id
         if d2t is None:
             return draft_token_ids.long().clone()
@@ -308,16 +310,17 @@ class RBLNEagleProposer(EagleProposer):
             dtype=np.int32,
         )
         self.backup_next_token_ids.copy_to_gpu(num_reqs)
-        backup_tokens_gpu = self.backup_next_token_ids.gpu
+        backup_tokens = self.backup_next_token_ids.gpu
 
         assert discard_request_mask.dtype == torch.bool
-        assert backup_tokens_gpu.dtype == torch.int32
+        assert backup_tokens.dtype == torch.int32
 
         batch_size = sampled_token_ids.shape[0]
+        sampled_token_ids = sampled_token_ids.to(backup_tokens.device)
         return eagle_prepare_next_token_padded(
             sampled_token_ids,
             discard_request_mask[:batch_size],
-            backup_tokens_gpu[:batch_size],
+            backup_tokens[:batch_size],
             gpu_input_batch.vocab_size,
         )
 
@@ -369,6 +372,8 @@ class RBLNEagleProposer(EagleProposer):
         super().load_model(target_model)
 
         self.draft_id_to_target_id = getattr(self.model, "draft_id_to_target_id", None)
+        if self.draft_id_to_target_id is not None:
+            self.draft_id_to_target_id = self.draft_id_to_target_id.cpu()
 
         # Fused MoE is the only reader of the step's padded token dimension, so a
         # draft without it runs no collective of its own -- which is what lets an
@@ -531,8 +536,7 @@ class RBLNEagleProposer(EagleProposer):
                 per_layer_attn_metadata[layer_name] = attn_metadata
 
         token_indices_to_sample = (
-            torch.arange(num_reqs, device=self.device, dtype=torch.int32)
-            * num_tokens_per_req
+            torch.arange(num_reqs, dtype=torch.int32) * num_tokens_per_req
         )
         input_ids, positions, hidden_states, token_indices_to_sample_padded = (
             self._preprocess(
@@ -568,8 +572,8 @@ class RBLNEagleProposer(EagleProposer):
 
         common_attn_metadata.num_actual_tokens = num_reqs
         common_attn_metadata.max_query_len = 1
-        common_attn_metadata.query_start_loc = self.arange_cpu[: num_reqs + 1]
-        common_attn_metadata.query_start_loc_cpu = self.arange_cpu[: num_reqs + 1]
+        common_attn_metadata.query_start_loc = self.arange[: num_reqs + 1]
+        common_attn_metadata.query_start_loc_cpu = self.arange[: num_reqs + 1]
         common_attn_metadata.seq_lens += 1
 
         batch_desc, num_tokens_across_dp = self._determine_batch_execution_and_padding(
@@ -670,16 +674,11 @@ class RBLNEagleProposer(EagleProposer):
         token_indices_to_sample: torch.Tensor | None = None,
         target_token_ids: torch.Tensor | None = None,
         next_token_ids: torch.Tensor | None = None,
-        cad: CommonAttentionMetadata | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
         if target_token_ids is not None:
             assert next_token_ids is not None
+            assert token_indices_to_sample is not None
             assert num_input_tokens == target_token_ids.shape[0]
-
-            if token_indices_to_sample is None:
-                assert cad is not None
-                token_indices_to_sample = cad.query_start_loc[1:] - 1
-            token_indices_to_sample = token_indices_to_sample.to(self.device)
 
             self.input_ids[: num_input_tokens - 1] = target_token_ids[1:]
             self.input_ids[token_indices_to_sample] = next_token_ids


### PR DESCRIPTION
### 🚀 Summary of Changes

Follow-up to #1042: cuts the EAGLE draft latency under `VLLM_RBLN_USE_DEVICE_TENSOR=1`.

**Problem** -- torch-rbln runs every eager op with an **int/bool input through a CPU fallback**. Under device tensors, the drafter's glue between its draft graphs -- token ids, positions, backup ids, the d2t mapping, the index arithmetic of `prepare_inputs_padded` -- round-tripped the host op by op. Each trip is a launch plus a D2H.

**Solution** -- **Allocate that bookkeeping on the host.** The device keeps only the attention metadata builders and the input stager, which stage the graph inputs onto it. The draft graph is unchanged. Draft ids come back with one D2H per pass; d2t sits on the host next to them. A step without drafts moves its device-sampled ids to the backup ids' device.

**This is how the target model already runs.** The runner keeps `input_ids`, `positions` and `query_start_loc` on the host, does its bookkeeping there in eager torch, and stages the inputs onto the device right before `execute_model`. The EAGLE drafter now follows the same pattern.

---

### 📌 Related Issues / Tickets

* Related to [fsw-efficiency#27](https://github.com/rebellions-sw/fsw-efficiency/issues/27)
* Follow-up to #1042

---

### ✅ Type of Change

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [x] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

MiniMax-M2.7 + Eagle3 spec decode, dp4: output tokens match device-tensor mode, tpot improves.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
