### PR TITLE
fix(pp): land the recv in a staging buffer, not the graph input

### DIFF
--- a/tests/native/v1/worker/test_rbln_model_runner.py
+++ b/tests/native/v1/worker/test_rbln_model_runner.py
@@ -1394,6 +1394,89 @@ class TestDummyRunDraftParticipation:
         runner._dummy_run(1, 1, is_prefill=False, warmup=False)  # must not raise
 
 
+class TestRecvIntermediateTensorsLanding:
+    # rcclRecv takes a single pointer, so a PP recv can only fill one device area.
+    # The graph input is pinned and may be replicated across chiplets, so the recv
+    # lands in a staging tensor and is copied in — the copy is what reaches every
+    # area the input is replicated across.
+    HIDDEN = 4
+    KEY = (2, 3)
+
+    def _runner(self, monkeypatch, recorded):
+        def make_empty(batch_size, dtype, device):
+            return {
+                "hidden_states": torch.zeros(batch_size, self.HIDDEN, dtype=dtype),
+                "residual": torch.zeros(batch_size, self.HIDDEN, dtype=dtype),
+            }
+
+        runner = _make_runner_stub(
+            model=SimpleNamespace(make_empty_intermediate_tensors=make_empty),
+            model_config=SimpleNamespace(dtype=torch.float16),
+            device=torch.device("cpu"),
+            intermediate_tensors_dict={},
+            recv_landing_dict={},
+        )
+
+        num_reqs_padded, query_len = self.KEY
+        meta = mr.TensorMetadata(
+            "cpu", torch.float16, torch.Size((num_reqs_padded, query_len, self.HIDDEN))
+        )
+        monkeypatch.setattr(
+            mr,
+            "get_pp_group",
+            lambda: SimpleNamespace(
+                rank_in_group=1,
+                world_size=2,
+                ranks=[0, 1],
+                cpu_group=object(),
+                device_group=object(),
+                recv_object=lambda src: [("hidden_states", meta), ("residual", meta)],
+            ),
+        )
+
+        def irecv(tensor, src, group):
+            recorded.append(tensor)
+            tensor.fill_(float(len(recorded)))
+            return SimpleNamespace(wait=lambda: None)
+
+        monkeypatch.setattr(torch.distributed, "irecv", irecv)
+        return runner
+
+    def test_recv_lands_in_staging_then_copies_into_pinned_input(self, monkeypatch):
+        recorded: list = []
+        runner = self._runner(monkeypatch, recorded)
+
+        out = runner.recv_intermediate_tensors()
+
+        landing = runner.recv_landing_dict[self.KEY]
+        pinned = runner.intermediate_tensors_dict[self.KEY]
+        # irecv wrote into the staging tensors, not the graph input.
+        assert [id(t) for t in recorded] == [
+            id(landing["hidden_states"]),
+            id(landing["residual"]),
+        ]
+        # The graph input is handed on unchanged in identity, with the data copied in.
+        for name in ("hidden_states", "residual"):
+            assert out[name] is pinned[name]
+            assert torch.equal(out[name], landing[name])
+        assert out["hidden_states"][0, 0, 0] == 1.0
+        assert out["residual"][0, 0, 0] == 2.0
+
+    def test_staging_and_input_are_reused_across_calls(self, monkeypatch):
+        recorded: list = []
+        runner = self._runner(monkeypatch, recorded)
+
+        first = runner.recv_intermediate_tensors()
+        landing_first = runner.recv_landing_dict[self.KEY]["hidden_states"]
+        second = runner.recv_intermediate_tensors()
+
+        # One staging set and one graph input per shape; neither is reallocated.
+        assert runner.recv_landing_dict[self.KEY]["hidden_states"] is landing_first
+        assert second["hidden_states"] is first["hidden_states"]
+        # The second recv's data replaced the first's.
+        assert second["hidden_states"][0, 0, 0] == 3.0
+
+
 class TestDummyRunPPIntermediateTensors:
     # A non-first PP rank builds empty intermediate tensors for the dummy step at
     # the group-bucket batch (num_reqs_padded), since the stager passes them
@@ -1431,6 +1514,7 @@ class TestDummyRunPPIntermediateTensors:
             input_stager=SimpleNamespace(stage=stage),
             model_executable=lambda **k: None,
             intermediate_tensors_dict={},
