### PR TITLE
fix(nixl): make P/D disaggregation work on vLLM 0.26

### DIFF
--- a/tests/native/distributed/kv_connector/test_rbln_nixl_base_worker.py
+++ b/tests/native/distributed/kv_connector/test_rbln_nixl_base_worker.py
@@ -22,6 +22,7 @@ import types
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 import torch
 from vllm.config import CacheConfig
@@ -369,22 +370,27 @@ class TestSwaViewDelegation:
         assert worker.add_remote_agent(MagicMock(engine_id="peer"), 2, 4) == "agent"
         assert calls == [(2, 4)]
 
-    def test_add_remote_agent_is_idempotent_on_rehandshake(self, monkeypatch):
-        # With SWA active, a remote already handshaked returns its cached name
-        # without re-registering (no super() / topology work).
+    def test_add_remote_agent_returns_the_cached_name_for_a_known_pair(
+        self, monkeypatch
+    ):
+        # The SWA branch's half of the cache check upstream keeps behind a TODO.
+        # Nothing reaches it today -- the agent map is empty until a handshake
+        # returns -- so this pins the lookup, not a retry path.
         worker = _build_worker(
             monkeypatch,
             swa_view_opt=True,
             specs=[_sliding_window_spec(block_size=64, sliding_window=16)],
         )
-        worker._remote_agents = {"peer": {0: "cached-name"}}
+        # Flat rank 1 of a TP2 peer is its (pp 0, tp 1): no pipelining, which
+        # this branch refuses, and not a palindrome, which would pass reversed.
+        worker._remote_agents = {"peer": {(0, 1): "cached-name"}}
         super_calls = []
         monkeypatch.setattr(
             NixlBaseConnectorWorker,
             "add_remote_agent",
             lambda self, *a, **k: super_calls.append(1),
         )
-        result = worker.add_remote_agent(MagicMock(engine_id="peer"), 0, 1)
+        result = worker.add_remote_agent(MagicMock(engine_id="peer"), 1, 2)
         assert result == "cached-name"
         assert super_calls == []
 
@@ -493,7 +499,7 @@ def _patch_worker_nixl_symbols(topo, *, mamba_spec=None, uniform_spec=None):
     msgspec_mock.msgpack.Encoder.return_value.encode.return_value = b"meta"
     return patch.multiple(
         wm,
-        TransferTopology=MagicMock(return_value=topo),
+        RblnTransferTopology=MagicMock(return_value=topo),
         compute_nixl_compatibility_hash=MagicMock(return_value="hash"),
         MambaSpec=mamba_spec or type("MambaSpec", (), {}),
         UniformTypeKVCacheSpecs=uniform_spec or type("UniformTypeKVCacheSpecs", (), {}),
@@ -540,7 +546,7 @@ class TestRegisterKvCachesImpl:
         fake = _fake_nixl_rbln(xfer_result)
 
         topo = MagicMock(
-            is_kv_layout_blocks_first=False,
+            virtually_split_kv_in_blocks=False,
             _cross_layers_blocks=False,
             cross_layers_blocks=False,
         )
@@ -592,9 +598,9 @@ class TestRegisterKvCachesImpl:
             worker.src_xfer_handles_by_block_size[worker.block_size] == "local-handle"
         )
 
-    def test_layout_blocks_first_doubles_region_count(self, monkeypatch):
-        # is_kv_layout_blocks_first flips the region count to 2x (K and V share a
-        # region tensor), which cascades into num_descs.
+    def test_a_split_kv_state_doubles_the_region_count(self, monkeypatch):
+        # A Mamba state indexes two regions per block, which doubles the count
+        # and cascades into num_descs.
         worker = _prep_impl_worker(monkeypatch)
         spec = _impl_layer_spec()
         worker._layer_specs = {"l0": spec, "l1": spec}
@@ -608,7 +614,7 @@ class TestRegisterKvCachesImpl:
         fake = _fake_nixl_rbln(xfer_result)
 
         topo = MagicMock(
-            is_kv_layout_blocks_first=True,
+            virtually_split_kv_in_blocks=True,
             _cross_layers_blocks=False,
             cross_layers_blocks=False,
         )
@@ -648,7 +654,7 @@ class TestRegisterKvCachesImpl:
         fake = _fake_nixl_rbln(xfer_result)
 
         topo = MagicMock(
-            is_kv_layout_blocks_first=False,
+            virtually_split_kv_in_blocks=False,
             _cross_layers_blocks=False,
             cross_layers_blocks=False,
         )
@@ -690,7 +696,7 @@ class TestRegisterKvCachesImpl:
         fake = _fake_nixl_rbln(xfer_result)
 
         topo = MagicMock(
-            is_kv_layout_blocks_first=False,
+            virtually_split_kv_in_blocks=False,
             _cross_layers_blocks=False,
             cross_layers_blocks=False,
         )
@@ -722,7 +728,7 @@ class TestRegisterKvCachesImpl:
         fake = _fake_nixl_rbln(xfer_result)
 
         topo = MagicMock(
-            is_kv_layout_blocks_first=False,
+            virtually_split_kv_in_blocks=False,
             _cross_layers_blocks=False,
             cross_layers_blocks=False,
         )
@@ -736,7 +742,7 @@ class TestRegisterKvCachesImpl:
         ):
             mock_rebel.context_of.return_value.rbln_ctx_ptr = 0x1000
             worker._register_kv_caches_impl(kv_caches)
