### PR TITLE
fix(pp): size the worker response queue from batches in flight

### DIFF
--- a/vllm_rbln/patches/__init__.py
+++ b/vllm_rbln/patches/__init__.py
@@ -42,6 +42,7 @@ from . import (
     modelopt_mixed_config,
     models_utils,
     multi_connector,
+    multiproc_executor,
     oot,
     profiler,
     qwen2_moe,

--- a/vllm_rbln/patches/multiproc_executor.py
+++ b/vllm_rbln/patches/multiproc_executor.py
@@ -1,0 +1,68 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Size the worker response queue from the number of batches in flight.
+
+A KV connector makes ``collective_rpc`` pass ``output_rank=None``, so every worker
+enqueues a response each step rather than only the output rank. Under pipeline
+parallelism the first stage runs ahead of the last one, and a step's future
+resolves only once the output rank has reported for that same step, so the first
+stage's responses stay unread for as many steps as the engine keeps in flight.
+The upstream ring is a fixed ten slots, which is fewer than that once the pipeline
+is deep enough: the first stage blocks in ``acquire_write``, and because
+``worker_busy_loop`` is serial it stops draining ``rpc_broadcast_mq``, so the
+engine cannot submit the next step either and the pipeline runs shallower than
+``pipeline_parallel_size``.
+
+Deriving the depth from ``max_concurrent_batches`` ties it to the quantity that
+sets the lag. The lower bound keeps the upstream depth wherever the derived value
+would be smaller, so deployments without pipeline parallelism are unchanged.
+"""
+
+from vllm.config import VllmConfig
+from vllm.distributed.device_communicators.shm_broadcast import Handle, MessageQueue
+from vllm.v1.executor.multiproc_executor import WorkerProc
+
+from vllm_rbln.patches import register_patch
+
+UPSTREAM_MAX_CHUNKS = 10
+
+
+@register_patch(
+    target="vllm.v1.executor.multiproc_executor.WorkerProc._init_message_queues",
+    reason=(
+        "Derive the worker response queue depth from max_concurrent_batches. A KV "
+        "connector makes every pipeline stage enqueue a response per step, and the "
+        "first stage runs that many steps ahead of the point where the engine reads "
+        "them, so the fixed upstream depth leaves it blocked in acquire_write and "
+        "the pipeline runs shallower than pipeline_parallel_size."
+    ),
+    key="vllm_rbln.patches.multiproc_executor.init_message_queues",
+    owner_module="vllm_rbln.patches.multiproc_executor",
+)
+def patched_init_message_queues(
+    self: WorkerProc, input_shm_handle: Handle, vllm_config: VllmConfig
+) -> None:
+    if vllm_config.parallel_config.nnodes_within_dp > 1:
+        _init_message_queues_upstream(self, input_shm_handle, vllm_config)
+        return
+
+    self.rpc_broadcast_mq = MessageQueue.create_from_handle(
+        input_shm_handle, self.worker.rank
+    )
+    max_chunks = max(UPSTREAM_MAX_CHUNKS, vllm_config.max_concurrent_batches * 2)
+    self.worker_response_mq = MessageQueue(1, 1, max_chunks=max_chunks)
+    self.peer_response_handles = []
+
+
+_init_message_queues_upstream = WorkerProc._init_message_queues


### PR DESCRIPTION
### 🚀 Summary of Changes

Derive the depth of a worker's response `MessageQueue` from `max_concurrent_batches` instead of leaving it at the upstream default.

A KV connector makes the executor pass `output_rank=None` to `collective_rpc`, because `KVOutputAggregator` counts `finished_sending` per rank and therefore needs a response from every worker. `worker_busy_loop` then calls `handle_output` on every rank each step, not only on the output rank.

Under pipeline parallelism that meets the pipeline's staggering. The first stage runs ahead of the last one, and a step's future resolves only once the output rank has reported for that same step, so the first stage's responses stay unread for as many steps as the engine keeps in flight -- that is `max_concurrent_batches`, which equals `pipeline_parallel_size`. The upstream ring is a fixed ten slots. Once the pipeline is deep enough the ring saturates, the first stage blocks in `acquire_write`, and because `worker_busy_loop` is serial it stops draining `rpc_broadcast_mq`; the engine then blocks in `collective_rpc` as well and cannot submit the next step. The pipeline runs shallower than `pipeline_parallel_size` while per-stage device time is unchanged.

The fix ties the depth to the quantity that sets the lag and keeps the upstream depth as a lower bound, so TP-only deployments and shallow pipelines are byte-for-byte unchanged.

Changed paths:

* `vllm_rbln/patches/multiproc_executor.py` (new) -- patches `WorkerProc._init_message_queues`
* `vllm_rbln/patches/__init__.py` -- registers the new patch module

---

### 📌 Related Issues / Tickets

* Related to rebellions-sw/fsw-inference#588

---

### ✅ Type of Change

* [x] ⚙️ Performance improvement (`perf`)

---

### 🧪 How to Test

1. Serve a model with `--pipeline-parallel-size 8` and a KV connector attached, for example `--kv-transfer-config '{"kv_connector":"RblnNixlConnector","kv_role":"kv_producer","kv_buffer_device":"rbln"}'`. A consumer is not required; the regression appears with no transfer at all.
2. Send a single long-prompt request with `--max-concurrency 1` so queueing time is zero, and record TTFT.
3. Compare against the same serve command without `--kv-transfer-config`. Before this change the connector run is markedly slower; after it the two match.
4. Edge case: with `--pipeline-parallel-size 1` and with tensor parallelism only, the derived depth falls back to the upstream value, so behaviour is unchanged.

Per-rank confirmation, if a torch profile is collected: the cross-rank `hop` between consecutive stages and the traversal time across all stages stay the same in both runs, while the per-stage `forward` period and the number of chunks in flight change. That separates a pipeline-occupancy regression from a compute regression.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

The upstream obligation itself is sound: `finished_sending` is a per-rank fact, arrives asynchronously, and the engine cannot tell an empty response from one that has not arrived yet, since `get_response` performs a blocking `dequeue` per queue. Skipping empty responses would need a protocol change. This PR changes only the buffer depth, so every response is still sent, aggregated, and counted exactly as before.

Both `max_chunk_bytes` and the output rank's queue are left untouched, keeping the change to one variable.