+            recv_landing_dict={},
         )
         monkeypatch.setattr(RBLNModelRunner, "use_wrapped_compute_logits", False)
         monkeypatch.setattr(
@@ -1457,6 +1541,22 @@ class TestDummyRunPPIntermediateTensors:
         )
         monkeypatch.setattr(mr, "build_kv_cache_forward_context_kwargs", lambda b: {})
         return runner, captured
+
+    def test_dummy_run_claims_the_recv_staging_buffer(self, monkeypatch):
+        # The staging buffer a PP recv lands in is allocated here rather than on the
+        # first recv, so a shape's first real step does not pay for it.
+        runner, _ = self._runner(monkeypatch, num_reqs_padded=8, query_len=1)
+        runner._dummy_run(1, 1, is_prefill=False, warmup=False)
+
+        key = (8, 1)
+        assert key in runner.recv_landing_dict
+        landing = runner.recv_landing_dict[key]
+        graph_input = runner.intermediate_tensors_dict[key]
+        for name in graph_input.tensors:
+            assert landing[name].shape == graph_input[name].shape
+            assert landing[name].dtype == graph_input[name].dtype
+            # Distinct storage: the recv must not reach the graph input.
+            assert landing[name].data_ptr() != graph_input[name].data_ptr()
 
     def test_idle_intermediate_tensors_use_group_bucket(self, monkeypatch):
         # DP-idle (warmup=False): this rank stages num_reqs=1 but a peer forced

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -421,6 +421,8 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         self.seq_lens_np = self.seq_lens.numpy()
         self.discard_request_mask = torch.zeros(self.max_num_reqs, dtype=torch.bool)
         self.intermediate_tensors_dict: dict[tuple[int, int], IntermediateTensors] = {}
+        # Where a PP recv lands, so it never rebinds the pinned graph input above.
+        self.recv_landing_dict: dict[tuple[int, int], IntermediateTensors] = {}
         self.input_stager = InputStager(self.device)
 
         # OPTIMIZATION: Cache the tensors rather than creating them every step.
@@ -1613,6 +1615,22 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             self.intermediate_tensors_dict[key] = tensors
         return tensors
 
+    def _create_or_get_recv_landing(
+        self, graph_input: IntermediateTensors, num_reqs_padded: int, query_len: int
+    ) -> IntermediateTensors:
+        """Flat staging tensors a PP recv writes into, one set per input shape."""
+
+        key = (num_reqs_padded, query_len)
+        if (landing := self.recv_landing_dict.get(key)) is None:
+            landing = IntermediateTensors(
+                {
+                    name: torch.empty(t.shape, dtype=t.dtype, device=t.device)
+                    for name, t in graph_input.items()
+                }
+            )
+            self.recv_landing_dict[key] = landing
+        return landing
+
     def recv_intermediate_tensors(self) -> IntermediateTensors:
         """Receive the previous PP stage's output into this stage's tensors.
 
@@ -1620,6 +1638,10 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         except that the upstream version allocates a new empty tensor on every call.
         Here we instead reuse buffers via _create_or_get_intermediate_tensors, keeping
         the graph input pinned to a fixed tensor.
+
+        The recv lands in a staging tensor and is copied into that pinned input, because
+        rcclRecv rebinds its target as one flat device area. Receiving into the input
+        would drop the layout the graph reads, and a pinned buffer is never re-staged.
         """
         pp_group = get_pp_group()
         src = (pp_group.rank_in_group - 1) % pp_group.world_size
@@ -1649,14 +1671,18 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             if self.device == torch.device("cpu")
             else pp_group.device_group
         )
+        landing = self._create_or_get_recv_landing(
+            intermediate_tensors, num_reqs_padded, query_len
+        )
         handles = [
-            torch.distributed.irecv(
-                intermediate_tensors[name], src=pp_group.ranks[src], group=group
-            )
+            torch.distributed.irecv(landing[name], src=pp_group.ranks[src], group=group)
             for name, _ in recv_metadata_list
         ]
         for handle in handles:
             handle.wait()