-            cast(MagicMock, wm.TransferTopology).assert_called_once_with(
+            cast(MagicMock, wm.RblnTransferTopology).assert_called_once_with(
                 tp_rank=0,
                 tp_size=1,
                 block_size=64,
@@ -764,7 +770,7 @@ class TestRegisterKvCachesImpl:
         kv_caches = _impl_kv_caches(num_blocks=worker.num_blocks)
 
         fake = _fake_nixl_rbln(_impl_xfer_result())
-        topo = MagicMock(is_kv_layout_blocks_first=False, _cross_layers_blocks=False)
+        topo = MagicMock(virtually_split_kv_in_blocks=False, _cross_layers_blocks=False)
         topo.get_transfer_cache_regions.side_effect = _split_kv(worker.num_blocks)
 
         with (
@@ -788,7 +794,7 @@ class TestRegisterKvCachesImpl:
         kv_caches = _impl_kv_caches(num_blocks=worker.num_blocks)
 
         fake = _fake_nixl_rbln(_impl_xfer_result())
-        topo = MagicMock(is_kv_layout_blocks_first=False, _cross_layers_blocks=True)
+        topo = MagicMock(virtually_split_kv_in_blocks=False, _cross_layers_blocks=True)
         topo.get_transfer_cache_regions.side_effect = _split_kv(worker.num_blocks)
 
         with (
@@ -824,7 +830,7 @@ class TestRegisterKvCachesImpl:
         fake = _fake_nixl_rbln(
             _impl_xfer_result(base_addrs=[0x20000, 0x30000], block_lens=[4096, 4096])
         )
-        topo = MagicMock(is_kv_layout_blocks_first=False, _cross_layers_blocks=False)
+        topo = MagicMock(virtually_split_kv_in_blocks=False, _cross_layers_blocks=False)
         topo.get_transfer_cache_regions.side_effect = _one_region
 
         with (
@@ -848,14 +854,18 @@ class TestRegisterLocalXferHandlerSwa:
         worker._has_mamba = False
         worker.tp_rank = 0
         worker.device_id = 0
-        worker.transfer_topo = MagicMock(is_kv_layout_blocks_first=False)
+        worker.transfer_topo = MagicMock(virtually_split_kv_in_blocks=False)
         worker.kv_caches_base_addr = {worker.engine_id: {0: [0x1000, 0x2000]}}
         worker.block_len_per_layer = [256, 256]
         worker.nixl_memory_type = "DRAM"
         worker.nixl_wrapper = MagicMock()
 
         with patch.object(worker, "get_backend_aware_kv_block_len", return_value=256):
-            worker.register_local_xfer_handler(64)  # block_size_ratio == 1
+            _, blocks = worker.register_local_xfer_handler(64)  # block_size_ratio 1
+
+        # This return becomes src_blocks_data, which upstream's hetero-TP split
+        # reads with .tolist(); a list of triples would not survive that.
+        assert (blocks.shape, blocks.dtype) == ((16, 3), np.uint64)
 
         worker.nixl_wrapper.get_xfer_descs.assert_called_once()
         blocks_data = worker.nixl_wrapper.get_xfer_descs.call_args[0][0]
@@ -887,6 +897,22 @@ def _remote_agent_meta():
 class TestAddRemoteAgentSwa:
     # The remote engine must be registered and its TPMapping built before any
     # topology lookup, or get_engine_info() KeyErrors.
+    def test_a_mamba_worker_is_refused(self, monkeypatch):
+        # The SWA tail builds Full-only descriptors, so a conv/ssm pair has no
+        # shape here. Nothing else in add_remote_agent says so.
+        worker = _build_worker(monkeypatch, num_blocks=4, block_size=64)
+        worker._sw_ratio = 2
+        worker._has_mamba = True
+        worker.transfer_topo = MagicMock()
+        worker._remote_agents = {}
+        worker.nixl_wrapper = MagicMock()
+
+        with (
+            patch.object(worker, "_register_remote_engine_prelude"),
+            pytest.raises(AssertionError, match="Mamba"),
+        ):
+            worker.add_remote_agent(_remote_agent_meta(), 0, 1)
+
     def test_registers_remote_engine_before_topology_lookups(self, monkeypatch):
         worker = _build_worker(monkeypatch, num_blocks=4, block_size=64)
         worker._sw_ratio = 2
@@ -896,7 +922,7 @@ class TestAddRemoteAgentSwa:
         worker._group_spec_types = ()
         worker.nixl_memory_type = "DRAM"
 
-        topo = MagicMock(is_kv_layout_blocks_first=False)
+        topo = MagicMock(virtually_split_kv_in_blocks=False)
         topo.block_size_ratio.return_value = 1
         topo.tp_ratio.return_value = 1
         topo.is_kv_replicated.return_value = True
@@ -965,7 +991,7 @@ class TestAddRemoteAgentSwa:
         worker._group_spec_types = ()
         worker.nixl_memory_type = "DRAM"
 
-        topo = MagicMock(is_kv_layout_blocks_first=False)
+        topo = MagicMock(virtually_split_kv_in_blocks=False)
         topo.block_size_ratio.return_value = 2
         topo.tp_ratio.return_value = 1
         topo.is_kv_replicated.return_value = True

--- a/tests/native/distributed/kv_connector/test_rbln_nixl_connector.py
+++ b/tests/native/distributed/kv_connector/test_rbln_nixl_connector.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# RblnNixlPullConnector's construction guards, role -> scheduler/worker wiring,
-# finalize delegation and the side-channel keying it hands upstream, with the
-# base __init__ and sub-connectors patched out.
+# The connectors' construction guards, role -> scheduler/worker wiring,
+# finalize delegation, and that handshake metadata reaches the scheduler that
+# serves it, with the base __init__ and sub-connectors patched out.
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
@@ -116,56 +116,21 @@ class TestFinalizeDelegation:
 
 
 class TestSetXferHandshakeMetadataPpAware:
-    # Producer side: every (pp_rank, tp_rank) shard must reach the side channel.
-    #
-    # EngineCore hands the merged worker dicts to
-    # ``set_xfer_handshake_metadata_pp_aware``. Upstream's implementation rejects
-    # pp_rank > 0 and keys by tp_rank alone; this connector flattens the pair into
-    # the rank a consumer asks for in ``_nixl_handshake``.
-    #
+    # This connector no longer overrides the pp-aware setter, and that deletion
+    # is the fix: the override it replaced called a method 0.26 removed from
+    # NixlConnector, so the call fell through to KVConnectorBase_V1's no-op, the
+    # side channel served nothing and every consumer handshake timed out.
 
-    @staticmethod
-    def _connector(tp_size):
+    def test_the_flattening_override_stays_deleted(self):
         c = object.__new__(RblnNixlPullConnector)
-        vllm_config = MagicMock()
-        vllm_config.parallel_config.tensor_parallel_size = tp_size
-        c._vllm_config = vllm_config
-        return c
+        c.connector_scheduler = MagicMock()
+        metadata = {(0, 0): "a", (0, 1): "b", (1, 0): "c", (1, 1): "d"}
 
-    def _flatten(self, metadata, *, tp_size):
-        c = self._connector(tp_size)
-        with patch.object(
-            RblnNixlPullConnector, "set_xfer_handshake_metadata"
-        ) as forward:
-            c.set_xfer_handshake_metadata_pp_aware(metadata)
-        forward.assert_called_once()
-        return forward.call_args[0][0]
+        c.set_xfer_handshake_metadata_pp_aware(metadata)
 
-    def test_single_stage_reduces_to_tp_rank(self):
-        # pp_size == 1: flat rank == tp_rank, i.e. upstream's behavior.
-        assert self._flatten({(0, 0): "m0", (0, 1): "m1"}, tp_size=2) == {
-            0: "m0",
-            1: "m1",
-        }
-
-    def test_pp_stages_get_distinct_flat_ranks(self):
-        assert self._flatten({(0, 0): "s0", (1, 0): "s1"}, tp_size=1) == {
-            0: "s0",
-            1: "s1",
-        }
-        assert self._flatten(
-            {(0, 0): "a", (0, 1): "b", (1, 0): "c", (1, 1): "d"}, tp_size=2
-        ) == {0: "a", 1: "b", 2: "c", 3: "d"}
-
-    def test_pp_rank_gt_zero_is_accepted(self):
-        # Upstream would raise here; a PP-aware connector must not.
-        assert self._flatten({(3, 0): "s3"}, tp_size=1) == {3: "s3"}
-
-    def test_collision_is_rejected(self):
-        # A tp_size disagreeing with the reported ranks would silently drop a
-        # shard; fail loudly instead.
-        with pytest.raises(ValueError, match="Duplicate handshake metadata"):
-            self._flatten({(0, 1): "a", (1, 0): "b"}, tp_size=1)
+        c.connector_scheduler.set_xfer_handshake_metadata.assert_called_once_with(
+            metadata
+        )
 
 
 class TestConnectorWiring:

--- a/tests/native/distributed/kv_connector/test_rbln_nixl_handshake.py
+++ b/tests/native/distributed/kv_connector/test_rbln_nixl_handshake.py
@@ -12,24 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Unit coverage: how a consumer pairs with the peers it handshakes.
-#
-# The handshake fan-out over a peer's shards, and the two axes each shard is
-# paired on -- the layers it owns and the KV heads its chiplet areas hold. The
-# ZMQ side-channel and add_remote_agent are mocked, so none of it needs a live
-# NIXL peer or nixl-rbln.
+# Unit coverage: the handshake and what it establishes about a peer -- among
+# other things the fan-out over its shards, the two axes each shard is paired
+# on, upstream's calling convention, and the clock offset it estimates. The ZMQ
+# side-channel and add_remote_agent are mocked, so none of it needs a live NIXL
+# peer or nixl-rbln.
 
+import threading
 import time
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import msgspec
+import numpy as np
 import pytest
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
     NixlAgentMetadata,
     NixlBaseConnectorWorker,
     NixlPullConnectorWorker,
+    NixlPushConnectorWorker,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     NixlHandshakePayload,
@@ -104,10 +107,21 @@ def _agent_meta(**overrides):
     return RblnNixlAgentMetadata(**fields)
 
 
+class _FakeClock:
+    """Scripted ``perf_counter``: the handshake reads it twice per query."""
+
+    def __init__(self, ticks):
+        self._ticks = list(ticks)
+
+    def perf_counter(self):
+        return self._ticks.pop(0)
+
+
 class _FakeSock:
-    # ZMQ REQ stand-in: replies to (GET_META_MSG, rank) with rank's payload.
-    #
-    # TP is 1 in these tests, so global_rank == pp_rank.
+    # Stands in for the listener at nixl/base_scheduler.py. An unpublished pair
+    # takes the real one down -- it indexes its metadata dict with no guard --
+    # and the caller then sees only a timeout; this raises in the caller instead,
+    # so the bad pair surfaces where it was asked for.
 
     def __init__(
         self,
@@ -117,13 +131,20 @@ class _FakeSock:
         compat="HASH",
         layers_per_stage=1,
         stage_layers=None,
+        tp_size=1,
+        peer_stamps=None,
     ):
         self.pp_size = pp_size
+        self.tp_size = tp_size
+        # What the peer echoes from ITS process clock, in query order. A real
+        # peer's origin is unrelated to ours; that unknown is what the midpoint
+        # and the lowest-RTT rule exist to absorb.
+        self.peer_stamps = list(peer_stamps) if peer_stamps is not None else None
         self.engine_id = engine_id
         self.compat = compat
         self.layers_per_stage = layers_per_stage
         # Optional per-stage layer-name lists (for uneven splits); indexed by
-        # global_rank. When None, stages advertise a uniform layers_per_stage.
+        # pp_rank, since layer ownership is a function of the stage alone.
         self.stage_layers = stage_layers
         self.queried = []
         self._last = None
@@ -132,12 +153,14 @@ class _FakeSock:
         pass
 
     def send(self, msg):
-        _, rank = msgspec.msgpack.decode(msg)
-        self.queried.append(rank)
-        self._last = rank
+        _, pp_rank, tp_rank = msgspec.msgpack.decode(msg)
+        if not (0 <= pp_rank < self.pp_size and 0 <= tp_rank < self.tp_size):
+            raise KeyError((pp_rank, tp_rank))
+        self.queried.append(pp_rank * self.tp_size + tp_rank)
+        self._last = pp_rank
 
-    def recv(self):
-        return _encode_payload(
+    def recv_multipart(self):
+        payload = _encode_payload(
             self._last,
             self.pp_size,
             engine_id=self.engine_id,
@@ -147,6 +170,12 @@ class _FakeSock:
                 self.stage_layers[self._last] if self.stage_layers is not None else None
             ),
         )
+        stamp = (
+            self.peer_stamps.pop(0)
+            if self.peer_stamps is not None
+            else time.perf_counter()
+        )
+        return [payload, msgspec.msgpack.encode(stamp)]
 
 
 def _make_worker(
@@ -157,8 +186,9 @@ def _make_worker(
     tp_ratio=1,
     host_buffer=True,
     has_swa=None,
+    cls=RblnNixlPullConnectorWorker,
 ):
-    w = object.__new__(RblnNixlPullConnectorWorker)
+    w = object.__new__(cls)
     # Host staging closes the D2D-only paths -- head matching and fan-in -- so
     # it is the default and a D2D shape has to ask for the device buffer.
     w.use_host_buffer = host_buffer
@@ -189,7 +219,7 @@ def _make_worker(
 
 
 @contextmanager
-def _patched_socket(sock):
+def _patched_socket(sock, clock=None):
     @contextmanager
     def fake_zmq_ctx(_type, _path):
         yield sock
@@ -198,6 +228,7 @@ def _patched_socket(sock):
         patch.object(W, "zmq_ctx", fake_zmq_ctx),
         patch.object(W, "make_zmq_path", lambda *a: "tcp://x"),
         patch.object(W, "current_platform", MagicMock()),
+        patch.object(W, "time", clock if clock is not None else time),
     ):
         yield
 
@@ -207,18 +238,132 @@ def _handshake(worker, sock, *, remote_tp_size=1, engine_id="eng"):
         return worker._nixl_handshake("h", 1234, remote_tp_size, engine_id)
 
 
+class TestUpstreamReachesTheHandshake:
+    # The other handshake tests here reach _nixl_handshake through a helper
+    # that calls it directly, which cannot see the calling convention. 0.26
+    # submits it to its own executor with six positional arguments and unpacks
+    # an (agents, clock_offset) pair.
+
+    @staticmethod
+    def _worker(cls=RblnNixlPullConnectorWorker):
+        w = _make_worker(cls=cls)
+        w._evict_stale_engines = lambda: None
+        w._handshake_lock = threading.RLock()
+        w._handshake_futures = {}
+        w._handshake_initiation_executor = ThreadPoolExecutor(max_workers=1)
+        w._remote_agents = {}
+        w._engine_clock_offset = {}
+        w._engine_last_active = {}
+        w._log_failure = MagicMock()
+        # This stand-in holds no NIXL state, and __del__ runs shutdown().
+        w.shutdown = w._handshake_initiation_executor.shutdown
+        return w
+
+    def test_ensure_handshake_publishes_the_agents_and_the_offset_midpoint(self):
+        # The offset is the peer's stamp minus the MIDPOINT of the round trip:
+        # the reply was stamped somewhere inside it and the midpoint is the
+        # least-wrong guess. Stage 0 spans 0..10 locally, so a peer stamp of
+        # 105 means the peer's clock reads 100 ahead of ours.
+        sock = _FakeSock(pp_size=2, peer_stamps=[105.0, 1005.0])
+        clock = _FakeClock([0.0, 10.0, 1000.0, 1010.0])
+        w = self._worker()
+
+        with _patched_socket(sock, clock):
+            fut = NixlBaseConnectorWorker._ensure_handshake(w, "eng", "h", 1234, 1)
+            fut.result()
+
+        assert w._remote_agents["eng"] == {(0, 0): "agent-0", (1, 0): "agent-1"}
+        assert w._engine_clock_offset["eng"] == pytest.approx(100.0)
+        w._log_failure.assert_not_called()
+
+    def test_the_lowest_rtt_sample_decides_the_offset(self):
+        # Two stages disagree on the offset because their round trips differ.
+        # The shorter trip pins the peer's stamp more tightly, so it wins --
+        # taking the longer one would import that trip's whole hop cost.
+        sock = _FakeSock(pp_size=2, peer_stamps=[150.0, 1002.0])
+        # Stage 0: 0..100 (slow, midpoint 50 -> offset 100).
+        # Stage 1: 1000..1002 (fast, midpoint 1001 -> offset 1).
+        clock = _FakeClock([0.0, 100.0, 1000.0, 1002.0])
+        w = self._worker()
+
+        with _patched_socket(sock, clock):
+            fut = NixlBaseConnectorWorker._ensure_handshake(w, "eng", "h", 1234, 1)
+            fut.result()
+
+        assert w._engine_clock_offset["eng"] == pytest.approx(1.0)
+
+    def test_the_push_writer_reaches_it_and_unpacks_the_pair(self):
+        # P's first write to a decode engine goes through upstream's blocking
+        # _ensure_d_handshake, which unpacks (agents, clock_offset). A dict of
+        # two shards, as here, unpacks into its own keys instead of raising, so
+        # the engine would store an int where an agent map belongs.
+        sock = _FakeSock(pp_size=2)
+        w = self._worker(cls=RblnNixlPushConnectorWorker)
+
+        with _patched_socket(sock):
+            assert NixlPushConnectorWorker._ensure_d_handshake(
+                w, "eng", "h", 1234, 1, "req-0"
+            )
+
+        assert w._remote_agents["eng"] == {(0, 0): "agent-0", (1, 0): "agent-1"}
+
+    def test_a_peer_whose_pipeline_size_contradicts_the_caller_is_refused(self):
+        # Push mode's decode side is told the producer's pipeline size by the
+        # router. If the producer then reports a different one, one of the two
+        # is describing another engine and pairing them would read from a stage
+        # that does not exist.
+        sock = _FakeSock(pp_size=2)
+        w = self._worker()
+
+        with _patched_socket(sock):
+            fut = NixlBaseConnectorWorker._ensure_handshake(
+                w, "eng", "h", 1234, 1, 3, True
+            )
+            with pytest.raises(RuntimeError, match="pipeline size 3, peer reports 2"):
+                fut.result()
+
+        assert "eng" not in w._remote_agents
+
+    def test_a_notif_only_peer_skips_descriptor_setup(self):
+        # Push mode's decode side never addresses the producer's memory, so
+        # upstream asks for agents alone; registering descriptors for a stage
+        # this rank cannot read would pair lists of different lengths.
+        sock = _FakeSock(pp_size=2)
+        w = self._worker()
+        w._add_notif_only_remote_agent = MagicMock(side_effect=["n0", "n1"])
+
+        with _patched_socket(sock):
+            fut = NixlBaseConnectorWorker._ensure_handshake(
+                w, "eng", "h", 1234, 2, 2, True
+            )
+            fut.result()
+
+        assert w._remote_agents["eng"] == {(0, 0): "n0", (1, 0): "n1"}
+        # Upstream builds the engine's EngineTransferInfo out of this
+        # argument, so what reaches it has to be the peer's tensor-parallel
+        # size and not ours.
+        assert [c.args[1] for c in w._add_notif_only_remote_agent.call_args_list] == [
+            2,
+            2,
+        ]
+        w.add_remote_agent.assert_not_called()
+        w._register_shard_xfer_state.assert_not_called()
+        assert w._overlapping_ranks == {"eng": []}
+
+
 class TestPpHandshakeFanout:
     @pytest.mark.parametrize("pp_size", [1, 2, 3])
-    def test_every_stage_is_queried_once_and_keyed_by_global_rank(self, pp_size):
+    def test_every_stage_is_queried_once_and_keyed_by_its_pair(self, pp_size):
         # The fan-out from one stage up. pp_size comes from the pp_rank-0 shard,
         # so that shard must not be queried twice; at pp_size 1 the whole thing
-        # reduces to upstream's single-shard shape, keyed by tp_rank.
+        # reduces to upstream's single-shard shape, whose pair is (0, tp_rank).
         w = _make_worker()
         sock = _FakeSock(pp_size=pp_size)
 
         result = _handshake(w, sock)
 
-        assert result == {r: f"agent-{r}" for r in range(pp_size)}
+        agents, _ = result
+        assert agents == {(r, 0): f"agent-{r}" for r in range(pp_size)}
         assert sock.queried == list(range(pp_size))
         assert sock.queried.count(0) == 1  # bootstrap reused, not re-queried
         assert w.add_remote_agent.call_count == pp_size
@@ -256,7 +401,7 @@ class TestPpHandshakeFanout:
 
         result = _handshake(w, sock)
 
-        assert result == {1: "agent-1"}
+        assert result[0] == {(1, 0): "agent-1"}
         assert [c.args[1] for c in w.add_remote_agent.call_args_list] == [1]
         assert set(w._remote_shard_layer_names["eng"]) == {0, 1}  # both enumerated
         assert w._overlapping_ranks["eng"] == [1]
@@ -434,16 +579,88 @@ class TestPpHandshakeFanout:
         w._peer_head_split = lambda *a, **k: 2
         w._fan_in_peer_areas = MagicMock(return_value=[0])
 
-        _handshake(w, _FakeSock(pp_size=2), remote_tp_size=2)
+        _handshake(w, _FakeSock(pp_size=2, tp_size=2), remote_tp_size=2)
 
-        # The last stage is global rank 2 of a TP2 peer, i.e. its tp_rank 0,
-        # and it advertises layer.2.
-        assert w._fan_in_peer_areas.call_args.args == (0, 2)
-        assert w._add_remote_agent_head_matched.call_args.kwargs[
-            "registered_layer_names"
-        ] == ("layer.2",)
+        # Both stages are the peer's tp_rank 0 -- the head band comes from that,
+        # not from the flat rank they are keyed by -- and stage i owns layer.i.
+        assert w._fan_in_peer_areas.call_args_list == [call(0, 2), call(0, 2)]
+        assert [
+            c.kwargs["registered_layer_names"]
+            for c in w._add_remote_agent_head_matched.call_args_list
+        ] == [("layer.0",), ("layer.1",)]
         kwargs = w._register_shard_xfer_state.call_args.kwargs
         assert (kwargs["split"], kwargs["replica_fanout"]) == (2, 1)
+
+    def test_the_head_band_follows_the_tp_rank_across_a_wider_peer(self):
+        # Every other test in this class talks to tp_rank 0 alone, which cannot
+        # tell the peer's TP rank from the constant 0. Here the consumer reads
+        # from both of a TP2 peer's ranks, so the two bands must differ.
+        w = _make_worker(tp_ratio=-2, tp_target_ranks=(0, 1), host_buffer=False)
+        w.local_seen_layer_names = ["layer.0"]
+        w.num_regions = 1
+        w._add_remote_agent_head_matched = MagicMock(side_effect=["a0", "a1"])
+        w._peer_head_split = lambda *a, **k: 1
+        w._fan_in_peer_areas = MagicMock(return_value=[0])
+
+        agents, _ = _handshake(w, _FakeSock(pp_size=1, tp_size=2), remote_tp_size=2)
+
+        assert w._fan_in_peer_areas.call_args_list == [call(0, 2), call(1, 2)]
+        # The head-matched branch publishes under the pair too, and this is
+        # the only shape here whose TP component is non-zero.
+        assert agents == {(0, 0): "a0", (0, 1): "a1"}
+
+    def test_a_notif_only_peer_is_still_refused_a_wider_pipelined_tp(self):
+        # The guard sits above the notif_agents_only branch, so it holds on the
+        # one shape where its reasoning is about work this rank will not do.
+        # (That it reads the peer's report rather than the caller's hint is not
+        # visible here -- the two agree on this branch -- but from the default
+        # hint in test_pp_with_larger_peer_tp_raises.)
+        w = _make_worker(tp_target_ranks=(0,), tp_ratio=-2)
+
+        with (
+            _patched_socket(_FakeSock(pp_size=2)),
+            pytest.raises(RuntimeError, match="larger tensor-parallel size"),
+        ):
+            w._nixl_handshake("h", 1234, 4, "eng", 2, True)
+
+    def test_both_sides_pipelined_is_allowed_on_the_pull_side(self):
+        # The shape the push-side guard below must not take with it: reading,
+        # this rank counts its own stages, so a pipeline on each side pairs
+        # stage for stage and both are registered.
+        w = _make_worker()
+        w.vllm_config.parallel_config.pipeline_parallel_size = 2
+
+        agents, _ = _handshake(w, _FakeSock(pp_size=2))
+
+        assert agents == {(0, 0): "agent-0", (1, 0): "agent-1"}
+        assert w._overlapping_ranks["eng"] == [0, 1]
+
+    def test_a_pipelined_consumer_on_the_push_side_is_refused(self):
+        # Upstream's completion count is the producer's pp times the producers
+        # per consumer rank; nothing in it stands for our stages, so a consumer
+        # split into them waits for notifications that never come. Upstream
+        # refuses this too, but only under kv_role=kv_consumer, and the
+        # launcher runs kv_both.
+        w = _make_worker()
+        w.vllm_config.parallel_config.pipeline_parallel_size = 2
+
+        with (
+            _patched_socket(_FakeSock(pp_size=2)),
+            pytest.raises(RuntimeError, match="pipelined consumer"),
+        ):
+            w._nixl_handshake("h", 1234, 1, "eng", 2, True)
+
+    def test_a_pipelined_consumer_is_fine_when_the_producer_is_not(self):
+        # The count is right whenever the producer has one stage: every rank of
+        # ours is written by that stage and waits for exactly one notification.
+        w = _make_worker()
+        w.vllm_config.parallel_config.pipeline_parallel_size = 2
+        w._add_notif_only_remote_agent = MagicMock(return_value="n0")
+
+        with _patched_socket(_FakeSock(pp_size=1)):
+            agents, _ = w._nixl_handshake("h", 1234, 1, "eng", 1, True)
+
+        assert agents == {(0, 0): "n0"}
 
     def test_a_split_region_alone_forces_the_per_shard_path(self):
         # Companion to test_a_finer_peer_alone_forces_the_per_shard_path: here
@@ -570,7 +787,6 @@ class TestShardLocalRegions:
         w.kv_caches_base_addr = {"eng": {0: [1000 * i for i in range(8)]}}
         w.block_len_per_layer = [64] * 8
         w.transfer_topo = MagicMock()
-        w.transfer_topo.is_kv_layout_blocks_first = False
         w.get_backend_aware_kv_block_len = MagicMock(return_value=64)
         w.nixl_wrapper = MagicMock()
         w.nixl_wrapper.prep_xfer_dlist.return_value = 42
@@ -586,14 +802,15 @@ class TestShardLocalRegions:
         handle, blocks = w._register_shard_local_xfer_handler(16, ("l2", "l3"))
 
         assert handle == 42
-        # shard regions [4,5,6,7] x num_blocks 4 = 16 descriptors.
-        assert len(blocks) == 16
+        # shard regions [4,5,6,7] x num_blocks 4 = 16 descriptors, as the Nx3
+        # uint64 array upstream's hetero-TP split reads back.
+        assert (blocks.shape, blocks.dtype) == ((16, 3), np.uint64)
         # first desc: region 4 base addr (4000), block 0.
-        assert blocks[0] == (4000, 64, 0)
+        assert blocks[0].tolist() == [4000, 64, 0]
         # block 1 of region 4: base + 1*stride(64).
-        assert blocks[1] == (4000 + 64, 64, 0)
+        assert blocks[1].tolist() == [4000 + 64, 64, 0]
         # regions used are exactly the shard's (no addr below 4000).
-        assert min(a for a, _, _ in blocks) == 4000
+        assert blocks[:, 0].min() == 4000
 
     def test_register_local_xfer_handler_routes_to_the_shard_path(self):
         # Dispatch to the shard path: no SWA view opt, layer names present. Miss
@@ -1959,16 +2176,18 @@ class TestHeadMatchedAgentRegistration:
         assert areas.call_args.args[0] == 1
 
     def test_a_shard_already_registered_is_not_registered_again(self):
-        # This path returns before upstream's own idempotence guard, so it
-        # carries its own. Without it a re-handshake -- which the retry after a
-        # partial one is -- hands NIXL a second agent for a rank it already has.
+        # Mirrors upstream's own cache check, which it keeps behind a TODO for
+        # a refresh path neither side has yet: within one handshake the engine's
+        # agent map is still empty, so today nothing reaches this.
         w = object.__new__(RblnNixlPullConnectorWorker)
-        w._remote_agents = {"eng": {3: "already"}}
+        # Flat rank 2 of a TP2 peer is its (pp 1, tp 0) -- not a palindrome, so
+        # the pair's order has to be right and not merely its members.
+        w._remote_agents = {"eng": {(1, 0): "already"}}
         w.nixl_wrapper = MagicMock()
         meta = MagicMock()
         meta.engine_id = "eng"
 
-        assert w._add_remote_agent_head_matched(meta, 3, 2) == "already"
+        assert w._add_remote_agent_head_matched(meta, 2, 2) == "already"
         w.nixl_wrapper.add_remote_agent.assert_not_called()
 
     def test_a_peer_with_a_different_tp_degree_is_routed_to_head_matching(self):

--- a/tests/native/distributed/kv_connector/test_rbln_nixl_pull_worker.py
+++ b/tests/native/distributed/kv_connector/test_rbln_nixl_pull_worker.py
@@ -74,16 +74,17 @@ class TestShardReadPath:
         assert descs.size == 0
 
     @staticmethod
-    def _read_worker(pp_size):
+    def _read_worker(pp_size, peer_tp_size=1, local_pp=1):
         w = object.__new__(RblnNixlPullConnectorWorker)
         w._remote_pp_size = {"eng": pp_size}
-        # Full-model decode: every stage overlaps. Decode-PP subsets this (see
-        # test_reads_only_overlapping_stages).
+        # Full-model decode against a TP1 peer: every stage overlaps. Decode-PP
+        # subsets this (see test_reads_only_overlapping_stages), and a wider
+        # peer splits a stage across ranks instead.
         w._overlapping_ranks = {"eng": list(range(pp_size))}
         # The read notification carries how many of us read each producer rank,
         # which counts our pipeline ranks too (see _xfer_notif_id).
         w.vllm_config = MagicMock()
-        w.vllm_config.parallel_config.pipeline_parallel_size = 1
+        w.vllm_config.parallel_config.pipeline_parallel_size = local_pp
         # Upstream reads both on the read path it hands us: start_load_kv
         # converts to kernel block ids, and _read_blocks_for_req checks the
         # bidirectional turn-2 expiry before delegating.
@@ -109,10 +110,14 @@ class TestShardReadPath:
         w._shard_descs_per_block = {}
         w.src_xfer_handles_by_remote = {("eng", r, 16): 100 + r for r in range(pp_size)}
         w.dst_xfer_side_handles = {"eng": {r: 200 + r for r in range(pp_size)}}
-        w._remote_agents = {"eng": {r: f"agent{r}" for r in range(pp_size)}}
+        w._remote_agents = {
+            "eng": {divmod(r, peer_tp_size): f"agent{r}" for r in range(pp_size)}
+        }
         topo = MagicMock()
         topo.get_engine_info.return_value = MagicMock(
-            remote_tp_size=1, remote_block_size=16, remote_physical_blocks_per_logical=1
+            remote_tp_size=peer_tp_size,
+            remote_block_size=16,
+            remote_physical_blocks_per_logical=1,
         )
         topo.tp_ratio.return_value = 1
         topo.block_size_ratio.return_value = 1
@@ -173,6 +178,29 @@ class TestShardReadPath:
         assert w.nixl_wrapper.send_notif.call_count == 2
         assert len(w._recving_transfers["r0"]) == 0
 
+    def test_the_read_notification_counts_our_stages(self):
+        # The parametrized case below pins this arithmetic; what this pins is
+        # the call site asking for the stage factor at all. The other cases
+        # that reach it run one local stage, where asking changes nothing.
+        w = self._read_worker(pp_size=2, local_pp=4)
+
+        w._read_blocks_for_req("r0", self._meta([], [[3, 4]]))
+
+        assert {
+            c.kwargs["notif_msg"] for c in w.nixl_wrapper.send_notif.call_args_list
+        } == {b"r0:2"}
+
+    def test_the_agent_lookup_splits_the_flat_rank_by_the_peers_tp_size(self):
+        # Everywhere else the peer is TP1, where dividing by its TP size is a
+        # no-op and the wrong divisor 1 goes unnoticed. Here flat rank 1 is the
+        # peer's (pp 0, tp 1), so the two shards share a stage.
+        w = self._read_worker(pp_size=2, peer_tp_size=2)
+        w._read_blocks_for_req("r0", self._meta([], [[3, 4]]))
+        assert [c.args[0] for c in w.nixl_wrapper.send_notif.call_args_list] == [
+            "agent0",
+            "agent1",
+        ]
+
     def test_a_dropped_notification_still_reaches_the_other_stages(self):
         # One notif per stage is new here -- upstream sends one -- so a stage
         # that throws must not take the rest with it. The peer whose notif was
@@ -225,6 +253,9 @@ class TestShardReadPath:
             (1, 1, 1, 1, 1),  # one to one
             (4, 1, 1, 1, 4),  # TP fan-out: 4 of us read the one producer rank
             (1, 4, 1, 1, 1),  # TP fan-in: we alone read each producer rank
+            # The only row where both TP degrees exceed 1, so the only one whose
+            # count divides by anything rather than falling to the max(1, ...).
+            (4, 2, 1, 1, 2),  # partial fan-out: 2 of us per producer rank
             (1, 1, 4, 1, 4),  # PP fan-out: our 4 stages read the one rank
             (1, 4, 4, 1, 4),  # both: fan-in leaves 1 per rank, times 4 stages
             (4, 1, 4, 1, 16),  # both fanning out

--- a/tests/native/distributed/kv_connector/test_rbln_nixl_push_worker.py
+++ b/tests/native/distributed/kv_connector/test_rbln_nixl_push_worker.py
@@ -194,7 +194,9 @@ class TestPerShardWrite:
         w._remote_pp_size = {"eng": 1}
         w._overlapping_ranks = {"eng": list(range(ranks))}
         w.vllm_config = MagicMock()
-        w.vllm_config.parallel_config.pipeline_parallel_size = 1
+        # A pipelined producer (PP4 -> TP1 push), so a write path that counted
+        # its stages would say so on the wire.
+        w.vllm_config.parallel_config.pipeline_parallel_size = 4
         w.world_size = 1
         w.num_blocks = 8
         w.dst_num_blocks = {"eng": 8}
@@ -293,7 +295,8 @@ class TestPerShardWrite:
             for c in worker.nixl_wrapper.make_prepped_xfer.call_args_list
         }
         # world_size 1 against a TP-1 peer: one writer, so the count divides
-        # out to one on the far side.
+        # out to one on the far side -- and our four stages stay out of it,
+        # because that far side multiplies them back in itself.
         assert notifs == {b"r0:1"}
 
     def test_a_partial_prefix_hit_keeps_our_matching_tail(self):
@@ -391,143 +394,103 @@ class TestTrimToConsumerBlocks:
         assert "registered 2 block(s)" in msg and "the 1 this producer holds" in msg
 
 
-class TestWriterCountAccounting:
-    """The consumer must not settle a request while some writer is still going.
+class TestWriterCompletionAccounting:
+    """0.26 counts a pushed request's writers itself, so this side must not.
 
-    The count rides in the notification scaled by this side's TP, so the same
-    field also has to keep working for a transfer the upstream path submitted.
+    Upstream settles on ``pp_size * producers_per_consumer`` notifications and
+    reads the producer's TP out of the notification. A count of our own on top
+    of that held all but one back, and a pipeline factor in the payload was
+    multiplied by the peer's ``pp_size`` a second time -- either one leaves the
+    request waiting for notifications that never come.
     """
 
-    def test_the_counter_survives_a_request_it_has_not_seen(self, monkeypatch):
-        # The one place __init__ runs: every other test here builds the worker
-        # with object.__new__ and hands the counter in already made, so a plain
-        # dict would pass all of them and KeyError on the first notification.
-        monkeypatch.setattr(RblnNixlWorkerBase, "__init__", lambda self, *a: None)
-        worker = RblnNixlPushConnectorWorker(MagicMock(), "eng", MagicMock())
-        worker.shutdown = lambda: None  # the writer state __del__ reaches is absent
-        worker._writer_counts_by_req["r0"] += 1
-        assert worker._writer_counts_by_req == {"r0": 1}
-
     @staticmethod
-    def _receiving_worker(world_size):
+    def _receiving_worker(world_size, pp_size):
         w = _push_worker()
         w.world_size = world_size
-        w._writer_counts_by_req = defaultdict(int)
         w._reqs_to_send = {}
         w._reqs_to_process = set()
-        w._recving_metadata = {"r0": object()}
+        w._recving_metadata = {"r0": SimpleNamespace(pp_size=pp_size)}
+        w._recving_transfers = {}
+        w.consumer_notification_counts_by_req = defaultdict(int)
         w._pending_completion_notifs = queue.Queue()
+        w.transfer_topo = MagicMock()
         return w
 
-    @pytest.fixture
-    def handed_through(self, monkeypatch):
-        """What reaches upstream, in order."""
-        seen = []
+    @staticmethod
+    def _writer_notif(*, producer_tp, consumer_tp):
+        """What a producer of that shape writes, from the write path itself.
 
-        def fake_base(self):
-            while True:
-                try:
-                    seen.append(self._pending_completion_notifs.get_nowait())
-                except queue.Empty:
-                    return set()
+        A literal here would let the two halves drift apart again -- that they
+        cannot disagree unseen is the point.
+        """
+        w = _push_worker()
+        w.world_size = producer_tp
+        w.vllm_config = MagicMock()
+        return w._xfer_notif_id("eng", "r0", consumer_tp, count_stages=False)
 
-        monkeypatch.setattr(NixlPushConnectorWorker, "_get_new_notifs", fake_base)
-        return seen
-
-    def test_only_the_last_of_four_writers_reaches_the_base(self, handed_through):
-        # Four peer ranks writing into this one: upstream settles on whatever it
-        # sees, so it may see exactly one notification.
-        worker = self._receiving_worker(world_size=1)
-        for _ in range(4):
-            worker._pending_completion_notifs.put(b"r0:4")
-
-        worker._get_new_notifs()
-
-        assert handed_through == [b"r0:4"]
-
-    def test_the_count_carries_across_steps(self, handed_through):
-        # Writers finish whenever they finish; the tally has to survive the
-        # steps in between.
-        worker = self._receiving_worker(world_size=1)
-        for _ in range(3):
-            worker._pending_completion_notifs.put(b"r0:4")
-        worker._get_new_notifs()
-        assert handed_through == []
-
-        worker._pending_completion_notifs.put(b"r0:4")
-        worker._get_new_notifs()
-        assert handed_through == [b"r0:4"]
-
-    def test_a_single_writer_is_passed_straight_through(self, handed_through):
-        # Equal TP with no pipeline: the upstream path submits it and puts its
-        # own tensor-parallel size in the notification, which divides out to one.
-        worker = self._receiving_worker(world_size=4)
-        worker._pending_completion_notifs.put(b"r0:4")
-
-        worker._get_new_notifs()
-
-        assert handed_through == [b"r0:4"]
-
-    @pytest.mark.parametrize(
-        "notif, reason",
-        [
-            (b"HB:engine-1", "heartbeat"),
-            (b"other:4", "not a request we are receiving"),
-        ],
-    )
-    def test_notifications_the_base_owns_are_untouched(
-        self, handed_through, notif, reason
-    ):
-        worker = self._receiving_worker(world_size=1)
+    @staticmethod
+    def _feed(worker, notif):
+        """One notification in, upstream's own done-report out."""
         worker._pending_completion_notifs.put(notif)
-
         worker._get_new_notifs()
+        return worker._pop_done_transfers(worker._recving_transfers)
 
-        assert handed_through == [notif], reason
-        assert worker._writer_counts_by_req == {}
+    def test_a_pipelined_producer_settles_on_its_last_stage(self):
+        # Four stages write into this one rank; upstream expects pp_size * 1.
+        worker = self._receiving_worker(world_size=1, pp_size=4)
+        notif = self._writer_notif(producer_tp=1, consumer_tp=1)
 
-    def test_our_own_outbound_request_is_left_to_the_base(self, handed_through):
-        # A request this rank is sending is upstream's own accounting, even
-        # though the notification looks identical.
-        worker = self._receiving_worker(world_size=1)
-        worker._reqs_to_process = {"r0"}
-        worker._pending_completion_notifs.put(b"r0:4")
+        assert [self._feed(worker, notif) for _ in range(4)] == [
+            set(),
+            set(),
+            set(),
+            {"r0"},
+        ]
 
-        worker._get_new_notifs()
+    def test_a_wider_producer_settles_on_its_last_rank(self):
+        # Four producer ranks per consumer rank, no pipeline: pp_size 1 * 4.
+        worker = self._receiving_worker(world_size=1, pp_size=1)
+        notif = self._writer_notif(producer_tp=4, consumer_tp=1)
 
-        assert handed_through == [b"r0:4"]
-        assert worker._writer_counts_by_req == {}
+        assert [self._feed(worker, notif) for _ in range(4)] == [
+            set(),
+            set(),
+            set(),
+            {"r0"},
+        ]
 
-    def test_upstreams_own_get_finished_is_what_reaches_the_filter(self):
-        # Same reason as the submission path's entry-point case: a direct call
-        # would survive upstream renaming the hook.
-        worker = self._receiving_worker(world_size=1)
-        worker.transfer_topo = MagicMock()
-        worker._recving_transfers = {}
-        worker._failed_recv_reqs = queue.Queue()
-        worker._pop_done_transfers = lambda _transfers: set()
-        worker._pending_completion_notifs.put(b"r0:2")
 
-        done_sending, _ = NixlBaseConnectorWorker.get_finished(worker)
+class TestNotifIdStageFactor:
+    """The read path counts our stages into the payload, the write path cannot.
 
-        # Two writers, one report: held back, and the tally advanced.
-        assert done_sending == set()
-        assert worker._writer_counts_by_req["r0"] == 1
+    Upstream's read side takes the payload as a plain consumer count; its write
+    side multiplies the peer's own ``pp_size`` back in.
+    """
 
-    def test_a_finished_request_drops_its_tally(self, monkeypatch):
-        # A retry reuses the request id, so a leftover partial count would
-        # settle it early.
-        worker = self._receiving_worker(world_size=1)
-        worker._writer_counts_by_req["r0"] = 2
-        monkeypatch.setattr(
-            NixlPushConnectorWorker,
-            "get_finished",
-            lambda self: (set(), {"r0"}),
-        )
+    @staticmethod
+    def _worker(local_pp, remote_pp, world_size=1):
+        w = _push_worker()
+        w.world_size = world_size
+        w._remote_pp_size = {"eng": remote_pp}
+        w.vllm_config = MagicMock()
+        w.vllm_config.parallel_config.pipeline_parallel_size = local_pp
+        return w
 
-        worker.get_finished()
+    def test_the_write_path_leaves_the_stages_to_upstream(self):
+        worker = self._worker(local_pp=4, remote_pp=1)
 
-        assert worker._writer_counts_by_req == {}
+        assert worker._xfer_notif_id("eng", "r0", 1, count_stages=False) == b"r0:1"
+
+    def test_the_read_path_still_carries_them(self):
+        worker = self._worker(local_pp=4, remote_pp=1)
+
+        assert worker._xfer_notif_id("eng", "r0", 1) == b"r0:4"
+
+    def test_a_wider_local_tp_is_scaled_either_way(self):
+        worker = self._worker(local_pp=1, remote_pp=1, world_size=4)
+
+        assert worker._xfer_notif_id("eng", "r0", 1, count_stages=False) == b"r0:4"
 
 
 class TestSaveBeforeWriteInvariant:
@@ -739,7 +702,6 @@ class TestTheThreeListsAgree:
         topo = MagicMock()
         topo.total_num_kv_heads = 8
         topo.tp_size = 1
-        topo.is_kv_layout_blocks_first = False
         topo.tp_ratio.return_value = -4
         w.transfer_topo = topo
         w.get_backend_aware_kv_block_len = lambda **kw: 512

--- a/tests/native/distributed/kv_connector/test_rbln_transfer_topology.py
+++ b/tests/native/distributed/kv_connector/test_rbln_transfer_topology.py
@@ -1,0 +1,175 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 0.26 standardized on a blocks-first cache whose K and V share one region and
+# asserts that layout in TransferTopology.__post_init__. RBLN's attention cache
+# is K/V-first and fails it; its MLA cache passes. Upstream's own registration
+# path builds the topology, so every test here constructs one directly.
+
+import pytest
+import torch
+from vllm.distributed.kv_transfer.kv_connector.utils import EngineTransferInfo
+
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_transfer_topology import (
+    RblnTransferTopology,
+)
+from vllm_rbln.v1.attention.backends.flash_attention import RBLNFlashAttentionBackend
+from vllm_rbln.v1.attention.backends.mla.flashattn_mla import RBLNFlashAttnMLABackend
+
+
+class TestRblnTransferTopology:
+    @staticmethod
+    def _topology(backend, *, is_mla=False, is_mamba=False, tensor_shape=None):
+        return RblnTransferTopology(
+            tp_rank=0,
+            tp_size=2,
+            block_size=64,
+            engine_id="e",
+            is_mla=is_mla,
+            is_mamba=is_mamba,
+            total_num_kv_heads=8,
+            attn_backends=[backend],
+            tensor_shape=tensor_shape,
+        )
+
+    def test_the_rbln_attention_layout_builds(self):
+        topo = self._topology(RBLNFlashAttentionBackend)
+
+        assert topo.cross_layers_blocks is False
+        assert topo.local_physical_heads == 4
+
+    def test_k_and_v_come_back_as_separate_regions(self):
+        # The caller divides the page size by how many regions come back, so
+        # one region here would double the per-block stride.
+        topo = self._topology(RBLNFlashAttentionBackend)
+        cache = torch.zeros(2, 4, 8, 1, 64, 64)
+
+        regions = topo.get_transfer_cache_regions(cache, object())
+
+        assert len(regions) == 2
+        assert all(region.shape[0] == 4 for region in regions)
+
+    def test_an_mla_layer_stays_one_region(self):
+        topo = self._topology(RBLNFlashAttnMLABackend, is_mla=True)
+        cache = torch.zeros(4, 64, 576)
+
+        assert len(topo.get_transfer_cache_regions(cache, object())) == 1
+
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            # FlashInfer-style: blocks first, K and V packed behind them.
+            lambda n, b, h, d: (n, 2, h, b, d),
+            # K/V first, but tokens where the blocks axis belongs.
+            lambda n, b, h, d: (2, b, h, n, d),
+        ],
+        ids=["blocks_first", "tokens_before_blocks"],
+    )
+    def test_a_cache_the_descriptors_cannot_read_is_rejected(self, shape):
+        # The arithmetic reads K and V off the leading dim and the blocks off
+        # the next, so a cache shaped otherwise has to stop here rather than
+        # transfer halves of itself.
+        class Backend:
+            @staticmethod
+            def get_kv_cache_shape(num_blocks, block_size, num_kv_heads, head_size):
+                return shape(num_blocks, block_size, num_kv_heads, head_size)
+
+        with pytest.raises(AssertionError, match="attention"):
+            self._topology(Backend)
+
+    def test_the_engine_map_is_there_for_upstream_to_fill(self):
+        # Upstream's own register/lookup read this map; no other test here
+        # would notice it missing.
+        topo = self._topology(RBLNFlashAttentionBackend)
+        info = EngineTransferInfo(
+            remote_tp_size=1,
+            remote_block_len=8,
+            remote_block_size=16,
+            remote_physical_blocks_per_logical=1,
+        )
+
+        topo.register_remote_engine("peer", info)
+
+        assert topo.get_engine_info("peer") is info
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"is_mamba": True},
+            {"tensor_shape": torch.Size((28, 2, 4, 8, 1, 64, 64))},
+        ],
+    )
+    def test_the_other_two_layouts_stay_on_upstream_s_path(self, kwargs):
+        # A Mamba state and cross-layer blocks are upstream's own shapes; the
+        # split this class restores is for the K/V-first attention cache alone.
+        # Registration walks a Mamba layer before the descriptor path refuses
+        # it, so that arm is reached in production.
+        topo = self._topology(RBLNFlashAttentionBackend, **kwargs)
+        cache = torch.zeros(2, 4, 8, 1, 64, 64)
+
+        assert len(topo.get_transfer_cache_regions(cache, object())) == 1
+
+    def test_a_mamba_topology_never_asks_the_backend_for_a_shape(self):
+        # A Mamba cache is a (conv, ssm) pair and the connector hands it no
+        # tensor shape, so the attention-shaped query has no answer to give.
+        class Refuses:
+            @staticmethod
+            def get_kv_cache_shape(**kwargs):
+                raise AssertionError("asked a Mamba topology for an attention shape")
+
+        topo = self._topology(Refuses, is_mamba=True)
+
+        assert topo.cross_layers_blocks is False
+
+    def test_it_sets_what_upstream_s_post_init_sets(self):
+        # __post_init__ is reimplemented rather than extended, so a field
+        # upstream adds to it is simply absent here and nothing fails until
+        # the first handshake reads it.
+        class BlocksFirst:
+            @staticmethod
+            def get_kv_cache_shape(num_blocks, block_size, num_kv_heads, head_size):
+                return (num_blocks, num_kv_heads, block_size, head_size)
+
+        (upstream,) = RblnTransferTopology.__bases__
+        theirs = upstream(
+            tp_rank=0,
+            tp_size=2,
+            block_size=64,
+            engine_id="e",
+            is_mla=False,
+            is_mamba=False,
+            total_num_kv_heads=8,
+            attn_backends=[BlocksFirst],
+        )
+
+        ours = self._topology(RBLNFlashAttentionBackend)
+
+        assert vars(ours).keys() == vars(theirs).keys()
+
+    def test_only_a_mamba_state_asks_for_the_block_split(self):
+        # The connector doubles its region count off this upstream property,
+        # which reads the _cross_layers_blocks that this __post_init__ sets --
+        # including on the arm that returns before the shape query.
+        attention = self._topology(RBLNFlashAttentionBackend)
+        mamba = self._topology(RBLNFlashAttentionBackend, is_mamba=True)
+
+        assert attention.virtually_split_kv_in_blocks is False
+        assert mamba.virtually_split_kv_in_blocks is True
+
+    def test_cross_layer_blocks_are_read_off_the_tensor_shape(self):
+        topo = self._topology(
+            RBLNFlashAttentionBackend, tensor_shape=torch.Size((28, 2, 4, 8, 1, 64, 64))
+        )
+
+        assert topo.cross_layers_blocks is True

