### PR TITLE
fix(worker): a model with no resolvable language model still loads

### DIFF
--- a/examples/experimental/offline_inference_basic.py
+++ b/examples/experimental/offline_inference_basic.py
@@ -54,7 +54,7 @@ def main():
 
     # Generate texts from the prompts. The output is a list of RequestOutput
     # objects that contain the prompt, generated text, and other information.
-    outputs = llm.generate(prompts, SamplingParams(temperature=0.8, min_p=0.1))
+    outputs = llm.generate(prompts, SamplingParams(temperature=0.0))
     # Print the outputs.
     for output in outputs:
         prompt = output.prompt

--- a/examples/experimental/offline_inference_basic.py
+++ b/examples/experimental/offline_inference_basic.py
@@ -54,7 +54,7 @@ def main():
 
     # Generate texts from the prompts. The output is a list of RequestOutput
     # objects that contain the prompt, generated text, and other information.
-    outputs = llm.generate(prompts, SamplingParams(temperature=0.0))
+    outputs = llm.generate(prompts, SamplingParams(temperature=0.8, min_p=0.1))
     # Print the outputs.
     for output in outputs:
         prompt = output.prompt

--- a/tests/optimum/v1/worker/test_optimum_model_runner.py
+++ b/tests/optimum/v1/worker/test_optimum_model_runner.py
@@ -153,6 +153,24 @@ def test_should_sort_batch_by_length_checks_language_submodule(
     assert RBLNOptimumModelRunner._should_sort_batch_by_length(model) is expected
 
 
+def test_should_sort_batch_by_length_tolerates_an_unresolvable_language_model():
+    """A SupportsMultiModal model without a marked language model (whisper)
+    inherits get_language_model, and upstream raises NotImplementedError from
+    it. The probe answers False instead of failing the whole model load."""
+
+    def _raise():
+        raise NotImplementedError(
+            "No language model found in RBLNOptimumWhisperForConditionalGeneration!"
+        )
+
+    model = SimpleNamespace(
+        model=SimpleNamespace(rbln_config=SimpleNamespace(requires_batch_sort=False)),
+        get_language_model=_raise,
+    )
+
+    assert RBLNOptimumModelRunner._should_sort_batch_by_length(model) is False
+
+
 @pytest.mark.parametrize(
     ("sort_batch_by_length", "expected_req_ids", "expected_lengths"),
     [

--- a/tests/optimum/v1/worker/test_optimum_model_runner.py
+++ b/tests/optimum/v1/worker/test_optimum_model_runner.py
@@ -28,10 +28,14 @@ from vllm.distributed import (
     ensure_model_parallel_initialized,
     init_distributed_environment,
 )
+from vllm.model_executor.models.interfaces import SupportsMultiModal
 from vllm.platforms import current_platform
 from vllm.v1.core.sched.output import CachedRequestData
 from vllm.v1.sample.metadata import SamplingMetadata
 
+from vllm_rbln.model_executor.models.optimum.model_base import (
+    RBLNOptimumMultimodalMixin,
+)
 from vllm_rbln.v1.core.optimum_scheduler import RBLNSchedulerOutput
 from vllm_rbln.v1.worker.optimum_model_runner import RBLNOptimumModelRunner
 
@@ -124,6 +128,15 @@ def _is_req_state_block_table_match(model_runner, req_id: str) -> bool:
     ).all()
 
 
+class _MultimodalModel(RBLNOptimumMultimodalMixin):
+    def __init__(self, rbln_config, language_model):
+        self.model = SimpleNamespace(rbln_config=rbln_config)
+        self._language_model = language_model
+
+    def get_language_model(self):
+        return self._language_model
+
+
 @pytest.mark.parametrize(
     (
         "top_level_requires_sort",
@@ -140,10 +153,9 @@ def _is_req_state_block_table_match(model_runner, req_id: str) -> bool:
 def test_should_sort_batch_by_length_checks_language_submodule(
     top_level_requires_sort, language_model_requires_sort, expected
 ):
-    rbln_config = SimpleNamespace(requires_batch_sort=top_level_requires_sort)
-    model = SimpleNamespace(
-        model=SimpleNamespace(rbln_config=rbln_config),
-        get_language_model=lambda: SimpleNamespace(
+    model = _MultimodalModel(
+        rbln_config=SimpleNamespace(requires_batch_sort=top_level_requires_sort),
+        language_model=SimpleNamespace(
             rbln_config=SimpleNamespace(
                 requires_batch_sort=language_model_requires_sort
             )
@@ -153,22 +165,17 @@ def test_should_sort_batch_by_length_checks_language_submodule(
     assert RBLNOptimumModelRunner._should_sort_batch_by_length(model) is expected
 
 
-def test_should_sort_batch_by_length_tolerates_an_unresolvable_language_model():
-    """A SupportsMultiModal model without a marked language model (whisper)
-    inherits get_language_model, and upstream raises NotImplementedError from
-    it. The probe answers False instead of failing the whole model load."""
+def test_should_sort_batch_by_length_skips_a_model_without_the_multimodal_mixin():
+    """Whisper inherits SupportsMultiModal directly, so upstream's
+    get_language_model raises. The probe only consults a language model
+    through RBLNOptimumMultimodalMixin."""
 
-    def _raise():
-        raise NotImplementedError(
-            "No language model found in RBLNOptimumWhisperForConditionalGeneration!"
-        )
+    class _WhisperLike(torch.nn.Module, SupportsMultiModal):
+        def __init__(self):
+            super().__init__()
+            self.model = SimpleNamespace(rbln_config=SimpleNamespace())
 
-    model = SimpleNamespace(
-        model=SimpleNamespace(rbln_config=SimpleNamespace(requires_batch_sort=False)),
-        get_language_model=_raise,
-    )
-
-    assert RBLNOptimumModelRunner._should_sort_batch_by_length(model) is False
+    assert RBLNOptimumModelRunner._should_sort_batch_by_length(_WhisperLike()) is False
 
 
 @pytest.mark.parametrize(

--- a/vllm_rbln/v1/worker/optimum_model_runner.py
+++ b/vllm_rbln/v1/worker/optimum_model_runner.py
@@ -310,17 +310,9 @@ class RBLNOptimumModelRunner(
         if getattr(rbln_config, "requires_batch_sort", False):
             return True
 
-        get_language_model = getattr(model, "get_language_model", None)
-        if get_language_model is None:
+        if not isinstance(model, RBLNOptimumMultimodalMixin):
             return False
-        try:
-            language_model = get_language_model()
-        except NotImplementedError:
-            # A SupportsMultiModal model without a marked language model
-            # (e.g. whisper) inherits get_language_model but cannot resolve
-            # one. This is a probe: no language model means no extra
-            # requires_batch_sort to consult, not a load failure.
-            return False
+        language_model = model.get_language_model()
         return bool(getattr(language_model.rbln_config, "requires_batch_sort", False))
 
     @instrument(span_name="Loading (RBLN)")

--- a/vllm_rbln/v1/worker/optimum_model_runner.py
+++ b/vllm_rbln/v1/worker/optimum_model_runner.py
@@ -313,7 +313,14 @@ class RBLNOptimumModelRunner(
         get_language_model = getattr(model, "get_language_model", None)
         if get_language_model is None:
             return False
-        language_model = get_language_model()
+        try:
+            language_model = get_language_model()
+        except NotImplementedError:
+            # A SupportsMultiModal model without a marked language model
+            # (e.g. whisper) inherits get_language_model but cannot resolve
+            # one. This is a probe: no language model means no extra
+            # requires_batch_sort to consult, not a load failure.
+            return False
         return bool(getattr(language_model.rbln_config, "requires_batch_sort", False))
 
     @instrument(span_name="Loading (RBLN)")


### PR DESCRIPTION
### 🚀 Summary of Changes

Fixes a model-loading failure triggered by the batch-sort capability probe when serving transcription-only models such as Whisper.

`_should_sort_batch_by_length` checks whether either the top-level model or its language submodel requires batch sorting. Previously, it used the presence of `get_language_model` to determine whether the language submodel should be inspected.

However, models implementing upstream `SupportsMultiModal` inherit `get_language_model` even when they do not have a resolvable language model. For example, calling this method on `RBLNOptimumWhisperForConditionalGeneration` raises `NotImplementedError`, preventing the model from loading.

This PR changes the capability check to use the RBLN-specific model interface:

* Always check the top-level `rbln_config.requires_batch_sort`.
* Inspect the language submodel only when the model implements `RBLNOptimumMultimodalMixin`.
* Skip the language-submodel check for models such as Whisper that implement `SupportsMultiModal` directly.

This approach uses an explicit RBLN contract instead of relying on method availability or suppressing `NotImplementedError`. It also avoids hiding genuine implementation errors from RBLN multimodal models.

---

### 📌 Related Issues / Tickets

* Resolves #
* Related to #

---

### ✅ Type of Change

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run:

   ```bash
   pytest tests/optimum/v1/worker/
   ```

2. Verify that the existing batch-sort tests correctly inspect both the top-level model configuration and the language submodel configuration for models implementing `RBLNOptimumMultimodalMixin`.

3. Verify that the Whisper-like regression test returns `False` without calling the unresolvable `get_language_model`, allowing model loading to continue.

Expected result: all tests pass.

---

### 📸 Screenshots / Logs (if applicable)

Before this fix, serving Whisper failed during model loading:

```text
File "vllm_rbln/v1/worker/optimum_model_runner.py", line 316, in _should_sort_batch_by_length
    language_model = get_language_model()
File "vllm/model_executor/models/interfaces.py", line 210, in get_language_model
    raise NotImplementedError(
NotImplementedError: No language model found in RBLNOptimumWhisperForConditionalGeneration!
You should initialize it via `_mark_language_model`, and make sure `embed_input_ids` is implemented.
```

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

The initial patch handled an unresolvable language model by catching `NotImplementedError`.

The implementation was revised to avoid exception-based capability detection. The runner now consults a nested language model only through `RBLNOptimumMultimodalMixin`, which represents the RBLN models for which that operation is part of the expected interface.