+
+        for name, _ in recv_metadata_list:
+            intermediate_tensors[name].copy_(landing[name])
 
         return intermediate_tensors
 
@@ -2500,6 +2526,11 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         else:
             intermediate_tensors = self._create_or_get_intermediate_tensors(
                 batch_desc.num_reqs_padded, query_len
+            )
+            # Claim the staging buffer here too, so the first recv of a shape does
+            # not pay its allocation on the critical path.
+            self._create_or_get_recv_landing(
+                intermediate_tensors, batch_desc.num_reqs_padded, query_len
             )
 
         # NOTE(RBLN): Clone tensors to make tensors non-view tensors.


### PR DESCRIPTION
## The defect

A PP stage on a chiplet-parallel model produces garbage tokens. Compile, startup and every HTTP response succeed; only the text is wrong, and it is wrong deterministically at `temperature 0`.

#1060 pinned the PP graph input to a reused buffer so the command stream would not be re-patched every step, and had the CCL recv write straight into it. That is where it breaks.

The graph input for such a model is replicated across chiplets — one device area per chiplet, each holding the whole tensor. `rcclRecv` takes a single pointer, so the recv rebinds its target as one flat area and fills only that. Nothing puts the replicated layout back, because the runtime re-stages a device input only when

```
device_bound_vaddrs_[input_idx] != vaddr   ||   NeedsDeviceCopy(vaddr)
```

and a pinned buffer a device-side recv just wrote fails both: the address is unchanged, and the sync state is `PHYSICAL_VIEW_IS_LATEST` because the device really does hold the newest bytes. `SetDeviceAllocConfiguration` and `EnsureSyncedOnPhysicalView` — the step that republishes the data to every replica — never run, so the graph reads the current data on one chiplet and whatever the last staging left on the others.

Before #1060 each step handed the runtime a freshly allocated tensor, so that step always ran. That, and not the allocation itself, is what made the earlier code correct.

## The fix

The recv lands in a staging buffer — cached per input shape, exactly like the graph input, and claimed during the dummy run so a shape's first real step does not pay its allocation — and is copied into the pinned input. The copy carries the input's device layout, so it reaches every area the input is replicated across, and the recv never touches the graph input's binding.

It also restores the re-stage as a safety net rather than relying on the copy's fast path: when the copy cannot go device-to-device it leaves the user view as the truth, which is precisely the state `NeedsDeviceCopy` reports as needing work. Correct either way.

The pinned buffer that #1060 introduced is kept. This is not a revert.

## Results

Measured on a single node, 8 chiplet-parallel PP stages, with the stack from rebellions-sw/fsw-inference#583.

| | output |
|---|---|
| before this change | garbage, byte-identical across runs |
| `#1060` reverted | correct |
| **this change** | **correct — byte-identical to the revert** |

Also checked, all on the same stack: forcing full device synchronisation after every runtime op does not help (the defect is a placement problem, not a race), and the recv itself is byte-exact — the sending stage's tensor and the receiving stage's buffer agree on a content digest. The corruption is entirely in which chiplets see the data.

Serving throughput and TTFT at concurrency 1 land on the reverted tree's numbers, within run-to-run noise. That is expected: the copy currently takes the host round trip, the same path the revert takes. Closing that gap needs the compiler-side change below, after which the copy stays on the device and the pinned buffer's original purpose is recovered.

## Follow-up

`CalculateDeviceToDeviceCopies` in rebel-compiler rejects a replicated destination and falls back to a host round trip, which is why the copy here is not yet device-to-device. rebellions-sw/rebel_compiler#13643 makes it emit one copy per replica. This change is correct without it; that one is what makes it fast.

## Tests

`tests/native/v1/worker/test_rbln_model_runner.py::TestRecvIntermediateTensorsLanding`

- the recv targets the staging tensors, not the graph input, and the graph input is handed on with the same identity and the data copied in
- both the staging set and the graph input are reused across calls, and the second recv's data replaces the first's

`::TestDummyRunPPIntermediateTensors::test_dummy_run_claims_the_recv_staging_buffer`

- the dummy run allocates the staging set alongside the graph input, matching shape and dtype on distinct storage

All three fail without the production change. The rest of the file is unaffected: same failures before and after (they are environment-gated, needing model access this checkout does not have).