--- a/tests/native/patches/test_kv_connector_utils.py
+++ b/tests/native/patches/test_kv_connector_utils.py
@@ -1,0 +1,52 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""The RBLN transfer topology has to reach upstream's own construction sites.
+
+Upstream builds ``TransferTopology`` inside its NIXL ``register_kv_caches``,
+which the host-bounce path delegates to, so the substitution has to be a patch
+rather than a call this side owns.
+"""
+
+from __future__ import annotations
+
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_transfer_topology import (
+    RblnTransferTopology,
+)
+from vllm_rbln.patches.registry import get_registered_patch_descriptors
+
+
+def test_one_registration_installs_it():
+    # Duplicate targets raise, but two registrations of this class against
+    # different targets would both apply and the later one would decide what
+    # upstream reads.
+    assert (
+        sum(
+            d.replacement is RblnTransferTopology
+            for d in get_registered_patch_descriptors()
+        )
+        == 1
+    )
+
+
+def test_the_name_nixl_binds_later_is_the_patched_one():
+    # The target is the module that defines the class, not the one that reads
+    # it: upstream's worker binds it with `from ... import`, and what that name
+    # ends up holding is the part the registry's identity check cannot see.
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
+        base_worker as upstream_nixl,
+    )
+
+    assert upstream_nixl.TransferTopology is RblnTransferTopology

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/base_worker.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/base_worker.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
 from collections import defaultdict
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
@@ -26,7 +27,6 @@ from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.utils import (
     BlockIds,
     EngineTransferInfo,
-    TransferTopology,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     CopyBlocksOp,
@@ -60,12 +60,24 @@ from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.metadata import
     RblnNixlAgentMetadata,
     rbln_compat_hash,
 )
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_transfer_topology import (
+    RblnTransferTopology,
+)
 from vllm_rbln.logger import init_logger
 
 if TYPE_CHECKING:
     from vllm.v1.kv_cache_interface import KVCacheConfig
 
 logger = init_logger(__name__)
+
+
+def _as_descs(blocks_data: list[tuple[int, int, int]]) -> np.ndarray:
+    """Columns are (addr, len, device), in upstream's own descriptor shape.
+
+    ``src_blocks_data`` is read back by upstream's hetero-TP split, which calls
+    ``.tolist()`` on it.
+    """
+    return np.asarray(blocks_data, dtype=np.uint64).reshape(-1, 3)
 
 
 class RblnNixlWorkerBase(NixlBaseConnectorWorker):
@@ -81,8 +93,8 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
     a replica is its own engine, and EP does not shard the KV cache.
 
       * the two pipeline sizes must tile each other
-      * both sides pipelined requires equal TP, and a pipelined peer may not
-        have MORE TP ranks
+      * both sides pipelined: read direction only, equal TP, and a pipelined
+        peer may not have MORE TP ranks
       * D2D only: one of OUR chiplet areas must fit inside a single peer rank's
         band (heads per area <= total KV heads / peer TP)
       * each side's TP degree must divide the model's KV heads; below that
@@ -341,7 +353,7 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
         """
         import nixl_rbln
 
