### PR TITLE
fix(dp): give each data parallel rank its own NPUs when a rank owns several

### DIFF
--- a/tests/native/compile/models.py
+++ b/tests/native/compile/models.py
@@ -33,6 +33,17 @@ _QWEN3_30B_A3B_BASE = CompileModelSpec(
     },
     OPT_ENVS,
 )
+_QWEN1_5_MOE_A2_7B_BASE = CompileModelSpec(
+    "Qwen/Qwen1.5-MoE-A2.7B",
+    {
+        "max_num_seqs": 1,
+        "max_model_len": 8192,
+        "block_size": 4096,
+        "enable_expert_parallel": True,
+    },
+    OPT_ENVS,
+    chips=ATOM,
+)
 _MINIMAX_BASE = CompileModelSpec(
     "MiniMaxAI/MiniMax-M2.7",
     {
@@ -51,18 +62,11 @@ MODELS: list[CompileModelSpec] = [
     _QWEN3_30B_A3B_BASE.variant(
         tensor_parallel_size=4, enable_expert_parallel=False, chips=REBEL
     ),
-    CompileModelSpec(
-        "Qwen/Qwen1.5-MoE-A2.7B",
-        {
-            "max_num_seqs": 1,
-            "max_model_len": 8192,
-            "block_size": 4096,
-            "tensor_parallel_size": 8,
-            "enable_expert_parallel": True,
-        },
-        OPT_ENVS,
+    _QWEN1_5_MOE_A2_7B_BASE.variant(tensor_parallel_size=8, rsd=4),
+    _QWEN1_5_MOE_A2_7B_BASE.variant(
+        tensor_parallel_size=2,
+        data_parallel_size=2,
         rsd=4,
-        chips=ATOM,
     ),
     CompileModelSpec(
         "openai/gpt-oss-20b",

--- a/tests/native/v1/worker/test_rbln_worker.py
+++ b/tests/native/v1/worker/test_rbln_worker.py
@@ -42,6 +42,7 @@ def _make_vllm_config(
     world_size=1,
     data_parallel_size=1,
     data_parallel_rank=0,
+    data_parallel_rank_local=None,
     world_size_across_dp=1,
     assigned_physical_gpu_ids=None,
     quantization=None,
@@ -57,6 +58,7 @@ def _make_vllm_config(
             pipeline_parallel_size=1,
             data_parallel_size=data_parallel_size,
             data_parallel_rank=data_parallel_rank,
+            data_parallel_rank_local=data_parallel_rank_local,
             world_size_across_dp=world_size_across_dp,
             assigned_physical_gpu_ids=assigned_physical_gpu_ids,
             disable_custom_all_reduce=False,
@@ -89,9 +91,6 @@ def _fake_super_init(
 
 @pytest.fixture(autouse=True)
 def _env_cleanup(monkeypatch):
-    # The logical-to-physical mapping is process-global and refuses a second,
-    # conflicting publish, so one test's DP mapping would fail the next.
-    monkeypatch.setattr(platform_interface, "_assigned_physical_gpu_ids", None)
     # Save/restore the process env vars the worker touches.
     keys = [
         "RBLN_VISIBLE_DEVICES",
@@ -119,6 +118,7 @@ def make_worker(monkeypatch):
         world_size=1,
         data_parallel_size=1,
         data_parallel_rank=0,
+        data_parallel_rank_local=None,
         world_size_across_dp=None,
         assigned_physical_gpu_ids=None,
         num_devices=1,
@@ -137,21 +137,36 @@ def make_worker(monkeypatch):
             world_size=world_size,
             data_parallel_size=data_parallel_size,
             data_parallel_rank=data_parallel_rank,
+            data_parallel_rank_local=data_parallel_rank_local,
             world_size_across_dp=wsd,
             assigned_physical_gpu_ids=assigned_physical_gpu_ids,
         )
+        # MultiprocExecutor.worker_main publishes the mapping in every worker
+        # process before the worker is built, so a test that supplies one must
+        # too or it exercises a path the engine never takes.
+        if assigned_physical_gpu_ids is not None:
+            monkeypatch.setattr(
+                platform_interface,
+                "_assigned_physical_gpu_ids",
+                assigned_physical_gpu_ids,
+            )
         monkeypatch.setattr(WorkerBase, "__init__", _fake_super_init)
         monkeypatch.setattr(
             wm,
             "current_platform",
             SimpleNamespace(
                 device_type="cpu",
-                # Not a literal: device_id_to_physical_device_id below reads it
-                # off RblnPlatform, so the two must not drift apart.
+                # Not a literal: the resolver below reads it off RblnPlatform,
+                # so the two must not drift apart.
                 device_control_env_var=RblnPlatform.device_control_env_var,
                 dist_backend="gloo",
                 get_device_name=lambda: device_name,
-                # The real mapping: the pool semantics under test are upstream's.
+                # Both real resolvers: the pool semantics under test are
+                # upstream's, and which of the two the worker picks is the
+                # difference between reading the pool and reading the mapping.
+                visible_device_id_to_physical_device_id=(
+                    RblnPlatform.visible_device_id_to_physical_device_id
+                ),
                 device_id_to_physical_device_id=(
                     RblnPlatform.device_id_to_physical_device_id
                 ),
@@ -240,7 +255,8 @@ class TestInitDeviceEnv:
     """The env var is a pool of NPUs to index into, one entry per NPU.
 
     A rank takes ``VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK`` consecutive entries
-    starting at ``local_rank`` times that count.
+    starting at its rank slot times that count. The slot spans the whole
+    deployment: ``data_parallel_rank_local * world_size + local_rank``.
     """
 
     def test_unset_pool_is_the_whole_host(self, make_worker):
@@ -251,12 +267,6 @@ class TestInitDeviceEnv:
     def test_unset_pool_indexes_by_local_rank(self, make_worker, local_rank, expected):
         make_worker(world_size=4, local_rank=local_rank)
         assert os.environ["RBLN_VISIBLE_DEVICES"] == expected
-
-    def test_dp_rank_alone_does_not_offset(self, make_worker):
-        # data_parallel_rank is reset to 0 for non-MoE DP, so deriving the
-        # offset from it put every replica on the same NPU.
-        make_worker(world_size=1, data_parallel_size=4, data_parallel_rank=3)
-        assert os.environ["RBLN_VISIBLE_DEVICES"] == "0"
 
     def test_pool_indexes_by_local_rank(self, make_worker):
         os.environ["RBLN_VISIBLE_DEVICES"] = "4,5,6,7"
@@ -325,32 +335,75 @@ class TestInitDeviceEnv:
         make_worker(world_size=1, num_devices=1, has_torch_rbln=True)
         assert "RBLN_NPUS_PER_DEVICE" not in os.environ
 
-    def test_dp_mapping_carries_the_offset(self, make_worker):
+    @pytest.mark.parametrize(
+        "dp_rank, local_rank, expected",
+        [(0, 0, "0"), (0, 1, "1"), (1, 0, "2"), (1, 1, "3")],
+    )
+    def test_dp_ranks_do_not_share(self, make_worker, dp_rank, local_rank, expected):
         make_worker(
-            world_size=1,
-            data_parallel_size=4,
-            data_parallel_rank=3,
-            assigned_physical_gpu_ids=[3],
+            world_size=2,
+            data_parallel_size=2,
+            data_parallel_rank=dp_rank,
+            data_parallel_rank_local=dp_rank,
+            local_rank=local_rank,
         )
-        assert os.environ["RBLN_VISIBLE_DEVICES"] == "3"
+        assert os.environ["RBLN_VISIBLE_DEVICES"] == expected
 
-    def test_dp_mapping_wins_over_pool_position(self, make_worker):
-        os.environ["RBLN_VISIBLE_DEVICES"] = "4,5,6,7"
-        make_worker(world_size=1, data_parallel_size=4, assigned_physical_gpu_ids=[6])
-        assert os.environ["RBLN_VISIBLE_DEVICES"] == "6"
+    @pytest.mark.parametrize(
+        "dp_rank, local_rank, expected",
+        [
+            (0, 0, "0,1,2,3"),
+            (0, 1, "4,5,6,7"),
+            (1, 0, "8,9,10,11"),
+            (1, 1, "12,13,14,15"),
+        ],
+    )
+    def test_dp_ranks_do_not_share_with_rsd(
+        self, make_worker, dp_rank, local_rank, expected
+    ):
+        make_worker(
+            world_size=2,
+            data_parallel_size=2,
+            data_parallel_rank=dp_rank,
+            data_parallel_rank_local=dp_rank,
+            # What vLLM's slicer hands this DP rank: one entry per rank.
+            assigned_physical_gpu_ids=[dp_rank * 2, dp_rank * 2 + 1],
+            num_devices=4,
+            local_rank=local_rank,
+        )
+        assert os.environ["RBLN_VISIBLE_DEVICES"] == expected
 
-    def test_dp_mapping_with_rsd_raises(self, make_worker):
-        # vLLM's slicer has no notion of rsd, so it hands over one entry per
-        # rank where this rank needs num_devices of them.
+    def test_dp_with_rsd_indexes_the_pool(self, make_worker):
+        os.environ["RBLN_VISIBLE_DEVICES"] = ",".join(str(i) for i in range(16, 32))
+        make_worker(
+            world_size=2,
+            data_parallel_size=2,
+            data_parallel_rank=1,
+            data_parallel_rank_local=1,
+            num_devices=4,
+            local_rank=1,
+        )
+        assert os.environ["RBLN_VISIBLE_DEVICES"] == "28,29,30,31"
+
+    def test_non_moe_dp_offsets_by_the_local_rank(self, make_worker):
+        # vLLM treats non-MoE DP ranks as independent engines: it resets
+        # data_parallel_size and data_parallel_rank, and only
+        # data_parallel_rank_local still tells the replicas apart.
+        make_worker(
+            world_size=2,
+            data_parallel_size=1,
+            data_parallel_rank=0,
+            data_parallel_rank_local=1,
+            num_devices=2,
+        )
+        assert os.environ["RBLN_VISIBLE_DEVICES"] == "4,5"
+
+    def test_device_ids_mapping_is_ignored(self, make_worker):
+        # --device-ids leaves one entry per rank on the config, which cannot
+        # express rsd, so the pool position decides instead.
         os.environ["RBLN_VISIBLE_DEVICES"] = "0,1,2,3"
-        with pytest.raises(ValueError, match="needs 2 NPU"):
-            make_worker(
-                world_size=1,
-                data_parallel_size=2,
-                data_parallel_rank=1,
-                assigned_physical_gpu_ids=[1],
-                num_devices=2,
-            )
+        make_worker(world_size=2, assigned_physical_gpu_ids=[2, 3], local_rank=1)
+        assert os.environ["RBLN_VISIBLE_DEVICES"] == "1"
 
 
 def _params():

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -55,10 +55,6 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
 from vllm.distributed.parallel_state import get_dp_group, get_pp_group, get_tp_group
 from vllm.model_executor.layers.attention import Attention
 from vllm.platforms import current_platform
-from vllm.platforms.interface import (
-    get_assigned_physical_gpu_ids,
-    set_assigned_physical_gpu_ids,
-)
 from vllm.profiler.wrapper import TorchProfilerWrapper
 from vllm.sequence import IntermediateTensors
 from vllm.tasks import SupportedTask
@@ -217,24 +213,23 @@ class RBLNWorker(WorkerBase):
         env_var = current_platform.device_control_env_var
         num_devices = envs.VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK
 
-        # UniProcExecutor never publishes the mapping, so publish it here rather
-        # than only reading it.
-        assigned = self.parallel_config.assigned_physical_gpu_ids
-        if assigned and get_assigned_physical_gpu_ids() is None:
-            set_assigned_physical_gpu_ids(assigned)
-
-        first = self.local_rank * num_devices
+        dp_rank = self.parallel_config.data_parallel_rank_local or 0
+        slot = dp_rank * self.parallel_config.world_size + self.local_rank
+        first = slot * num_devices
+        # The visible variant, because every worker process is handed a data
+        # parallel mapping of one device per rank that the logical variant
+        # prefers (MultiprocExecutor.worker_main), and a rank owning
+        # num_devices NPUs cannot be described by one entry.
         try:
             selected = [
-                current_platform.device_id_to_physical_device_id(first + offset)
+                current_platform.visible_device_id_to_physical_device_id(first + offset)
                 for offset in range(num_devices)
             ]
         except IndexError as e:
             raise ValueError(
-                f"local rank {self.local_rank} needs {num_devices} NPU(s) from "
-                f"index {first} of {env_var}="
-                f"{os.environ.get(env_var, '')!r}, or of the data parallel "
-                f"mapping when one is in effect. One entry per NPU is expected."
+                f"rank slot {slot} needs {num_devices} NPU(s) from index "
+                f"{first} of {env_var}={os.environ.get(env_var, '')!r}. "
+                "One entry per NPU is expected."
             ) from e
 
         selected_devices = ",".join(str(device) for device in selected)


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

Under data parallelism, DP ranks did not get their own NPUs.

A rank took its NPUs at `local_rank * VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK`. This index does not include the DP rank, so every replica started at the same place. It also went through `device_id_to_physical_device_id()`, which prefers vLLM's DP mapping. That mapping has one device per rank, but an RBLN rank owns RSD devices, so the engine failed to start.

2 changes:
- The slot now spans the whole deployment: `data_parallel_rank_local * world_size + local_rank`.
- The pool is read with `visible_device_id_physical_device_id()`, which ignores that mapping by design.

TP2 / DP2 / RSD2 now gets 0-3, 4-7, 8-11, 12-15.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [x] 🛠 Bug fix (`fix`)

---

### 🧪 How to Test

1. Unit tests:
  `uv run --no-sync pytest tests/native/v1/worker/test_rbln_worker.py -k TestInitDeviceEnv`
  28 pass
2. On ATOM, serve with TP2 / DP2 / RSD4

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

- `--device-ids` is still ignored on the native path. vLLM slices it per rank before the worker sees it, so the full list cannot be recovered. Use `RBLN_VISIBLE_DEVICES` instead. Fixing that would need a patch on vLLM's DP slicer, which this PR does not do.

---
