### PR TITLE
fix(dp): zero the idle dummy step's input buffers

### DIFF
--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -2469,6 +2469,15 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             num_reqs_padded=batch_desc.num_reqs_padded,
         )
 
+        if is_idle:
+            # Only the real path writes these persistent buffers, so slicing them
+            # here would feed this rank its previous request's last token id and
+            # position. An idle rank still joins the expert all-gather, so those
+            # stale values enter the collective and cost the whole group device
+            # time on every step.
+            self.input_ids[:num_tokens].zero_()
+            self.positions[:num_tokens].zero_()
+
         input_ids = self.input_ids[:num_tokens]
         inputs_embeds = None
         positions = self.positions[:num_tokens]


### PR DESCRIPTION
### 🚀 Summary of Changes

`_dummy_run` slices `self.input_ids` / `self.positions` on the DP-idle path without writing them. Both are persistent buffers created with `torch.zeros`; the real path overwrites them every step through `index_select(out=self.input_ids[:n])`, but the dummy path has no such write.

So a rank that has served even one request keeps feeding that request's last token id and position into every idle step that follows. An idle rank still joins the expert all-gather, so those stale values enter the collective and raise the decode step for the whole DP group. The slot they occupy is one the MoE tokens mask discards, so this costs device time, not correctness.

The user-visible symptom is that the first rank to receive a request in a DP pool has the lowest TPOT, and once any other rank has served a request the whole pool moves up and stays there. The axis is not "am I warm" but "has anyone else run" — the state is not in the measured rank, the collective carries it there.

This PR zeros both buffers on the idle path. The real path rewrites the whole region every step, so this cannot affect a later real step, and it makes an already-served rank contribute what a never-served one does.

Model path: **vLLM-native** (`v1/worker/rbln_model_runner.py`). The optimum-rbln path is untouched.

---

### 📌 Related Issues / Tickets

* Related to rebellions-sw/fsw-inference#578

> There is no issue for this in this repository; the investigation lives in the internal one. Tell me if you want one opened here to satisfy the checklist.

---

### ✅ Type of Change

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`fix`)
* [x] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

Unit tests covering the idle path:

```bash
pytest tests/native/v1/worker/test_rbln_model_runner.py::TestDummyRunPadding \
       tests/native/v1/worker/test_rbln_model_runner.py::TestDummyRunDraftParticipation \
       tests/native/v1/worker/test_rbln_model_runner.py::TestDummyRunPPIntermediateTensors -q
```

Result: 12 passed. `uvx pre-commit run --files vllm_rbln/v1/worker/rbln_model_runner.py` passes.

End-to-end reproduction, on a MoE model with expert parallelism:

1. Start one server per DP rank, each pinned to its own device, so a client selects the rank by port rather than through the balancer.
2. Send a single-stream request to one rank and record its TPOT. Repeat a few times so the within-phase spread is known.
3. Send one request to a second rank, then measure the first rank again. Repeat for the third and fourth ranks.
4. Before this change, the first rank's TPOT rises as each additional rank has served, and does not come back down. After it, the measurement stays flat across all four phases.

Edge case tested: the very first phase, where no peer has served yet. The change makes no difference there, because the buffers are still zero — that is the control for the rest.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue — the issue is in the internal repository, see above
* [x] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated (if applicable) — no documentation covers this path

---

### 💬 Notes

What is **not** established: whether the extra device time lands in the idle rank's own graph (its attention runs on a stale position, so RoPE feeds it very different values) or in its peers after the all-gather. The second is the likelier of the two: expert weight load is dynamic, so a stale token that routes to a different set of experts widens the set the group has to load. The device execution window bundles device compute and in-graph collective wait, and the measurement does not separate them. The buffers have to be written either way, so the fix does not depend on which it is. Attention length is not the mechanism: `_dummy_run` resets `seq_lens`, and that is what bounds the attention range, not `positions`.

The block table is also stale on this path — `_dummy_run` does not reset it — but zeroing these two buffers was enough to remove the regression, so that is left alone here.

Raw figures and per-phase traces are in the internal issue, kept out of this description per the repository rule on absolute measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