-        self.transfer_topo = TransferTopology(
+        self.transfer_topo = RblnTransferTopology(
             tp_rank=self.tp_rank,
             tp_size=self.world_size,
             block_size=self.block_size,
@@ -480,11 +492,11 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
         )
 
         self.num_regions = len(xfer.base_addrs)
-        if self.transfer_topo.is_kv_layout_blocks_first:
-            # Blocks-first layout doubles the region count (K/V split), like the
-            # upstream's virtually_split_kv_in_blocks -- except for key-only MLA
-            # regions, which have no V half. Inert while the connector rejects
-            # blocks-first outright (FA layout only).
+        if self.transfer_topo.virtually_split_kv_in_blocks:
+            # A Mamba state indexes its two regions separately, which doubles
+            # the count -- except for key-only MLA regions, which have no
+            # second half. Registration reaches this; the descriptor path then
+            # refuses Mamba, so the doubled count never reaches a transfer.
             self.num_regions = sum(
                 1 if self._is_region_replicated(i) else 2
                 for i in range(len(self._region_is_mla))
@@ -555,7 +567,7 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
         split: int = 1,
         region_ids: list[int] | None = None,
         replica_fanout: int = 1,
-    ) -> tuple[int, list[tuple[int, int, int]]]:
+    ) -> tuple[int, np.ndarray]:
         if self._sw_ratio is None:
             if (
                 registered_layer_names is None
@@ -584,11 +596,6 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
         ), (
             "RBLN NIXL: SWA view-opt is not supported with pipeline "
             "parallelism or heterogeneous tensor parallelism"
-        )
-        assert self.transfer_topo is not None
-        assert not self.transfer_topo.is_kv_layout_blocks_first, (
-            "RBLN NIXL connector only supports FA layout (K and V in "
-            "separate regions), not FlashInfer."
         )
         assert not self._has_mamba, "RBLN NIXL connector does not support Mamba layers."
 
@@ -623,10 +630,11 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
             self.tp_rank,
         )
 
-        descs = self.nixl_wrapper.get_xfer_descs(blocks_data, self.nixl_memory_type)
+        descs_data = _as_descs(blocks_data)
+        descs = self.nixl_wrapper.get_xfer_descs(descs_data, self.nixl_memory_type)
         return (
             self.nixl_wrapper.prep_xfer_dlist("NIXL_INIT_AGENT", descs),
-            blocks_data,
+            descs_data,
         )
 
     # ------------------------------------------------------------------
@@ -997,8 +1005,12 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
         `_fan_in_peer_areas` to the chiplet areas a finer peer owns.
         """
         engine_id = nixl_agent_meta.engine_id
-        if remote_tp_rank in self._remote_agents.get(engine_id, {}):
-            return self._remote_agents[engine_id][remote_tp_rank]
+        # Shards keep the flat rank because it collapses to the peer's TP rank
+        # at pp_size 1, which is what upstream's int-keyed descriptor dicts get
+        # from it; the agent map is keyed by the pair it decomposes into.
+        agent_key = divmod(remote_tp_rank, remote_tp_size)
+        if agent_key in self._remote_agents.get(engine_id, {}):
+            return self._remote_agents[engine_id][agent_key]
 
         self._register_remote_engine_prelude(nixl_agent_meta, remote_tp_size)
         remote_agent_name = self.nixl_wrapper.add_remote_agent(
@@ -1011,10 +1023,7 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
         )
         self._validate_remote_agent_handshake(nixl_agent_meta, remote_tp_size)
 
-        # Under PP the caller keys shards by the flat global rank
-        # (pp_rank * tp_size + tp_rank); the head band depends only on the
-        # tp_rank part. Modulo is a no-op on the non-PP path.
-        peer_tp_rank = remote_tp_rank % remote_tp_size
+        _, peer_tp_rank = agent_key
         blocks_data = self._build_head_matched_remote(
             nixl_agent_meta,
             peer_tp_rank,
@@ -1063,14 +1072,15 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
                 nixl_agent_meta, remote_tp_rank, remote_tp_size
             )
         engine_id = nixl_agent_meta.engine_id
-        if remote_tp_rank in self._remote_agents.get(engine_id, {}):
+        agent_key = divmod(remote_tp_rank, remote_tp_size)
+        if agent_key in self._remote_agents.get(engine_id, {}):
             logger.debug(
                 "Remote agent with engine_id %s and rank %s already "
                 "exchanged metadata, skip handshake.",
                 engine_id,
                 remote_tp_rank,
             )
-            return self._remote_agents[engine_id][remote_tp_rank]
+            return self._remote_agents[engine_id][agent_key]
 
         self._register_remote_engine_prelude(nixl_agent_meta, remote_tp_size)
 
@@ -1078,10 +1088,7 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
             nixl_agent_meta.agent_metadata
         )
 
-        kv_topo = self.transfer_topo
-        assert not kv_topo.is_kv_layout_blocks_first, (
-            "RBLN NIXL connector only supports FA layout."
-        )
+        assert not self._has_mamba, "RBLN NIXL connector does not support Mamba."
 
         block_size_ratio = self.transfer_topo.block_size_ratio(
             nixl_agent_meta.block_size
@@ -1264,12 +1271,25 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
         )
 
     def _query_agent_meta(
-        self, sock: "zmq.Socket", remote_rank: int, expected_engine_id: str
-    ) -> RblnNixlAgentMetadata:
-        sock.send(msgspec.msgpack.encode((GET_META_MSG, remote_rank)))
+        self,
+        sock: "zmq.Socket",
+        remote_pp_rank: int,
+        remote_tp_rank: int,
+        expected_engine_id: str,
+    ) -> tuple[RblnNixlAgentMetadata, float, float]:
+        """Returns the peer's metadata, the round trip time, and the clock
+        offset that trip estimates. The counter-party is upstream's
+        ``_nixl_handshake_listener``; the query arity and frame count are its.
+        """
+        start_time = time.perf_counter()
+        sock.send(
+            msgspec.msgpack.encode((GET_META_MSG, remote_pp_rank, remote_tp_rank))
+        )
+        payload_bytes, perf_bytes = sock.recv_multipart()
+        recv_time = time.perf_counter()
         try:
             handshake_payload = msgspec.msgpack.Decoder(NixlHandshakePayload).decode(
-                sock.recv()
+                payload_bytes
             )
         except (msgspec.DecodeError, msgspec.ValidationError) as e:
             raise RuntimeError(
@@ -1304,7 +1324,12 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
                 "Remote NIXL agent engine ID mismatch. "
                 f"Expected {expected_engine_id}, received {metadata.engine_id}."
             )
-        return metadata
+        remote_perf = msgspec.msgpack.decode(perf_bytes)
+        return (
+            metadata,
+            recv_time - start_time,
+            remote_perf - (start_time + recv_time) / 2,
+        )
 
     def _nixl_handshake(
         self,
@@ -1312,16 +1337,24 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
         port: int,
         remote_tp_size: int,
         expected_engine_id: str,
-    ) -> dict[int, str]:
+        remote_pp_size: int = 1,
+        notif_agents_only: bool = False,
+    ) -> tuple[dict[tuple[int, int], str], float]:
         """Handshake with every shard of one peer engine.
 
-        Runs on upstream's single-worker handshake executor, outside its lock;
-        the one thing published under that lock is this method's return value,
-        which upstream's done callback assigns to ``_remote_agents[engine_id]``.
-        The read path reaches a peer only once that key exists, which is what
-        makes the per-shard state written here visible to it. So every write has
-        to land BEFORE the return -- state published after it, or from another
-        thread, would be read half-built.
+        Runs off the main thread -- on upstream's handshake executor, or inline
+        on the writer thread when a producer opens one -- and neither publishes
+        anything of ours: both take the agents out of the return and assign them
+        to ``_remote_agents[engine_id]`` under the handshake lock. A peer is
+        reached only once that key exists, which is what makes the per-shard
+        state written here visible. So every write has to land BEFORE the return
+        -- state published after it would be read half-built.
+
+        Upstream takes the peer's pipeline size from its caller and never
+        asks, and no caller derives it: it is relayed from the producer
+        through kv_transfer_params, while the read handshake and a producer's
+        own reverse handshake both pass nothing and take the default of 1.
+        Asking the peer is why this override exists.
         """
         # Background thread needs a device context (see upstream _nixl_handshake).
         if not self.use_host_buffer:
@@ -1330,7 +1363,7 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
         assert self.transfer_topo is not None
         p_remote_tp_ranks = self.transfer_topo.handshake_target_ranks(remote_tp_size)
         path = make_zmq_path("tcp", host, port)
-        remote_rank_to_agent_name: dict[int, str] = {}
+        remote_rank_to_agent_name: dict[tuple[int, int], str] = {}
         overlapping: list[int] = []
 
         with zmq_ctx(zmq.REQ, path) as sock:
@@ -1338,10 +1371,19 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
 
             # Bootstrap: the first shard (pp_rank 0) advertises pp_size.
             first_rank = p_remote_tp_ranks[0]
-            metas = {
-                first_rank: self._query_agent_meta(sock, first_rank, expected_engine_id)
-            }
-            pp_size = metas[first_rank].pp_size
+            first_meta, best_rtt, best_offset = self._query_agent_meta(
+                sock, 0, first_rank, expected_engine_id
+            )
+            metas = {(0, first_rank): first_meta}
+            pp_size = first_meta.pp_size
+            # TODO(vllm>=0.29.0): the reason above expires -- the read path
+            # gains a caller that carries pp_size, and remote_dcp_size lands
+            # ahead of remote_pp_size in this signature.
+            if remote_pp_size > 1 and remote_pp_size != pp_size:
+                raise RuntimeError(
+                    f"RBLN NIXL: caller expects peer {expected_engine_id} to run "
+                    f"pipeline size {remote_pp_size}, peer reports {pp_size}."
+                )
 
             # Guard on either side's pipeline, not just the peer's: the peer
             # runs none in the reverse shape, where ours is the finer one.
@@ -1371,6 +1413,18 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
                         f"parallelism on BOTH sides (peer pp={pp_size}, local "
                         f"pp={local_pp}) is not supported."
                     )
+                if notif_agents_only and pp_size > 1 and local_pp > 1:
+                    # Upstream waits for pp_size * producers_per_consumer
+                    # completions, a count with no term for our own stages, and
+                    # refuses the shape itself only under kv_role=kv_consumer,
+                    # which kv_both does not reach. A single producer stage
+                    # writes every rank of ours, so that one is exact.
+                    raise RuntimeError(
+                        "RBLN NIXL: a pipelined producer pushing into a "
+                        f"pipelined consumer (peer pp={pp_size}, local "
+                        f"pp={local_pp}) is not supported; the completion count "
+                        "the peer waits for cannot express this side's stages."
+                    )
                 if tp_ratio < 0 and pp_size > 1:
                     # The peer splits layers AND holds our heads across
                     # several of its ranks; host staging then borrows upstream's
@@ -1385,12 +1439,21 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
             for pp_rank in range(pp_size):
                 for remote_tp_rank in p_remote_tp_ranks:
                     global_rank = pp_rank * remote_tp_size + remote_tp_rank
-                    if global_rank in metas:
-                        metadata = metas[global_rank]
+                    if (pp_rank, remote_tp_rank) in metas:
+                        metadata = metas[(pp_rank, remote_tp_rank)]
                     else:
-                        metadata = self._query_agent_meta(
-                            sock, global_rank, expected_engine_id
+                        metadata, rtt, offset = self._query_agent_meta(
+                            sock, pp_rank, remote_tp_rank, expected_engine_id
                         )
+                        if rtt < best_rtt:
+                            best_rtt, best_offset = rtt, offset
+                    if notif_agents_only:
+                        # The peer's memory is never addressed from here, so
+                        # no descriptors are built for it.
+                        remote_rank_to_agent_name[(pp_rank, remote_tp_rank)] = (
+                            self._add_notif_only_remote_agent(metadata, remote_tp_size)
+                        )
+                        continue
                     names = tuple(metadata.registered_layer_names)
                     self._remote_shard_layer_names[expected_engine_id][global_rank] = (
                         names
@@ -1412,7 +1475,7 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
                     if self._is_head_matched_peer(remote_tp_size):
                         # Different TP degrees: pair by head range, over the
                         # layers we share.
-                        remote_rank_to_agent_name[global_rank] = (
+                        remote_rank_to_agent_name[(pp_rank, remote_tp_rank)] = (
                             self._add_remote_agent_head_matched(
                                 metadata,
                                 global_rank,
@@ -1423,13 +1486,14 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
                     else:
                         # Equal TP delegates to upstream, which needs a wider
                         # stage trimmed to our band (_trim_agent_meta_to_layers).
-                        remote_rank_to_agent_name[global_rank] = self.add_remote_agent(
+                        agent = self.add_remote_agent(
                             self._trim_agent_meta_to_layers(metadata, overlap)
                             if partial
                             else metadata,
                             global_rank,
                             remote_tp_size,
                         )
+                        remote_rank_to_agent_name[(pp_rank, remote_tp_rank)] = agent
 
                     if not (pp_size > 1 or partial or fan_in or split > 1):
                         # Nothing is narrowed: upstream's whole-engine handle
@@ -1441,7 +1505,7 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
                         metadata.block_size,
                         names,
                         peer_areas=self._fan_in_peer_areas(
-                            global_rank % remote_tp_size, remote_tp_size
+                            remote_tp_rank, remote_tp_size
                         ),
                         split=split,
                         remote_tp_size=remote_tp_size,
@@ -1453,7 +1517,7 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
         # of appending its shards a second time and reading every block twice.
         self._overlapping_ranks[expected_engine_id] = overlapping
         self._remote_pp_size[expected_engine_id] = pp_size
-        return remote_rank_to_agent_name
+        return remote_rank_to_agent_name, best_offset
 
     def _base_fan_in_handle(
         self,
@@ -1654,12 +1718,7 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
         split: int = 1,
         region_ids: list[int] | None = None,
         replica_fanout: int = 1,
-    ) -> tuple[int, list[tuple[int, int, int]]]:
-        assert self.transfer_topo is not None
-        assert not self.transfer_topo.is_kv_layout_blocks_first, (
-            "RBLN NIXL connector only supports FA layout (K and V in separate "
-            "regions), not FlashInfer."
-        )
+    ) -> tuple[int, np.ndarray]:
         assert not self._has_mamba, "RBLN NIXL connector does not support Mamba."
 
         block_size_ratio = self.block_size // block_size
@@ -1697,10 +1756,11 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
                             )
                         )
 
-        descs = self.nixl_wrapper.get_xfer_descs(blocks_data, self.nixl_memory_type)
+        descs_data = _as_descs(blocks_data)
+        descs = self.nixl_wrapper.get_xfer_descs(descs_data, self.nixl_memory_type)
         return (
             self.nixl_wrapper.prep_xfer_dlist("NIXL_INIT_AGENT", descs),
-            blocks_data,
+            descs_data,
         )
 
     def _get_block_descs_ids_for_shard(
@@ -1926,24 +1986,27 @@ class RblnNixlWorkerBase(NixlBaseConnectorWorker):
         )
 
     def _xfer_notif_id(
-        self, engine_id: str, remote_request_id: str, remote_tp_size: int
+        self,
+        engine_id: str,
+        remote_request_id: str,
+        remote_tp_size: int,
+        *,
+        count_stages: bool = True,
     ) -> bytes:
         """Notification carrying how many of our ranks pair with one peer rank.
 
         NOTE(RBLN): upstream sends its own tensor-parallel size, which the peer
         divides by its own to learn how many of us to hear from before settling
-        the request -- freeing its blocks on the read path, declaring them
-        written on the write path. A finer pipeline on our side multiplies that,
-        each stage pairing with the same peer rank for its own layers, so send
-        the count in the unit the peer already divides by: ours times the peer's
-        TP. The two agree whenever the pipelines match, which is every shape
-        upstream assumes.
-
-        Direction-free -- it only asks how much finer we are cut than the peer.
+        the request. A finer pipeline on our side multiplies that, each stage
+        pairing with the same peer rank for its own layers, so the read path
+        sends the count in the unit the peer divides by: ours times the peer's
+        TP. The write path must not -- 0.26's writer accounting multiplies OUR
+        `pp_size` back in, taking it from the producer's own kv_transfer_params,
+        so the stages would be counted twice.
         """
-        remote_pp = self._remote_pp_size.get(engine_id, 1)
-        local_pp = self.vllm_config.parallel_config.pipeline_parallel_size
-        peers = max(1, self.world_size // remote_tp_size) * max(
-            1, local_pp // remote_pp
-        )
+        peers = max(1, self.world_size // remote_tp_size)
+        if count_stages:
+            remote_pp = self._remote_pp_size.get(engine_id, 1)
+            local_pp = self.vllm_config.parallel_config.pipeline_parallel_size
+            peers *= max(1, local_pp // remote_pp)
         return f"{remote_request_id}:{peers * remote_tp_size}".encode()

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/connector.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/connector.py
@@ -20,7 +20,6 @@ from vllm.distributed.kv_transfer.kv_connector.utils import (
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
-    KVConnectorHandshakeMetadata,
     KVConnectorRole,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
@@ -104,30 +103,6 @@ class RblnNixlConnectorBase(NixlBaseConnector, SupportsKVCacheRegistrationFinali
         self.kv_transfer_config = vllm_config.kv_transfer_config
         self.connector_scheduler = None
         self.connector_worker = None
-
-    def set_xfer_handshake_metadata_pp_aware(
-        self, metadata: dict[tuple[int, int], KVConnectorHandshakeMetadata]
-    ) -> None:
-        """Serve every producer shard, including pipeline-parallel stages.
-
-        Upstream rejects `pp_rank > 0` and keys the side channel by `tp_rank`
-        alone, so PP stages would overwrite each other. Flatten to the rank a
-        peer actually asks for in `_nixl_handshake`, using this engine's
-        `tp_size`; at `pp_size == 1` that is upstream's key again.
-        """
-        tp_size = self._vllm_config.parallel_config.tensor_parallel_size
-        flattened: dict[int, KVConnectorHandshakeMetadata] = {}
-        for (pp_rank, tp_rank), rank_metadata in metadata.items():
-            flat_rank = pp_rank * tp_size + tp_rank
-            if flat_rank in flattened:
-                raise ValueError(
-                    "Duplicate handshake metadata for flat rank "
-                    f"{flat_rank} (pp_rank={pp_rank}, tp_rank={tp_rank}); "
-                    f"tensor_parallel_size={tp_size} disagrees with the ranks "
-                    "reported by the workers."
-                )
-            flattened[flat_rank] = rank_metadata
-        self.set_xfer_handshake_metadata(flattened)
 
     def finalize_kv_cache_registration(self) -> None:
         """Run the worker's deferred NIXL registration after warm-up

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/pull_worker.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/pull_worker.py
@@ -106,7 +106,11 @@ class RblnNixlPullConnectorWorker(RblnNixlWorkerBase, NixlPullConnectorWorker):
         handles: list[int] = []
         for global_rank in self._overlapping_ranks[engine_id]:
             if prefix_hit:
-                agent_name = self._remote_agents[engine_id][global_rank]
+                # Stages are tracked by the flat rank, agents by the pair it
+                # decomposes into (see add_remote_agent).
+                agent_name = self._remote_agents[engine_id][
+                    divmod(global_rank, remote_info.remote_tp_size)
+                ]
                 try:
                     self.nixl_wrapper.send_notif(agent_name, notif_msg=notif_id)
                 except Exception as e:

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/push_worker.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/push_worker.py
@@ -12,13 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import queue
 import threading
 import time
-from collections import defaultdict
 from typing import TYPE_CHECKING
 
-from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.utils import (
     BlockIds,
 )
@@ -36,7 +33,6 @@ if TYPE_CHECKING:
         NixlConnectorMetadata,
         ReqMeta,
     )
-    from vllm.v1.kv_cache_interface import KVCacheConfig
 
 logger = init_logger(__name__)
 
@@ -47,20 +43,10 @@ class RblnNixlPushConnectorWorker(RblnNixlWorkerBase, NixlPushConnectorWorker):
     The producer drives the transfer here, so the peer this rank hands its
     metadata to is the consumer rather than the other way round. Pairing does
     not care -- it describes what two peers hold -- so what belongs here is the
-    write: which peers to issue it against, the writer thread that issues it,
-    and the count a consumer settles a request by.
+    write: which peers to issue it against and the writer thread that issues it.
     """
 
     _writes_into_peer = True
-
-    def __init__(
-        self, vllm_config: VllmConfig, engine_id: str, kv_cache_config: "KVCacheConfig"
-    ) -> None:
-        super().__init__(vllm_config, engine_id, kv_cache_config)
-
-        # Completion notifications seen per request being received, counted
-        # against the number of writers the peer put in them.
-        self._writer_counts_by_req: defaultdict[str, int] = defaultdict(int)
 
     def start_load_kv(self, metadata: "NixlConnectorMetadata") -> None:
         """Hand this step's work to the writer, once the KV it names is settled.
@@ -108,59 +94,6 @@ class RblnNixlPushConnectorWorker(RblnNixlWorkerBase, NixlPushConnectorWorker):
         )
         self._push_writer_thread.start()
         logger.info("nixl-push-writer thread started (rank=%d)", self.tp_rank)
-
-    def _get_new_notifs(self) -> set[str]:
-        """Hold a request back until every writer of it has reported.
-
-        NOTE(RBLN): upstream settles a pushed request on the FIRST completion
-        notification, which is right only while one peer rank writes the whole
-        thing. Several do as soon as either axis is cut finer on their side, and
-        the rest of them are still writing -- host staging would copy a
-        half-filled buffer to the device. Each writer's notification carries the
-        count (see `_xfer_notif_id`), so drop all but the last one and let
-        upstream settle the request on that.
-        """
-        for notif in self._drain_completion_notifs():
-            if self._writer_still_pending(notif):
-                continue
-            self._pending_completion_notifs.put(notif)
-        return super()._get_new_notifs()
-
-    def _drain_completion_notifs(self) -> list[bytes]:
-        notifs = []
-        while True:
-            try:
-                notifs.append(self._pending_completion_notifs.get_nowait())
-            except queue.Empty:
-                return notifs
-
-    def _writer_still_pending(self, notif: bytes) -> bool:
-        """Whether this notification leaves a request short of its writers.
-
-        False for anything upstream has to see itself: heartbeats, our own
-        outbound accounting, and a request we are not receiving.
-        """
-        msg = notif.decode("utf-8")
-        if msg.startswith("HB:"):
-            return False
-        req_id, count = msg.rsplit(":", 1)
-        if req_id in self._reqs_to_send or req_id in self._reqs_to_process:
-            return False
-        if req_id not in self._recving_metadata:
-            return False
-        # The peer scales the count by our tensor-parallel size, the unit
-        # upstream divides by on the other direction (see `_xfer_notif_id`).
-        writers = max(1, int(count) // self.world_size)
-        self._writer_counts_by_req[req_id] += 1
-        return self._writer_counts_by_req[req_id] < writers
-
-    def get_finished(self) -> tuple[set[str], set[str]]:
-        done_sending, done_recving = super().get_finished()
-        # Both completion and failure land here, and a retried request must not
-        # inherit a partial count.
-        for req_id in done_recving:
-            self._writer_counts_by_req.pop(req_id, None)
-        return done_sending, done_recving
 
     def _xfer_blocks_for_req(self, req_id: str, meta: "ReqMeta") -> None:
         """Write this request's blocks, one transfer per paired peer rank.
@@ -210,7 +143,10 @@ class RblnNixlPushConnectorWorker(RblnNixlWorkerBase, NixlPushConnectorWorker):
         remote_block_ids = meta.remote.block_ids
         local_block_ids = meta.local_physical_block_ids
         notif_id = self._xfer_notif_id(
-            engine_id, meta.remote.request_id, remote_info.remote_tp_size
+            engine_id,
+            meta.remote.request_id,
+            remote_info.remote_tp_size,
+            count_stages=False,
         )
 
         local_block_ids = self._trim_to_consumer_blocks(

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_transfer_topology.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_transfer_topology.py
@@ -1,0 +1,69 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""RBLN's variant of upstream's NIXL transfer topology.
+
+It lives beside the connector rather than inside it so that the patch module
+that substitutes it upstream can import it without pulling the whole connector
+package in at plugin load.
+"""
+
+import torch
+from vllm.distributed.kv_transfer.kv_connector.utils import (
+    EngineId,
+    EngineTransferInfo,
+    TransferTopology,
+)
+from vllm.v1.kv_cache_interface import KVCacheSpec
+
+
+class RblnTransferTopology(TransferTopology):
+    """Upstream's topology with the KV layout it standardized on in 0.26 undone.
+
+    ``__post_init__`` reimplements upstream's rather than extending it, since
+    upstream's asserts the very layout this class exists to decline. So a
+    field upstream sets there has to be set here too, and leaving one out
+    fails nowhere until the first handshake reads it.
+    """
+
+    def __post_init__(self) -> None:
+        self.local_physical_heads = max(1, self.total_num_kv_heads // self.tp_size)
+        self._engines: dict[tuple[EngineId, int], EngineTransferInfo] = {}
+        self._cross_layers_blocks = False
+        if self.is_mamba:
+            # Upstream skips the shape for the same reason: a Mamba cache is a
+            # (conv, ssm) pair, and the connector hands it no tensor shape.
+            return
+        shape = self.attn_backends[0].get_kv_cache_shape(
+            num_blocks=1, block_size=16, num_kv_heads=1, head_size=1
+        )
+        leading = (1,) if self.is_mla else (2, 1)
+        assert shape[: len(leading)] == leading, (
+            "RBLN NIXL descriptors assume a (2, num_blocks, ...) attention "
+            f"cache or a (num_blocks, ...) MLA cache, got {shape} from "
+            f"{self.attn_backends[0].__name__}."
+        )
+        self._cross_layers_blocks = (
+            self.tensor_shape is not None and len(self.tensor_shape) == len(shape) + 1
+        )
+
+    def get_transfer_cache_regions(
+        self, cache: torch.Tensor, layer_spec: KVCacheSpec
+    ) -> list[torch.Tensor] | torch.Tensor:
+        if self.is_mla or self.is_mamba or self._cross_layers_blocks:
+            return super().get_transfer_cache_regions(cache, layer_spec)
+        # Iterating the tensor yields K and V; the caller divides the page size
+        # by how many come back.
+        return cache

--- a/vllm_rbln/patches/__init__.py
+++ b/vllm_rbln/patches/__init__.py
@@ -35,6 +35,7 @@ from . import (
     fp8_moe_method,
     gpt_oss,
     gpt_oss_mxfp4_config,
+    kv_connector_utils,
     llama_eagle3,
     metrics,
     minimax_m2,

--- a/vllm_rbln/patches/kv_connector_utils.py
+++ b/vllm_rbln/patches/kv_connector_utils.py
@@ -1,0 +1,31 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_transfer_topology import (
+    RblnTransferTopology,
+)
+from vllm_rbln.patches import register_patch
+
+register_patch(
+    target="vllm.distributed.kv_transfer.kv_connector.utils.TransferTopology",
+    reason=(
+        "0.26 asserts a blocks-first, K/V-packed cache in "
+        "TransferTopology.__post_init__; RBLN's attention cache is K/V-first "
+        "and fails it, so those models cannot register at all. Upstream has "
+        "no per-platform way to say the layout differs, and it builds the "
+        "class inside its own register_kv_caches, which the host-bounce path "
+        "delegates to."
+    ),
+)(RblnTransferTopology)


### PR DESCRIPTION
# fix(nixl): make P/D disaggregation work on vLLM 0.26

### 🚀 Summary of Changes

#### Summary

The v0.26.0 bump lands the version; this puts P/D back on its feet on top of it. Three
layers broke: the NIXL side channel, the KV cache layout, and the accounting that
settles a pushed request. Each 0.26 change is reasonable upstream, and each lands on a
premise this connector was built on.

The unit suite stayed green through all of it, which is the theme. The handshake had
one test entry point that called `_nixl_handshake` directly, so a changed calling
convention could not show; the topology was faked in every registration test, so the
layout assert never ran; and the push accounting is two layers deep with the test for
ours replacing upstream's half with a stub, so the two could not disagree.

#### What changed

**A. The pair replaces the flat rank only where upstream owns the contract.** The wire
and `_remote_agents` go to `(pp, tp)`. Descriptor handles stay int-keyed: upstream's
read path indexes them with plain TP ranks, and the flat rank collapses to exactly
that at `pp_size == 1`, which is what lets one dict serve both the delegated path and
ours. The three sites that need the pair decompose the flat rank where they read the
agent map. The return also carries the clock offset upstream estimates from the round
trip; the midpoint formula and the lowest-RTT rule are upstream's, copied from the
loop this override replaces.

`NixlConnector` dropped the plain `set_xfer_handshake_metadata` that this connector's
flattening override called, so that call landed on the connector base's no-op: the
producer never started its side-channel listener and the consumer's bootstrap query
went to a port nobody served. The override is deleted; the `(pp, tp)` dict reaches the
scheduler unflattened.

**B. A caller's pipeline size now has to agree with the peer's.** Upstream takes that
number from its caller and never asks: the producer puts `pp_size` into
`kv_transfer_params`, while the read handshake and a producer's own reverse handshake
pass nothing and take the default of 1. A pipelined producer reached that way would be
handshaked at stage 0 alone, which is why this override asks the peer; above 1 the two
have to agree. `TODO(vllm>=0.29.0)`: 0.29's read path gains a caller that carries
`pp_size`, and `remote_dcp_size` lands ahead of `remote_pp_size` in the same signature
— read off the 0.29rc1 tag, not inferred.

**C. `notif_agents_only` is honoured.** Push mode's decode side never reads the
producer's memory, so upstream asks it for agents alone. Registering descriptors for a
stage this rank cannot read would pair lists of different lengths.

**D. Local descriptors follow upstream's array shape.** 0.26 vectorised descriptor
construction: `register_local_xfer_handler` answers `(handle, Nx3 uint64)`, which
upstream's hetero-TP split reads back with `.tolist()`. Both branches this connector
owns built a list of triples.

**E. The RBLN KV layout survives 0.26's standardization.** 0.26 requires a blocks-first
cache whose K and V share one region and asserts it in `TransferTopology.__post_init__`.
RBLN's attention cache is K/V-first, so every worker using it died at registration,
before any handshake — MLA passes the assert, so the failure is per model. A subclass
restores what 0.24's layout flag decided. Upstream builds the class inside its own
`register_kv_caches`, which the host-bounce path delegates to and no extension point
reaches, so the substitution goes through the patch registry at the definition site.
`is_kv_layout_blocks_first` goes with the flag: of the two facts it carried, the
FlashInfer half is unreachable on RBLN backends and the Mamba half is upstream's
surviving `virtually_split_kv_in_blocks`. What the three guards really rejected was
Mamba, now said where it is live.

**F. 0.26 counts a pushed request's writers, so this side stops.** 0.24 settled on the
first completion notification, right only while one peer rank writes the whole thing,
so this side held all but the last back. 0.26 counts them itself —
`pp_size * producers_per_consumer` — and that filter left it one of the several it now
waits for, so any producer cut finer than its consumer hung until the registration
timed out. The pipeline factor in the payload compounded it: the write path multiplied
our stages in and 0.26 multiplies our `pp_size` back, so the stage count now stays on
the read path alone, where upstream applies no such factor.

#### What is deliberately not here

- **No frame-count guard on the reply.** A pre-0.26 peer cannot send a short reply: it
  unpacks our three-field query outside its `try` and dies on the query instead.
- **No runtime guard for a layout no RBLN backend produces.** The topology's assertion
  names the leading dims the descriptor arithmetic assumes; a cache with those dims and
  a different rank still passes, where upstream also constrained the rank.
- **The two idempotence checks are kept but cannot fire.** The agent map is assigned
  whole after a handshake returns and both entry points return early once the engine is
  in it. They mirror upstream's own check.
- **Two pre-existing defects were left alone** — a write-only per-shard layer-name map,
  and a NIXL source handle leaked when a failed handshake is retried. Both are
  byte-identical to the base branch.
- **One defect outside this diff is not fixed here.** The bump deleted this connector's
  `push_scheduler.request_finished` override, which seeded `remote_block_ids` with
  `setdefault`; 0.26 seeds the same field but assigns unconditionally, so a proxy
  forwarding a producer's reply with it already filled now has it overwritten. The
  guard test went with the override. It needs its own issue.

#### Testing

- **Behavioural equivalence of the handshake rewrite.** `_nixl_handshake` was driven
  with identical inputs on a `dev-0.26.0` worktree and on this one, in each of these
  configurations — equal TP, host staging, SWA view-opt, fan-in with and without the
  head helpers stubbed, fan-in with a pipelined peer, a pipelined local consumer, and a
  three-stage producer against a full-layer consumer. Internal state, downstream call
  arguments, every raise and the wire traffic came out identical; the deltas are the
  query's third field, the reply's second frame, and the return pair. Failure paths
  were compared the same way. Measured before the §F guard, which none of those
  configurations reaches.
- **The 0.24 topology was measured, not assumed.** Its four observables — the layout
  flag, cross-layer blocks, local physical heads, and the region count per layer for
  attention and MLA — were read off upstream 0.24 with a stub backend of the RBLN shape
  and compared against the subclass on 0.26. They agree on every one.
- **Mutation.** Planting the inverse of each of these fails the suite: the query's
  field order, the pair's key order at all three decomposition sites, the clock
  offset's midpoint and its lowest-RTT rule, the pipeline-size guard and the push term
  of the pipelined-consumer refusal, the `notif_agents_only` branch and the peer TP a
  notif-only agent is registered with, the descriptor dtype and row order, the deleted
  connector override, the topology substitution and the blocks axis in its layout
  check, the stage factor in the payload, and reinstating the writer filter. A control
  that renames the payload arithmetic without changing it stays green.
- `pytest tests/native/distributed/kv_connector/` and the wider
  `pytest tests/native/distributed/` are green; `pre-commit` is clean on every changed
  file.
- **What none of this establishes.** It all runs in-process against fakes: no assertion
  here moves a byte between two engines, so the wire format, the descriptor addresses
  and the completion count are shown to be internally consistent and nothing more. The
  clock offset is read from a scripted clock, so engines with unrelated clock origins
  are outside what these tests say, as is an agent outliving a lease eviction.

#### Risk / compatibility

- **Do not merge this before the v0.26.0 bump.** It cherry-picks onto `dev` without a
  conflict, so it looks mergeable there, but on 0.24 it does not degrade: the
  three-field query kills that listener thread, the one-frame reply meets an unpack of
  two, the handshake callback would assign a tuple into `_remote_agents`, and 0.24's
  `is_kv_layout_blocks_first` reads a field the subclass no longer sets. A plain
  TP1/PP1 pair hits that last one first, at registration, before the wire matters.
- **A P/D pair has to be deployed together, and the skew is not symmetric.** A 0.24
  listener dies on our three-field query and the consumer times out; the other
  direction is worse, since a pre-0.26 consumer's two-field query kills an upgraded
  producer's listener and that producer then serves nobody. Peers that get past the
  wire are refused by the compatibility hash, which carries the vLLM version and
  upstream's connector version and is enforced by default.
- **A pipelined consumer behind a pipelined producer on the push side is now refused,
  where 0.24 accounted for it.** 0.26's count has no term for this side's stages, so
  such a consumer waits for a count too high by exactly its own pipeline size and no
  payload value corrects it. A single-stage producer writes every rank of ours, so that
  shape is exact and stays admitted. Upstream refuses the same shape — under the comment
  "Decode-side PP is unsupported (completions counted per consumer rank)" — but keyed on
  `kv_role == "kv_consumer"`, which `kv_both` never reaches, so the handshake refuses it
  here instead. On 0.24 the arithmetic was this connector's own and carried
  `local_pp // remote_pp`, which did express this side's stages. The read direction is
  unaffected. One consequence of the deleted filter: upstream clears its per-request
  counter only on completion, so any pushed request that never reaches its count leaves
  a dict entry behind for the engine's life.
- **The topology patch is global to the process**, and the next bump moves it rather
  than deletes it. It replaces the class at its definition site, so the connectors that
  import it — upstream's NIXL worker and Mooncake — get the subclass; only this
  connector's use is verified, and `KV_CONNECTOR=NixlConnector` on RBLN turns from a
  loud refusal into an unknown. Upstream is mid-rewrite on this axis:
  `get_transfer_cache_regions` is already gone in 0.27.0, and `cross_layers_blocks` and
  `virtually_split_kv_in_blocks` in 0.28.1rc0, where `__post_init__` is two lines. The
  constraint did not go with the assert — the packed layout now lives in upstream's
  `register_kv_caches`, which loops one region per attention layer — and
  `compute_nixl_compatibility_hash`'s third positional argument changed from
  `cross_layers_blocks: bool` to `transfer_mode: str` in the same window, so a
  rename-only port would hash the wrong thing quietly.
- **A listener that dies stays dead, and this change does not close that class.** The
  same unguarded lookup makes a producer unreachable to its whole fleet if a consumer
  asks for a `(pp, tp)` it never published, which a stale router entry or a producer
  restarted at a different TP degree can cause. Fixing that is upstream's.
- **A pipelined consumer in the READ direction is admitted by every guard.** Of the
  handshake's five pipeline guards only the push-side one refuses it, and at equal TP
  with sizes that tile the other four do not fire. The notification arithmetic works
  out on paper, nothing refuses the shape on the way in — and no test covers it.
- **The clock offset is newly live.** 0.24 had no such field and the broken handshake
  return meant the bump never populated it; it now gates upstream's turn-2 read expiry,
  which an operator reaches by enabling bidirectional transfer — on the read path only,
  since 0.26 refuses that option at the push scheduler's construction. It is one sample
  taken at handshake time, never refreshed. Over-estimating it costs a recomputed read
  and a warning; under-estimating it moves the deadline later and lets a read land
  after the peer released the blocks, with no warning at all.
- **Rolling this back does not restore the previous behaviour.** On a 0.26 tree a
  revert leaves no P/D at all, since registration then dies at upstream's layout assert.
  Two narrower shapes exist but are edits, not reverts, because this ships as one
  commit: dropping the registry patch alone leaves D2D working and takes host-bounce
  down with it; dropping `patches/kv_connector_utils.py` while keeping the worker breaks
  plugin import for every native-path user, P/D or not.
- **Consumer-side PP depends on `kv_role=kv_both` being what the deployment reports.**
  0.26 refuses `kv_role == "kv_consumer"` with `pipeline_parallel_size > 1` at worker
  construction. Nothing here changes that, and what sets the role is outside this
  repository.
- **A sliding-window model with PP now fails earlier.** 0.26 refuses `pp_size > 1` with
  any non-`FullAttentionSpec` KV group at worker construction whenever the hybrid KV
  cache manager is on. This connector already refused that combination, so only the
  message and the timing change. Plain MLA is unaffected: `MLAAttentionSpec` subclasses
  `FullAttentionSpec`.

---

### 📌 Related Issues / Tickets

* Resolves rebellions-sw/fsw-inference#581 — vllm-rbln 0.26.0 bump P/D disaggregation
  follow-up.
* Depends on the v0.26.0 bump PR: this branch is based on `dev-0.26.0` and must not
  merge before it.

---

### ✅ Type of Change

* [x] 🛠 Bug fix (`fix`)

---

### 🧪 How to Test

1. `uv run --no-sync pytest tests/native/distributed/kv_connector/`
2. `uv run --no-sync pytest tests/native/distributed/ tests/native/patches/`
3. Expected: all green.
4. Edge cases covered: a pipelined producer whose stages are queried once apiece and
   keyed by their pair; a peer whose reported pipeline size contradicts the caller's; a
   notif-only peer, which must get agents and no descriptors; a backend whose cache is
   neither layout, refused when the topology is built; a pushed request settling on its
   last writer and not before; and a pipelined consumer on the push side, refused at the
   handshake, against the same shape behind a single-stage producer, which must not be.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

- Affects the **vLLM-native path** only.
- The test diff is more than twice the source diff. That is the fix, not padding: each
  half of the suite was blind for its own reason, listed in the Summary, and the added
  cases go through `_ensure_handshake`, through the scheduler, and through upstream's
  own counter fed by what the write path puts on the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
