### PR TITLE
feature: fixed decode query length with specdec

### DIFF
--- a/tests/native/v1/core/test_rbln_scheduler.py
+++ b/tests/native/v1/core/test_rbln_scheduler.py
@@ -466,10 +466,9 @@ class TestScheduleSpecDecodeCap:
 
 
 class TestBackfillCrossBlockNoSpec:
-    # A decode-ready request entering exactly at a block boundary cannot take its
-    # window's slack in front of its scheduled token without crossing into the
-    # previous block. The runner puts the slack behind it instead, so the batch --
-    # including a running decode that was never at risk -- keeps its spec.
+    # A decode-ready request entering exactly at a block boundary cannot backfill
+    # num_spec past tokens without crossing into the previous block, so the whole
+    # decode batch is forced to qlen=1 -- even a running decode that is safe.
     _BS = 16
     _NUM_SPEC = 4
 
@@ -497,7 +496,7 @@ class TestBackfillCrossBlockNoSpec:
         sched.add_request(req)
         return req
 
-    def test_decode_ready_peer_at_a_boundary_keeps_batch_spec(self):
+    def test_unsafe_decode_ready_peer_forces_batch_no_spec(self):
         sched = self._scheduler()
 
         # A running decode that, on its own, keeps full spec (block_size is far
@@ -512,16 +511,16 @@ class TestBackfillCrossBlockNoSpec:
         assert out.scheduled_spec_decode_tokens["R"] == [1, 2, 3, 4]
         sched.update_from_output(out, make_model_runner_output(out, 1))
 
-        # Introduce a decode-ready peer at a block boundary.
+        # Introduce an unsafe decode-ready peer at a block boundary.
         self._decode_ready_at_boundary(sched, "seed", "A")
         running.spec_token_ids = [1, 2, 3, 4]
         out = sched.schedule()
 
-        # The peer joins with a single token, as it must, but no longer drags the
-        # batch with it: the running decode keeps its drafts and its full query.
+        # The unsafe peer forces the whole decode batch to no-spec: the running
+        # decode loses its otherwise-valid drafts and drops to a single token.
+        assert out.num_scheduled_tokens["R"] == 1
+        assert "R" not in out.scheduled_spec_decode_tokens
         assert out.num_scheduled_tokens["A"] == 1
-        assert out.num_scheduled_tokens["R"] == 1 + self._NUM_SPEC
-        assert out.scheduled_spec_decode_tokens["R"] == [1, 2, 3, 4]
 
 
 class TestStrandedBlockDelta:
@@ -1065,11 +1064,10 @@ class TestPriorityScheduling:
         assert all(r.is_finished() for r in reqs)
 
 
-class TestSpecDecodeSurvivesDecodeReadyJoin:
-    # A decode-ready join used to demote the whole decode batch to no-spec when
-    # its fixed window could not be front-padded inside the current block. The
-    # runner now pads behind the scheduled tokens in that case, so the scheduler
-    # has no boundary left to demote and the batch keeps its drafts.
+class TestSpecDecodeRetroactiveTrim:
+    # A decode-ready join whose backfill window would cross a block boundary
+    # forces the whole decode batch to no-spec. Reachable only via a prefix
+    # match, the one way a waiting request reaches decode un-prefilled.
     @staticmethod
     def _running_decoder_with_spec():
         # req0: a running decode carrying 4 spec tokens, positioned mid-block so
@@ -1090,16 +1088,26 @@ class TestSpecDecodeSurvivesDecodeReadyJoin:
         req0.spec_token_ids = [1] * 4
         return sched, req0
 
-    def test_join_at_a_block_start_keeps_the_batch_spec(self):
-        # req1 matches the full 16-token prefix, so it joins at a block start
-        # where a front-padded window would reach into the previous block. The
-        # batch keeps its drafts; the runner pads behind instead.
+    def test_unsafe_decode_ready_join_trims_whole_batch(self):
+        # req1 matches the full 16-token prefix -> joins at the block start, so
+        # its backfill would cross the boundary -> the batch loses its spec.
         sched, req0 = self._running_decoder_with_spec()
         req1 = make_request("1", list(range(16)) + [999], 16, max_tokens=50)
         sched.add_request(req1)
         out = sched.schedule()
         assert out.num_scheduled_tokens[req1.request_id] == 1  # decode-ready join
-        assert out.num_scheduled_tokens[req0.request_id] == 5  # not demoted
+        assert out.num_scheduled_tokens[req0.request_id] == 1  # retroactively trimmed
+        assert not out.scheduled_spec_decode_tokens.get(req0.request_id)
+
+    def test_safe_decode_ready_join_keeps_spec(self):
+        # req1 matches only the first sub-block -> joins mid-block where the
+        # backfill fits, proving it is the crossing that trims, not the join.
+        sched, req0 = self._running_decoder_with_spec()
+        req1 = make_request("1", list(range(8)) + [999], 16, max_tokens=50)
+        sched.add_request(req1)
+        out = sched.schedule()
+        assert out.num_scheduled_tokens[req1.request_id] == 1
+        assert out.num_scheduled_tokens[req0.request_id] == 5  # spec preserved
         assert len(out.scheduled_spec_decode_tokens[req0.request_id]) == 4
 
 

--- a/tests/native/v1/core/test_rbln_scheduler.py
+++ b/tests/native/v1/core/test_rbln_scheduler.py
@@ -452,9 +452,10 @@ class TestScheduleSpecDecodeCap:
 
 
 class TestBackfillCrossBlockNoSpec:
-    # A decode-ready request entering exactly at a block boundary cannot backfill
-    # num_spec past tokens without crossing into the previous block, so the whole
-    # decode batch is forced to qlen=1 -- even a running decode that is safe.
+    # A decode-ready request entering exactly at a block boundary cannot take its
+    # window's slack in front of its scheduled token without crossing into the
+    # previous block. The runner puts the slack behind it instead, so the batch --
+    # including a running decode that was never at risk -- keeps its spec.
     _BS = 16
     _NUM_SPEC = 4
 
@@ -482,7 +483,7 @@ class TestBackfillCrossBlockNoSpec:
         sched.add_request(req)
         return req
 
-    def test_unsafe_decode_ready_peer_forces_batch_no_spec(self):
+    def test_decode_ready_peer_at_a_boundary_keeps_batch_spec(self):
         sched = self._scheduler()
 
         # A running decode that, on its own, keeps full spec (block_size is far
@@ -497,16 +498,16 @@ class TestBackfillCrossBlockNoSpec:
         assert out.scheduled_spec_decode_tokens["R"] == [1, 2, 3, 4]
         sched.update_from_output(out, make_model_runner_output(out, 1))
 
-        # Introduce an unsafe decode-ready peer at a block boundary.
+        # Introduce a decode-ready peer at a block boundary.
         self._decode_ready_at_boundary(sched, "seed", "A")
         running.spec_token_ids = [1, 2, 3, 4]
         out = sched.schedule()
 
-        # The unsafe peer forces the whole decode batch to no-spec: the running
-        # decode loses its otherwise-valid drafts and drops to a single token.
-        assert out.num_scheduled_tokens["R"] == 1
-        assert "R" not in out.scheduled_spec_decode_tokens
+        # The peer joins with a single token, as it must, but no longer drags the
+        # batch with it: the running decode keeps its drafts and its full query.
         assert out.num_scheduled_tokens["A"] == 1
+        assert out.num_scheduled_tokens["R"] == 1 + self._NUM_SPEC
+        assert out.scheduled_spec_decode_tokens["R"] == [1, 2, 3, 4]
 
 
 class TestStrandedBlockDelta:
@@ -1050,10 +1051,11 @@ class TestPriorityScheduling:
         assert all(r.is_finished() for r in reqs)
 
 
-class TestSpecDecodeRetroactiveTrim:
-    # A decode-ready join whose backfill window would cross a block boundary
-    # forces the whole decode batch to no-spec. Reachable only via a prefix
-    # match, the one way a waiting request reaches decode un-prefilled.
+class TestSpecDecodeSurvivesDecodeReadyJoin:
+    # A decode-ready join used to demote the whole decode batch to no-spec when
+    # its fixed window could not be front-padded inside the current block. The
+    # runner now pads behind the scheduled tokens in that case, so the scheduler
+    # has no boundary left to demote and the batch keeps its drafts.
     @staticmethod
     def _running_decoder_with_spec():
         # req0: a running decode carrying 4 spec tokens, positioned mid-block so
@@ -1074,26 +1076,16 @@ class TestSpecDecodeRetroactiveTrim:
         req0.spec_token_ids = [1] * 4
         return sched, req0
 
-    def test_unsafe_decode_ready_join_trims_whole_batch(self):
-        # req1 matches the full 16-token prefix -> joins at the block start, so
-        # its backfill would cross the boundary -> the batch loses its spec.
+    def test_join_at_a_block_start_keeps_the_batch_spec(self):
+        # req1 matches the full 16-token prefix, so it joins at a block start
+        # where a front-padded window would reach into the previous block. The
+        # batch keeps its drafts; the runner pads behind instead.
         sched, req0 = self._running_decoder_with_spec()
         req1 = make_request("1", list(range(16)) + [999], 16, max_tokens=50)
         sched.add_request(req1)
         out = sched.schedule()
         assert out.num_scheduled_tokens[req1.request_id] == 1  # decode-ready join
-        assert out.num_scheduled_tokens[req0.request_id] == 1  # retroactively trimmed
-        assert not out.scheduled_spec_decode_tokens.get(req0.request_id)
-
-    def test_safe_decode_ready_join_keeps_spec(self):
-        # req1 matches only the first sub-block -> joins mid-block where the
-        # backfill fits, proving it is the crossing that trims, not the join.
-        sched, req0 = self._running_decoder_with_spec()
-        req1 = make_request("1", list(range(8)) + [999], 16, max_tokens=50)
-        sched.add_request(req1)
-        out = sched.schedule()
-        assert out.num_scheduled_tokens[req1.request_id] == 1
-        assert out.num_scheduled_tokens[req0.request_id] == 5  # spec preserved
+        assert out.num_scheduled_tokens[req0.request_id] == 5  # not demoted
         assert len(out.scheduled_spec_decode_tokens[req0.request_id]) == 4
 
 

--- a/tests/native/v1/spec_decode/test_eagle.py
+++ b/tests/native/v1/spec_decode/test_eagle.py
@@ -232,7 +232,6 @@ class TestPrepareInputsPadded:
             common_attn_metadata=cad,
             spec_decode_metadata=spec_md,
             valid_sampled_tokens_count=valid_count,
-            back_pad=torch.zeros(3, dtype=torch.int32),
         )
         assert num_rejected.cpu().tolist() == [1, 0, 2]
         assert token_indices.cpu().tolist() == [1, 5, 6]

--- a/tests/native/v1/spec_decode/test_eagle.py
+++ b/tests/native/v1/spec_decode/test_eagle.py
@@ -141,32 +141,12 @@ class TestPreprocess:
             token_indices_to_sample=token_indices_to_sample,
             target_token_ids=torch.arange(11, 20, dtype=torch.int32),
             next_token_ids=torch.tensor([100, 200, 300], dtype=torch.int32),
-            cad=make_cad([0, 3, 5, 9], [3, 5, 4]),
         )
 
-    def test_first_pass_shifts_tokens_and_inserts_next(self):
-        # Three requests, query_lens [3, 2, 4]. The target ids shift left by one
-        # (drop the first) and each request's next token lands at its last slot.
-        proposer = make_eagle_proposer()
-        # None token indices default to query_start_loc[1:] - 1.
-        _, _, _, tip = self._first_pass(proposer, None)
-        assert tip.cpu().tolist() == [2, 4, 8]
-        # shifted target [12..19] with next tokens overwritten at [2, 4, 8].
-        assert proposer.input_ids[:9].cpu().tolist() == [
-            12,
-            13,
-            100,
-            15,
-            200,
-            17,
-            18,
-            19,
-            300,
-        ]
-
     def test_first_pass_uses_explicit_token_indices_verbatim(self):
-        # Given token indices are used as-is (not recomputed from
-        # query_start_loc); the next tokens land at exactly those slots.
+        # The target ids shift left by one (drop the first) and each request's
+        # next token lands at the caller's index -- never at a slot recomputed
+        # from query_start_loc, which back padding can leave un-scheduled.
         proposer = make_eagle_proposer()
         _, _, _, tip = self._first_pass(
             proposer, torch.tensor([0, 3, 8], dtype=torch.int64)
@@ -252,6 +232,7 @@ class TestPrepareInputsPadded:
             common_attn_metadata=cad,
             spec_decode_metadata=spec_md,
             valid_sampled_tokens_count=valid_count,
+            back_pad=torch.zeros(3, dtype=torch.int32),
         )
         assert num_rejected.cpu().tolist() == [1, 0, 2]
         assert token_indices.cpu().tolist() == [1, 5, 6]

--- a/tests/native/v1/spec_decode/test_utils.py
+++ b/tests/native/v1/spec_decode/test_utils.py
@@ -101,7 +101,7 @@ class TestEaglePrepareInputsPadded:
         query_start_loc = _t([0, 3, 6, 9])
 
         token_indices, num_rejected = eagle_prepare_inputs_padded(
-            cu_num_draft, valid_count, query_start_loc, _t([0, 0, 0])
+            cu_num_draft, valid_count, query_start_loc
         )
         # rejected = (2+1) - valid = [1, 0, 2]; index = qsl[1:]-1-rejected.
         assert num_rejected.cpu().tolist() == [1, 0, 2]
@@ -115,26 +115,11 @@ class TestEaglePrepareInputsPadded:
         query_start_loc = _t([0, 1, 4])
 
         token_indices, num_rejected = eagle_prepare_inputs_padded(
-            cu_num_draft, valid_count, query_start_loc, _t([0, 0])
+            cu_num_draft, valid_count, query_start_loc
         )
         # req0: no draft -> 0; req1: (3+1)-2 = 2.
         assert num_rejected.cpu().tolist() == [0, 2]
         assert token_indices.cpu().tolist() == [0, 1]
-
-    def test_back_padding_shifts_the_index_off_the_padded_slots(self):
-        # The target staged 2 slots behind req0's scheduled tokens and 1 behind
-        # req1's, so the walk back starts at the last scheduled token, not at
-        # the query's last slot.
-        cu_num_draft = _t([2, 4])
-        valid_count = _t([2, 3])
-        query_start_loc = _t([0, 5, 10])
-
-        token_indices, num_rejected = eagle_prepare_inputs_padded(
-            cu_num_draft, valid_count, query_start_loc, _t([2, 1])
-        )
-        # rejected = [1, 0]; index = qsl[1:] - 1 - back_pad - rejected.
-        assert num_rejected.cpu().tolist() == [1, 0]
-        assert token_indices.cpu().tolist() == [1, 8]
 
     def test_cumulative_counts_are_differenced_per_request(self):
         # cu = [3, 5, 10] must yield per-request drafts [3, 2, 5], not the raw
@@ -144,7 +129,7 @@ class TestEaglePrepareInputsPadded:
         query_start_loc = _t([0, 3, 5, 10])
 
         token_indices, num_rejected = eagle_prepare_inputs_padded(
-            cu_num_draft, valid_count, query_start_loc, _t([0, 0, 0])
+            cu_num_draft, valid_count, query_start_loc
         )
         # rejected = [3+1-2, 2+1-1, 5+1-4] = [2, 2, 2].
         assert num_rejected.cpu().tolist() == [2, 2, 2]

--- a/tests/native/v1/spec_decode/test_utils.py
+++ b/tests/native/v1/spec_decode/test_utils.py
@@ -101,7 +101,7 @@ class TestEaglePrepareInputsPadded:
         query_start_loc = _t([0, 3, 6, 9])
 
         token_indices, num_rejected = eagle_prepare_inputs_padded(
-            cu_num_draft, valid_count, query_start_loc
+            cu_num_draft, valid_count, query_start_loc, _t([0, 0, 0])
         )
         # rejected = (2+1) - valid = [1, 0, 2]; index = qsl[1:]-1-rejected.
         assert num_rejected.cpu().tolist() == [1, 0, 2]
@@ -115,11 +115,26 @@ class TestEaglePrepareInputsPadded:
         query_start_loc = _t([0, 1, 4])
 
         token_indices, num_rejected = eagle_prepare_inputs_padded(
-            cu_num_draft, valid_count, query_start_loc
+            cu_num_draft, valid_count, query_start_loc, _t([0, 0])
         )
         # req0: no draft -> 0; req1: (3+1)-2 = 2.
         assert num_rejected.cpu().tolist() == [0, 2]
         assert token_indices.cpu().tolist() == [0, 1]
+
+    def test_back_padding_shifts_the_index_off_the_padded_slots(self):
+        # The target staged 2 slots behind req0's scheduled tokens and 1 behind
+        # req1's, so the walk back starts at the last scheduled token, not at
+        # the query's last slot.
+        cu_num_draft = _t([2, 4])
+        valid_count = _t([2, 3])
+        query_start_loc = _t([0, 5, 10])
+
+        token_indices, num_rejected = eagle_prepare_inputs_padded(
+            cu_num_draft, valid_count, query_start_loc, _t([2, 1])
+        )
+        # rejected = [1, 0]; index = qsl[1:] - 1 - back_pad - rejected.
+        assert num_rejected.cpu().tolist() == [1, 0]
+        assert token_indices.cpu().tolist() == [1, 8]
 
     def test_cumulative_counts_are_differenced_per_request(self):
         # cu = [3, 5, 10] must yield per-request drafts [3, 2, 5], not the raw
@@ -129,7 +144,7 @@ class TestEaglePrepareInputsPadded:
         query_start_loc = _t([0, 3, 5, 10])
 
         token_indices, num_rejected = eagle_prepare_inputs_padded(
-            cu_num_draft, valid_count, query_start_loc
+            cu_num_draft, valid_count, query_start_loc, _t([0, 0, 0])
         )
         # rejected = [3+1-2, 2+1-1, 5+1-4] = [2, 2, 2].
         assert num_rejected.cpu().tolist() == [2, 2, 2]

--- a/tests/native/v1/worker/test_rbln_model_runner.py
+++ b/tests/native/v1/worker/test_rbln_model_runner.py
@@ -1030,8 +1030,6 @@ class TestMayReorderBatch:
 
 
 class TestDraftInputsFollowTheScheduledToken:
-    # Both drafter paths walk back from the staged query's last slot, which back
-    # padding leaves un-scheduled, so the runner shifts them by that padding.
     STAGED = 8  # two requests, four staged slots each
     LOGICAL = 99  # what the scheduler advanced; the draft must not use it
 
@@ -1095,9 +1093,6 @@ class TestDraftInputsFollowTheScheduledToken:
 
 
 class TestDummyRunDecodeWindowPadding:
-    # make_model_runner builds a real Attention, so these open the NPU --
-    # the marker is what runs them in a fresh process instead of pinning
-    # this session's device.
     pytestmark = pytest.mark.maybe_use_device
 
     NUM_REQS = 2

--- a/tests/native/v1/worker/test_rbln_model_runner.py
+++ b/tests/native/v1/worker/test_rbln_model_runner.py
@@ -282,7 +282,6 @@ class TestPadDepad:
                 padded.cu_num_draft_tokens,
                 torch.tensor([2, 2], dtype=torch.int32),
                 torch.tensor([0, 2, 4], dtype=torch.int32),
-                torch.zeros(2, dtype=torch.int32),
             )
 
 
@@ -983,85 +982,6 @@ class TestCalcSpecDecodeMetadata:
         assert md.bonus_logits_indices.tolist() == [0, 1]
 
 
-class TestPrepareInputsFixedWindow:
-    # _prepare_inputs stages a fixed num_spec_tokens + 1 decode window and fills
-    # the slack in front of the scheduled tokens as far as the block allows, then
-    # behind them. `logits_indices` has to follow the tokens, not the window.
-    BLOCK = 16
-    NUM_SPEC = 3
-
-    def _runner(self, num_computed):
-        runner = _make_runner_stub(
-            num_spec_tokens=self.NUM_SPEC,
-            speculative_config=SimpleNamespace(use_eagle=lambda: True),
-            cache_config=SimpleNamespace(block_size=self.BLOCK),
-            arange_np=np.arange(8),
-            positions=torch.zeros(64, dtype=torch.int64),
-            input_ids=torch.zeros(64, dtype=torch.int32),
-            query_start_loc=torch.zeros(9, dtype=torch.int32),
-            decode_back_pad=torch.zeros(8, dtype=torch.int32),
-            seq_lens_np=np.zeros(8, dtype=np.int32),
-            discard_request_mask=torch.zeros(8, dtype=torch.bool),
-            device=torch.device("cpu"),
-            requests={"0": SimpleNamespace(num_tokens=num_computed + 1)},
-        )
-        runner.is_prefill = False
-        runner.query_start_loc_np = runner.query_start_loc.numpy()
-        runner.decode_back_pad_np = runner.decode_back_pad.numpy()
-        runner.input_batch = SimpleNamespace(
-            num_reqs=1,
-            num_computed_tokens_cpu=np.array([num_computed], dtype=np.int32),
-            token_ids_cpu=np.zeros((1, 64), dtype=np.int32),
-            token_ids_cpu_tensor=torch.zeros(1, 64, dtype=torch.int32),
-            req_id_to_index={"0": 0},
-            num_prompt_tokens=np.array([1], dtype=np.int32),
-            req_ids=["0"],
-        )
-        return runner
-
-    def _prepare(self, num_computed):
-        runner = self._runner(num_computed)
-        scheduler_output = SimpleNamespace(
-            total_num_scheduled_tokens=1,
-            scheduled_spec_decode_tokens={},
-        )
-        logits_indices, _, query_lengths, total = runner._prepare_inputs(
-            scheduler_output, np.array([1], dtype=np.int32)
-        )
-        return runner, logits_indices, query_lengths, total
-
-    @pytest.mark.parametrize(
-        "num_computed,window_start,sample_slot",
-        [
-            # Mid-block: all three slack slots fit in front of the token.
-            (10, 7, 3),
-            # At a block start: nothing to re-run, so all of it goes behind.
-            (16, 16, 0),
-            # One computed token in the block: one in front, two behind.
-            (17, 16, 1),
-        ],
-    )
-    def test_window_is_fixed_and_stays_in_the_block(
-        self, num_computed, window_start, sample_slot
-    ):
-        runner, logits_indices, query_lengths, total = self._prepare(num_computed)
-        window = self.NUM_SPEC + 1
-
-        assert query_lengths.tolist() == [window]
-        assert total == window
-        positions = runner.positions.numpy()[:window].tolist()
-        assert positions == list(range(window_start, window_start + window))
-        # The whole point of the split: one write range, one block.
-        assert window_start // self.BLOCK == positions[-1] // self.BLOCK
-        # The sampled slot is the scheduled token, wherever the padding put it.
-        assert logits_indices.tolist() == [sample_slot]
-        assert positions[sample_slot] == num_computed
-        # seq_lens stays the logical length; the padding must not inflate it.
-        assert runner.seq_lens_np[0] == num_computed + 1
-        # The drafter path reads this to find the same slot.
-        assert runner.decode_back_pad_np[0] == window - 1 - sample_slot
-
-
 class TestMayReorderBatch:
     # Stable descending sort by num_tokens_no_spec, applied in place. Uses a real
     # InputBatch; scheduler_output is unused by the sort path, so None is passed.
@@ -1109,33 +1029,138 @@ class TestMayReorderBatch:
         assert r.input_batch.batch_update_builder.moved != []
 
 
+class TestDraftInputsFollowTheScheduledToken:
+    # Both drafter paths walk back from the staged query's last slot, which back
+    # padding leaves un-scheduled, so the runner shifts them by that padding.
+    STAGED = 8  # two requests, four staged slots each
+    LOGICAL = 99  # what the scheduler advanced; the draft must not use it
+
+    @classmethod
+    def _propose(cls, back_pad, spec_decode_metadata, cad, walk_back=None):
+        runner = _make_runner_stub(
+            speculative_config=SimpleNamespace(
+                method="mtp", use_eagle=lambda: True, num_speculative_tokens=3
+            ),
+            num_spec_tokens=3,
+            input_ids=torch.arange(32, dtype=torch.int32),
+            positions=torch.arange(32, dtype=torch.int64),
+            decode_back_pad=torch.tensor(back_pad, dtype=torch.int32),
+            requests={},
+            discard_request_mask=torch.zeros(8, dtype=torch.bool),
+            input_batch=SimpleNamespace(num_reqs=2),
+            drafter=MagicMock(spec=RBLNEagleProposer),
+        )
+        runner.drafter.prepare_next_token_ids_padded.return_value = (
+            torch.zeros(2, dtype=torch.int32),
+            torch.zeros(2, dtype=torch.int32),
+        )
+        if walk_back is not None:
+            runner.drafter.prepare_inputs_padded.return_value = (
+                cad,
+                walk_back,
+                torch.zeros(2, dtype=torch.int32),
+            )
+        runner.propose_draft_token_ids(
+            scheduler_output=SimpleNamespace(total_num_scheduled_tokens=cls.LOGICAL),
+            sampled_token_ids=torch.zeros(1, dtype=torch.int32),
+            sampling_metadata=None,
+            hidden_states=torch.zeros(1),
+            sample_hidden_states=torch.zeros(1),
+            spec_decode_metadata=spec_decode_metadata,
+            common_attn_metadata=cad,
+            combined_hidden_states=None,
+        )
+        return runner.drafter.propose.call_args.kwargs
+
+    def test_the_proposers_index_is_corrected_by_the_back_padding(self):
+        cad = SimpleNamespace(num_actual_tokens=self.STAGED, query_start_loc=None)
+        kwargs = self._propose(
+            [2, 1],
+            SimpleNamespace(),
+            cad,
+            walk_back=torch.tensor([3, 7], dtype=torch.int32),
+        )
+        assert kwargs["token_indices_to_sample"].tolist() == [1, 6]
+        assert kwargs["target_token_ids"].tolist() == list(range(self.STAGED))
+
+    def test_the_no_spec_path_stages_the_window_and_finds_the_token(self):
+        # query_start_loc[1:] - 1 - back_pad = [3, 7] - [3, 0] = [0, 7].
+        cad = SimpleNamespace(
+            query_start_loc=torch.tensor([0, 4, 8], dtype=torch.int32),
+            num_actual_tokens=self.STAGED,
+        )
+        kwargs = self._propose([3, 0], None, cad)
+        assert kwargs["token_indices_to_sample"].tolist() == [0, 7]
+        assert kwargs["target_token_ids"].tolist() == list(range(self.STAGED))
+
+
+class TestDummyRunDecodeWindowPadding:
+    # make_model_runner builds a real Attention, so these open the NPU --
+    # the marker is what runs them in a fresh process instead of pinning
+    # this session's device.
+    pytestmark = pytest.mark.maybe_use_device
+
+    NUM_REQS = 2
+    NUM_SPEC = 3
+
+    @pytest.mark.parametrize(
+        "fixed_window,warmup,expected_tokens",
+        [
+            # The window is the only decode shape warm-up compiles, so a shorter
+            # request has to be padded out to it.
+            (True, True, 1 + NUM_SPEC),
+            # An ngram-style drafter compiles qlen=1 too; nothing to pad to.
+            (False, True, 1),
+            # Not warm-up: the DP idle entry must stay minimal so it does not
+            # drive the shape decision the busy ranks make.
+            (True, False, 1),
+        ],
+    )
+    def test_only_a_warm_up_with_a_fixed_window_pads(
+        self, make_model_runner, monkeypatch, fixed_window, warmup, expected_tokens
+    ):
+        runner = make_model_runner()
+        monkeypatch.setattr(runner, "num_spec_tokens", self.NUM_SPEC)
+        monkeypatch.setattr(type(runner), "uses_fixed_decode_window", fixed_window)
+        seen: list = []
+        monkeypatch.setattr(
+            runner,
+            "_determine_batch_execution_and_padding",
+            lambda num_reqs, num_tokens, is_idle, **kw: (seen.append(num_tokens))
+            or (None, None, None),
+        )
+
+        runner._dummy_run(self.NUM_REQS, 1, False, warmup=warmup)
+
+        assert seen == [self.NUM_REQS * expected_tokens]
+
+
 class TestFixedDecodeWindowConfig:
     # The fixed decode window is placed inside one KV block, so the sequence's
     # last block has to be able to hold it. A max_model_len whose remainder is
     # shorter than the window has no valid placement there, and is refused at
     # load rather than a step into serving.
     @staticmethod
-    def _runner(max_model_len, num_spec_tokens):
-        runner = _make_runner_stub(
+    def _runner(max_model_len, num_spec_tokens, block_size=1024):
+        return _make_runner_stub(
             max_model_len=max_model_len,
             num_spec_tokens=num_spec_tokens,
-            speculative_config=SimpleNamespace(use_eagle=lambda: True),
-            cache_config=SimpleNamespace(block_size=1024),
+            speculative_config=SimpleNamespace(method="mtp"),
+            cache_config=SimpleNamespace(block_size=block_size),
         )
-        return runner
 
-    def test_a_last_block_too_short_for_the_window_is_refused(self):
-        runner = self._runner(1024 * 4 + 2, 3)
+    @pytest.mark.parametrize(
+        "max_model_len,block_size",
+        [
+            (1024 * 4 + 2, 1024),  # last block leaves 2 of the 4 slots
+            (1024 * 4, 2),  # no block can hold the window at all
+        ],
+    )
+    def test_a_block_too_short_for_the_window_is_refused(
+        self, max_model_len, block_size
+    ):
+        runner = self._runner(max_model_len, 3, block_size)
         with pytest.raises(ValueError, match="cannot hold the 4-slot"):
-            runner.initialize_kv_cache(SimpleNamespace(kv_cache_groups=[]))
-
-    @pytest.mark.parametrize("max_model_len", [1024 * 4, 1024 * 4 + 4, 1024 * 4 + 900])
-    def test_a_last_block_that_fits_is_accepted(self, max_model_len):
-        # Block-aligned, exactly the window, and a long remainder all pass the
-        # check; the raise is the only thing under test, so the call is expected
-        # to fail later on the stub's missing state.
-        runner = self._runner(max_model_len, 3)
-        with pytest.raises(AttributeError):
             runner.initialize_kv_cache(SimpleNamespace(kv_cache_groups=[]))
 
 
@@ -1400,7 +1425,7 @@ class TestDummyRunDraftParticipation:
         attrs = dict(
             max_num_tokens=64,
             max_num_reqs=8,
-            speculative_config=SimpleNamespace(),
+            speculative_config=SimpleNamespace(method="eagle"),
             num_spec_tokens=cls.NUM_SPEC,
             query_start_loc_np=np.zeros(16, dtype=np.int32),
             input_ids=torch.zeros(64, dtype=torch.int32),
@@ -1458,18 +1483,18 @@ class TestDummyRunDraftParticipation:
         runner._dummy_run(1, 1, is_prefill=False, warmup=False)
         drafter.dummy_run.assert_called_once_with(1, 1, False)
 
-    @pytest.mark.parametrize("query_len", [1, 1 + NUM_SPEC])
-    def test_warmup_compiles_the_draft_at_every_query_length(
-        self, monkeypatch, query_len
+    @pytest.mark.parametrize("requested", [1, 1 + NUM_SPEC])
+    def test_warmup_compiles_the_draft_at_the_window_length(
+        self, monkeypatch, requested
     ):
-        # Both decode lengths reach the draft. Query length 1 is the one a step
-        # forced to no-spec runs, and compiling only the spec length leaves that
-        # step to compile its own graph while it serves.
+        # The window is the only decode length this config compiles, so a warm-up
+        # dummy asking for a shorter decode query reaches the draft padded out to
+        # it rather than at a length nothing compiled.
         runner, drafter = self._runner(monkeypatch, has_drafter=True)
-        runner._dummy_run(2, query_len, is_prefill=False, warmup=True)
+        runner._dummy_run(2, requested, is_prefill=False, warmup=True)
         # warmup path keeps the num_padded_tokens kwarg (draft's own pad target).
         drafter.dummy_run.assert_called_once_with(
-            2, query_len, False, num_padded_tokens=None
+            2, 1 + self.NUM_SPEC, False, num_padded_tokens=None
         )
 
     def test_no_drafter_skips_cleanly(self, monkeypatch):

--- a/tests/native/v1/worker/test_rbln_model_runner.py
+++ b/tests/native/v1/worker/test_rbln_model_runner.py
@@ -1029,69 +1029,6 @@ class TestMayReorderBatch:
         assert r.input_batch.batch_update_builder.moved != []
 
 
-class TestDraftInputsFollowTheScheduledToken:
-    STAGED = 8  # two requests, four staged slots each
-    LOGICAL = 99  # what the scheduler advanced; the draft must not use it
-
-    @classmethod
-    def _propose(cls, back_pad, spec_decode_metadata, cad, walk_back=None):
-        runner = _make_runner_stub(
-            speculative_config=SimpleNamespace(
-                method="mtp", use_eagle=lambda: True, num_speculative_tokens=3
-            ),
-            num_spec_tokens=3,
-            input_ids=torch.arange(32, dtype=torch.int32),
-            positions=torch.arange(32, dtype=torch.int64),
-            decode_back_pad=torch.tensor(back_pad, dtype=torch.int32),
-            requests={},
-            discard_request_mask=torch.zeros(8, dtype=torch.bool),
-            input_batch=SimpleNamespace(num_reqs=2),
-            drafter=MagicMock(spec=RBLNEagleProposer),
-        )
-        runner.drafter.prepare_next_token_ids_padded.return_value = (
-            torch.zeros(2, dtype=torch.int32),
-            torch.zeros(2, dtype=torch.int32),
-        )
-        if walk_back is not None:
-            runner.drafter.prepare_inputs_padded.return_value = (
-                cad,
-                walk_back,
-                torch.zeros(2, dtype=torch.int32),
-            )
-        runner.propose_draft_token_ids(
-            scheduler_output=SimpleNamespace(total_num_scheduled_tokens=cls.LOGICAL),
-            sampled_token_ids=torch.zeros(1, dtype=torch.int32),
-            sampling_metadata=None,
-            hidden_states=torch.zeros(1),
-            sample_hidden_states=torch.zeros(1),
-            spec_decode_metadata=spec_decode_metadata,
-            common_attn_metadata=cad,
-            combined_hidden_states=None,
-        )
-        return runner.drafter.propose.call_args.kwargs
-
-    def test_the_proposers_index_is_corrected_by_the_back_padding(self):
-        cad = SimpleNamespace(num_actual_tokens=self.STAGED, query_start_loc=None)
-        kwargs = self._propose(
-            [2, 1],
-            SimpleNamespace(),
-            cad,
-            walk_back=torch.tensor([3, 7], dtype=torch.int32),
-        )
-        assert kwargs["token_indices_to_sample"].tolist() == [1, 6]
-        assert kwargs["target_token_ids"].tolist() == list(range(self.STAGED))
-
-    def test_the_no_spec_path_stages_the_window_and_finds_the_token(self):
-        # query_start_loc[1:] - 1 - back_pad = [3, 7] - [3, 0] = [0, 7].
-        cad = SimpleNamespace(
-            query_start_loc=torch.tensor([0, 4, 8], dtype=torch.int32),
-            num_actual_tokens=self.STAGED,
-        )
-        kwargs = self._propose([3, 0], None, cad)
-        assert kwargs["token_indices_to_sample"].tolist() == [0, 7]
-        assert kwargs["target_token_ids"].tolist() == list(range(self.STAGED))
-
-
 class TestDummyRunDecodeWindowPadding:
     pytestmark = pytest.mark.maybe_use_device
 

--- a/tests/native/v1/worker/test_rbln_model_runner.py
+++ b/tests/native/v1/worker/test_rbln_model_runner.py
@@ -282,6 +282,7 @@ class TestPadDepad:
                 padded.cu_num_draft_tokens,
                 torch.tensor([2, 2], dtype=torch.int32),
                 torch.tensor([0, 2, 4], dtype=torch.int32),
+                torch.zeros(2, dtype=torch.int32),
             )
 
 
@@ -976,6 +977,85 @@ class TestCalcSpecDecodeMetadata:
         assert md.logits_indices.tolist() == [0, 1]
         assert md.target_logits_indices.tolist() == []
         assert md.bonus_logits_indices.tolist() == [0, 1]
+
+
+class TestPrepareInputsFixedWindow:
+    # _prepare_inputs stages a fixed num_spec_tokens + 1 decode window and fills
+    # the slack in front of the scheduled tokens as far as the block allows, then
+    # behind them. `logits_indices` has to follow the tokens, not the window.
+    BLOCK = 16
+    NUM_SPEC = 3
+
+    def _runner(self, num_computed):
+        runner = _make_runner_stub(
+            num_spec_tokens=self.NUM_SPEC,
+            speculative_config=SimpleNamespace(use_eagle=lambda: True),
+            cache_config=SimpleNamespace(block_size=self.BLOCK),
+            arange_np=np.arange(8),
+            positions=torch.zeros(64, dtype=torch.int64),
+            input_ids=torch.zeros(64, dtype=torch.int32),
+            query_start_loc=torch.zeros(9, dtype=torch.int32),
+            decode_back_pad=torch.zeros(8, dtype=torch.int32),
+            seq_lens_np=np.zeros(8, dtype=np.int32),
+            discard_request_mask=torch.zeros(8, dtype=torch.bool),
+            device=torch.device("cpu"),
+            requests={"0": SimpleNamespace(num_tokens=num_computed + 1)},
+        )
+        runner.is_prefill = False
+        runner.query_start_loc_np = runner.query_start_loc.numpy()
+        runner.decode_back_pad_np = runner.decode_back_pad.numpy()
+        runner.input_batch = SimpleNamespace(
+            num_reqs=1,
+            num_computed_tokens_cpu=np.array([num_computed], dtype=np.int32),
+            token_ids_cpu=np.zeros((1, 64), dtype=np.int32),
+            token_ids_cpu_tensor=torch.zeros(1, 64, dtype=torch.int32),
+            req_id_to_index={"0": 0},
+            num_prompt_tokens=np.array([1], dtype=np.int32),
+            req_ids=["0"],
+        )
+        return runner
+
+    def _prepare(self, num_computed):
+        runner = self._runner(num_computed)
+        scheduler_output = SimpleNamespace(
+            total_num_scheduled_tokens=1,
+            scheduled_spec_decode_tokens={},
+        )
+        logits_indices, _, query_lengths, total = runner._prepare_inputs(
+            scheduler_output, np.array([1], dtype=np.int32)
+        )
+        return runner, logits_indices, query_lengths, total
+
+    @pytest.mark.parametrize(
+        "num_computed,window_start,sample_slot",
+        [
+            # Mid-block: all three slack slots fit in front of the token.
+            (10, 7, 3),
+            # At a block start: nothing to re-run, so all of it goes behind.
+            (16, 16, 0),
+            # One computed token in the block: one in front, two behind.
+            (17, 16, 1),
+        ],
+    )
+    def test_window_is_fixed_and_stays_in_the_block(
+        self, num_computed, window_start, sample_slot
+    ):
+        runner, logits_indices, query_lengths, total = self._prepare(num_computed)
+        window = self.NUM_SPEC + 1
+
+        assert query_lengths.tolist() == [window]
+        assert total == window
+        positions = runner.positions.numpy()[:window].tolist()
+        assert positions == list(range(window_start, window_start + window))
+        # The whole point of the split: one write range, one block.
+        assert window_start // self.BLOCK == positions[-1] // self.BLOCK
+        # The sampled slot is the scheduled token, wherever the padding put it.
+        assert logits_indices.tolist() == [sample_slot]
+        assert positions[sample_slot] == num_computed
+        # seq_lens stays the logical length; the padding must not inflate it.
+        assert runner.seq_lens_np[0] == num_computed + 1
+        # The drafter path reads this to find the same slot.
+        assert runner.decode_back_pad_np[0] == window - 1 - sample_slot
 
 
 class TestMayReorderBatch:

--- a/tests/native/v1/worker/test_rbln_model_runner.py
+++ b/tests/native/v1/worker/test_rbln_model_runner.py
@@ -1105,6 +1105,36 @@ class TestMayReorderBatch:
         assert r.input_batch.batch_update_builder.moved != []
 
 
+class TestFixedDecodeWindowConfig:
+    # The fixed decode window is placed inside one KV block, so the sequence's
+    # last block has to be able to hold it. A max_model_len whose remainder is
+    # shorter than the window has no valid placement there, and is refused at
+    # load rather than a step into serving.
+    @staticmethod
+    def _runner(max_model_len, num_spec_tokens):
+        runner = _make_runner_stub(
+            max_model_len=max_model_len,
+            num_spec_tokens=num_spec_tokens,
+            speculative_config=SimpleNamespace(use_eagle=lambda: True),
+            cache_config=SimpleNamespace(block_size=1024),
+        )
+        return runner
+
+    def test_a_last_block_too_short_for_the_window_is_refused(self):
+        runner = self._runner(1024 * 4 + 2, 3)
+        with pytest.raises(ValueError, match="cannot hold the 4-slot"):
+            runner.initialize_kv_cache(SimpleNamespace(kv_cache_groups=[]))
+
+    @pytest.mark.parametrize("max_model_len", [1024 * 4, 1024 * 4 + 4, 1024 * 4 + 900])
+    def test_a_last_block_that_fits_is_accepted(self, max_model_len):
+        # Block-aligned, exactly the window, and a long remainder all pass the
+        # check; the raise is the only thing under test, so the call is expected
+        # to fail later on the stub's missing state.
+        runner = self._runner(max_model_len, 3)
+        with pytest.raises(AttributeError):
+            runner.initialize_kv_cache(SimpleNamespace(kv_cache_groups=[]))
+
+
 class TestAllocateKvCacheTensors:
     # Device selection: "cpu" if not compiling, else self.device if device-tensor,
     # else "meta". The mapping/validation logic is exercised on CPU.

--- a/tests/native/v1/worker/test_rbln_model_runner_inputs.py
+++ b/tests/native/v1/worker/test_rbln_model_runner_inputs.py
@@ -36,16 +36,14 @@ def _decode_ready(
     num_spec_tokens: int,
     num_computed: int = 3,
     fixed_window: bool = True,
-    req_ids: tuple[str, ...] = ("a",),
 ) -> None:
-    """Requests past their prompt in the decode phase, so the spec branch is
+    """One request past its prompt in the decode phase, so the spec branch is
     reachable. The phase comes from the scheduler output, so it is set through
     _is_prefill_step rather than derived from input_batch."""
     monkeypatch.setattr(mr, "get_pp_group", lambda: SimpleNamespace(is_last_rank=True))
-    runner._update_states(schedule_new(*req_ids))
-    for idx in range(len(req_ids)):
-        runner.input_batch.num_computed_tokens_cpu[idx] = num_computed
-        runner.input_batch.num_tokens_no_spec[idx] = num_computed
+    runner._update_states(schedule_new("a"))
+    runner.input_batch.num_computed_tokens_cpu[0] = num_computed
+    runner.input_batch.num_tokens_no_spec[0] = num_computed
     # Patched rather than configured: a real speculative_config would pull in a
     # drafter, and the only thing the arithmetic reads off it is whether the
     # drafter is model-based, which decides the fixed decode window.
@@ -110,39 +108,6 @@ class TestPrepareInputsSpecDecode:
         assert logits_indices.tolist() == [0]
 
 
-class TestPrepareInputsUniformQueryLength:
-    # RBLN runs one query length per step (see dp_utils.determine_batch_
-    # execution_and_padding), so a step that stages the window has to stage it
-    # for the whole batch.
-    def test_a_mixed_batch_stages_one_query_length(
-        self, make_model_runner, monkeypatch
-    ):
-        runner = make_model_runner()
-        _decode_ready(
-            runner,
-            monkeypatch,
-            num_spec_tokens=2,
-            num_computed=8,
-            fixed_window=False,
-            req_ids=("a", "b"),
-        )
-
-        # "a" kept both drafts, "b" none -- logical lengths 3 and 1.
-        _logits, spec_md, query_lengths, total = runner._prepare_inputs(
-            make_scheduler_output(
-                num_scheduled_tokens={"a": 3, "b": 1},
-                spec_decode_tokens={"a": [11, 12]},
-            ),
-            np.array([3, 1], dtype=np.int32),
-        )
-
-        window = 3
-        assert query_lengths.tolist() == [window, window]
-        assert total % len(query_lengths) == 0
-        assert spec_md is not None
-        assert spec_md.num_draft_tokens == [2, 0]
-
-
 class TestPrepareInputsFixedWindow:
     # A decode with a model-based drafter always stages num_spec_tokens + 1
     # slots, spending the slack on tokens already computed in this block and
@@ -154,16 +119,12 @@ class TestPrepareInputsFixedWindow:
     @pytest.mark.parametrize(
         "num_computed,window_start,sample_slot",
         [
-            # Mid-block: the tail holds the whole slack, so the window re-runs
-            # the two tokens before the scheduled one.
+            # Mid-block: the used tail holds the whole slack, so the window
+            # re-runs the two tokens before the scheduled one.
             (3, 1, 2),
             # At a block start there is no tail to re-run, so the slack has
-            # nowhere to go but behind.
+            # nowhere to go but behind the scheduled token.
             (BLOCK, BLOCK, 0),
-            # One token into the block: one slot in front, one behind.
-            (BLOCK + 1, BLOCK, 1),
-            # The block's last slot: the whole slack fits in front.
-            (BLOCK - 1, BLOCK - 1 - 2, 2),
         ],
     )
     def test_window_is_fixed_and_stays_in_one_block(
@@ -190,11 +151,8 @@ class TestPrepareInputsFixedWindow:
         assert window_start // self.BLOCK == positions[-1] // self.BLOCK
         # The sampled slot is the scheduled token, wherever the padding put it.
         assert logits_indices.tolist() == [sample_slot]
-        assert positions[sample_slot] == num_computed
         # seq_lens stays the logical length; padding must not inflate it.
         assert runner.seq_lens[:1].tolist() == [num_computed + 1]
-        # The drafter path reads this to find the same slot.
-        assert runner.decode_back_pad_np[0] == window - 1 - sample_slot
 
 
 class TestBookkeepingSyncSpecDecode:

--- a/tests/native/v1/worker/test_rbln_model_runner_inputs.py
+++ b/tests/native/v1/worker/test_rbln_model_runner_inputs.py
@@ -113,10 +113,7 @@ class TestPrepareInputsSpecDecode:
 class TestPrepareInputsUniformQueryLength:
     # RBLN runs one query length per step (see dp_utils.determine_batch_
     # execution_and_padding), so a step that stages the window has to stage it
-    # for the whole batch. An ngram-style drafter is where this bites: it can
-    # propose k tokens for one request and none for its neighbour, and running
-    # each at its own logical length would hand the shape decision a batch it
-    # cannot describe.
+    # for the whole batch.
     def test_a_mixed_batch_stages_one_query_length(
         self, make_model_runner, monkeypatch
     ):
@@ -141,10 +138,7 @@ class TestPrepareInputsUniformQueryLength:
 
         window = 3
         assert query_lengths.tolist() == [window, window]
-        # What the shape decision asserts: num_tokens is a multiple of num_reqs.
         assert total % len(query_lengths) == 0
-        # "b" had no draft, so its whole slack is padding; the scheduled token
-        # still has to be the sampled slot.
         assert spec_md is not None
         assert spec_md.num_draft_tokens == [2, 0]
 

--- a/tests/native/v1/worker/test_rbln_model_runner_inputs.py
+++ b/tests/native/v1/worker/test_rbln_model_runner_inputs.py
@@ -36,20 +36,24 @@ def _decode_ready(
     num_spec_tokens: int,
     num_computed: int = 3,
     fixed_window: bool = True,
+    req_ids: tuple[str, ...] = ("a",),
 ) -> None:
-    """One request past its prompt in the decode phase, so the spec branch is
+    """Requests past their prompt in the decode phase, so the spec branch is
     reachable. The phase comes from the scheduler output, so it is set through
     _is_prefill_step rather than derived from input_batch."""
     monkeypatch.setattr(mr, "get_pp_group", lambda: SimpleNamespace(is_last_rank=True))
-    runner._update_states(schedule_new("a"))
-    runner.input_batch.num_computed_tokens_cpu[0] = num_computed
-    runner.input_batch.num_tokens_no_spec[0] = num_computed
+    runner._update_states(schedule_new(*req_ids))
+    for idx in range(len(req_ids)):
+        runner.input_batch.num_computed_tokens_cpu[idx] = num_computed
+        runner.input_batch.num_tokens_no_spec[idx] = num_computed
     # Patched rather than configured: a real speculative_config would pull in a
     # drafter, and the only thing the arithmetic reads off it is whether the
     # drafter is model-based, which decides the fixed decode window.
     monkeypatch.setattr(runner, "num_spec_tokens", num_spec_tokens)
     monkeypatch.setattr(
-        runner, "speculative_config", SimpleNamespace(use_eagle=lambda: fixed_window)
+        runner,
+        "speculative_config",
+        SimpleNamespace(method="mtp" if fixed_window else "ngram"),
     )
     runner._is_prefill_step = False
     assert runner.is_prefill is False
@@ -60,7 +64,8 @@ class TestPrepareInputsSpecDecode:
         self, make_model_runner, monkeypatch
     ):
         # 1 real + 1 draft = 2 logical tokens, but the decode query is fixed at
-        # num_spec_tokens + 1 = 3, so one already-computed token is backfilled.
+        # num_spec_tokens + 1 = 3, so one slot is padded. Mid-block the used tail
+        # absorbs it, so the window re-runs the token before the scheduled ones.
         runner = make_model_runner()
         _decode_ready(runner, monkeypatch, num_spec_tokens=2)
 
@@ -73,7 +78,7 @@ class TestPrepareInputsSpecDecode:
 
         assert query_lengths.tolist() == [3]
         assert total == 3
-        # Positions start one token earlier (num_computed 3 - backfill 1).
+        # Slot 0 re-runs position 2; the scheduled tokens land in slots 1 and 2.
         assert runner.positions[:3].tolist() == [2, 3, 4]
         # seq_lens follows the logical count (3 + 2), not the padded query
         # length, or attention would read a KV slot this step never wrote.
@@ -105,23 +110,66 @@ class TestPrepareInputsSpecDecode:
         assert logits_indices.tolist() == [0]
 
 
+class TestPrepareInputsUniformQueryLength:
+    # RBLN runs one query length per step (see dp_utils.determine_batch_
+    # execution_and_padding), so a step that stages the window has to stage it
+    # for the whole batch. An ngram-style drafter is where this bites: it can
+    # propose k tokens for one request and none for its neighbour, and running
+    # each at its own logical length would hand the shape decision a batch it
+    # cannot describe.
+    def test_a_mixed_batch_stages_one_query_length(
+        self, make_model_runner, monkeypatch
+    ):
+        runner = make_model_runner()
+        _decode_ready(
+            runner,
+            monkeypatch,
+            num_spec_tokens=2,
+            num_computed=8,
+            fixed_window=False,
+            req_ids=("a", "b"),
+        )
+
+        # "a" kept both drafts, "b" none -- logical lengths 3 and 1.
+        _logits, spec_md, query_lengths, total = runner._prepare_inputs(
+            make_scheduler_output(
+                num_scheduled_tokens={"a": 3, "b": 1},
+                spec_decode_tokens={"a": [11, 12]},
+            ),
+            np.array([3, 1], dtype=np.int32),
+        )
+
+        window = 3
+        assert query_lengths.tolist() == [window, window]
+        # What the shape decision asserts: num_tokens is a multiple of num_reqs.
+        assert total % len(query_lengths) == 0
+        # "b" had no draft, so its whole slack is padding; the scheduled token
+        # still has to be the sampled slot.
+        assert spec_md is not None
+        assert spec_md.num_draft_tokens == [2, 0]
+
+
 class TestPrepareInputsFixedWindow:
     # A decode with a model-based drafter always stages num_spec_tokens + 1
-    # slots, taking the slack in front of the scheduled token as far as the
-    # block allows and behind it for the rest. Everything downstream has to
-    # follow the token, not the window.
+    # slots, spending the slack on tokens already computed in this block and
+    # putting whatever the block's used tail cannot absorb behind the scheduled
+    # token. Everything downstream has to follow the token, not the window.
     BLOCK = 1024
     NUM_SPEC = 2
 
     @pytest.mark.parametrize(
         "num_computed,window_start,sample_slot",
         [
-            # Mid-block: both slack slots fit in front of the token.
+            # Mid-block: the tail holds the whole slack, so the window re-runs
+            # the two tokens before the scheduled one.
             (3, 1, 2),
-            # At a block start: nothing to re-run, so all of it goes behind.
+            # At a block start there is no tail to re-run, so the slack has
+            # nowhere to go but behind.
             (BLOCK, BLOCK, 0),
-            # One computed token in the block: one in front, one behind.
+            # One token into the block: one slot in front, one behind.
             (BLOCK + 1, BLOCK, 1),
+            # The block's last slot: the whole slack fits in front.
+            (BLOCK - 1, BLOCK - 1 - 2, 2),
         ],
     )
     def test_window_is_fixed_and_stays_in_one_block(
@@ -141,9 +189,7 @@ class TestPrepareInputsFixedWindow:
             np.array([1], dtype=np.int32),
         )
 
-        assert spec_md is None
         assert query_lengths.tolist() == [window]
-        assert total == window
         positions = runner.positions[:window].tolist()
         assert positions == list(range(window_start, window_start + window))
         # The invariant the split exists for: one write range, one block.

--- a/tests/native/v1/worker/test_rbln_model_runner_inputs.py
+++ b/tests/native/v1/worker/test_rbln_model_runner_inputs.py
@@ -29,17 +29,28 @@ from tests.native.v1.worker.utils import make_scheduler_output, schedule_new
 pytestmark = pytest.mark.maybe_use_device
 
 
-def _decode_ready(runner, monkeypatch, *, num_spec_tokens: int) -> None:
+def _decode_ready(
+    runner,
+    monkeypatch,
+    *,
+    num_spec_tokens: int,
+    num_computed: int = 3,
+    fixed_window: bool = True,
+) -> None:
     """One request past its prompt in the decode phase, so the spec branch is
     reachable. The phase comes from the scheduler output, so it is set through
     _is_prefill_step rather than derived from input_batch."""
     monkeypatch.setattr(mr, "get_pp_group", lambda: SimpleNamespace(is_last_rank=True))
     runner._update_states(schedule_new("a"))
-    runner.input_batch.num_computed_tokens_cpu[0] = 3
-    runner.input_batch.num_tokens_no_spec[0] = 3
+    runner.input_batch.num_computed_tokens_cpu[0] = num_computed
+    runner.input_batch.num_tokens_no_spec[0] = num_computed
     # Patched rather than configured: a real speculative_config would pull in a
-    # drafter, and none of the arithmetic under test depends on one.
+    # drafter, and the only thing the arithmetic reads off it is whether the
+    # drafter is model-based, which decides the fixed decode window.
     monkeypatch.setattr(runner, "num_spec_tokens", num_spec_tokens)
+    monkeypatch.setattr(
+        runner, "speculative_config", SimpleNamespace(use_eagle=lambda: fixed_window)
+    )
     runner._is_prefill_step = False
     assert runner.is_prefill is False
 
@@ -72,13 +83,14 @@ class TestPrepareInputsSpecDecode:
         assert spec_md.num_draft_tokens == [1]
         assert logits_indices.tolist() == spec_md.logits_indices.tolist()
 
-    def test_no_padding_when_scheduler_kept_no_drafts(
+    def test_an_ngram_style_drafter_runs_the_logical_length(
         self, make_model_runner, monkeypatch
     ):
-        # num_spec_tokens alone must not force the full-spec query: zero-draft
-        # steps and the unsafe-boundary fallback expect the plain qlen=1 decode.
+        # Without a model-based drafter the window is not fixed: an ngram-style
+        # proposer misses often, and padding every miss out to the full window
+        # would cost more than the extra compiled shape.
         runner = make_model_runner()
-        _decode_ready(runner, monkeypatch, num_spec_tokens=2)
+        _decode_ready(runner, monkeypatch, num_spec_tokens=2, fixed_window=False)
 
         logits_indices, spec_md, query_lengths, total = runner._prepare_inputs(
             make_scheduler_output(num_scheduled_tokens={"a": 1}),
@@ -91,6 +103,58 @@ class TestPrepareInputsSpecDecode:
         assert runner.positions[:1].tolist() == [3]
         assert runner.seq_lens[:1].tolist() == [4]
         assert logits_indices.tolist() == [0]
+
+
+class TestPrepareInputsFixedWindow:
+    # A decode with a model-based drafter always stages num_spec_tokens + 1
+    # slots, taking the slack in front of the scheduled token as far as the
+    # block allows and behind it for the rest. Everything downstream has to
+    # follow the token, not the window.
+    BLOCK = 1024
+    NUM_SPEC = 2
+
+    @pytest.mark.parametrize(
+        "num_computed,window_start,sample_slot",
+        [
+            # Mid-block: both slack slots fit in front of the token.
+            (3, 1, 2),
+            # At a block start: nothing to re-run, so all of it goes behind.
+            (BLOCK, BLOCK, 0),
+            # One computed token in the block: one in front, one behind.
+            (BLOCK + 1, BLOCK, 1),
+        ],
+    )
+    def test_window_is_fixed_and_stays_in_one_block(
+        self, make_model_runner, monkeypatch, num_computed, window_start, sample_slot
+    ):
+        runner = make_model_runner()
+        _decode_ready(
+            runner,
+            monkeypatch,
+            num_spec_tokens=self.NUM_SPEC,
+            num_computed=num_computed,
+        )
+        window = self.NUM_SPEC + 1
+
+        logits_indices, spec_md, query_lengths, total = runner._prepare_inputs(
+            make_scheduler_output(num_scheduled_tokens={"a": 1}),
+            np.array([1], dtype=np.int32),
+        )
+
+        assert spec_md is None
+        assert query_lengths.tolist() == [window]
+        assert total == window
+        positions = runner.positions[:window].tolist()
+        assert positions == list(range(window_start, window_start + window))
+        # The invariant the split exists for: one write range, one block.
+        assert window_start // self.BLOCK == positions[-1] // self.BLOCK
+        # The sampled slot is the scheduled token, wherever the padding put it.
+        assert logits_indices.tolist() == [sample_slot]
+        assert positions[sample_slot] == num_computed
+        # seq_lens stays the logical length; padding must not inflate it.
+        assert runner.seq_lens[:1].tolist() == [num_computed + 1]
+        # The drafter path reads this to find the same slot.
+        assert runner.decode_back_pad_np[0] == window - 1 - sample_slot
 
 
 class TestBookkeepingSyncSpecDecode:

--- a/tests/native/v1/worker/test_rbln_worker.py
+++ b/tests/native/v1/worker/test_rbln_worker.py
@@ -492,27 +492,6 @@ class TestDetermineAvailableMemory:
         # 1 + buckets(3)*1 = 4 (no MoE); draft = 1 + buckets(3) = 4. Total 8.
         assert cap["num_runtimes"] == 8
 
-    def test_a_variable_window_still_reserves_both_decode_lengths(
-        self, make_worker, monkeypatch
-    ):
-        # An ngram-style method keeps qlen=1 reachable, so warm-up compiles both
-        # decode query lengths and the reservation has to cover them.
-        drafter = SimpleNamespace(
-            model=SimpleNamespace(
-                parameters=lambda: iter([torch.zeros(20, dtype=torch.float16)])
-            )
-        )
-        spec = SimpleNamespace(
-            draft_model_config=SimpleNamespace(quantization=None),
-            draft_parallel_config=None,
-            method="medusa",
-        )
-        cap = self._capture(
-            make_worker, monkeypatch, drafter=drafter, speculative_config=spec
-        )
-        # Target = 1 + buckets(3)*2 = 7 (no MoE); draft = 1 + buckets(3) = 4.
-        assert cap["num_runtimes"] == 11
-
     def test_draft_runtime_adds_specialized_moe_fallback(
         self, make_worker, monkeypatch
     ):

--- a/tests/native/v1/worker/test_rbln_worker.py
+++ b/tests/native/v1/worker/test_rbln_worker.py
@@ -376,6 +376,7 @@ class TestDetermineAvailableMemory:
         hf_config=None,
         params=None,
         specialized_moe_decode=False,
+        uses_fixed_decode_window=False,
         decode_buckets=3,
         drafter=None,
         speculative_config=None,
@@ -399,6 +400,7 @@ class TestDetermineAvailableMemory:
                 decode_batch_buckets_count=decode_buckets
             ),
             drafter=drafter,
+            uses_fixed_decode_window=uses_fixed_decode_window,
         )
         worker.determine_available_memory()
         return captured
@@ -478,12 +480,37 @@ class TestDetermineAvailableMemory:
             method="eagle",
         )
         cap = self._capture(
-            make_worker, monkeypatch, drafter=drafter, speculative_config=spec
+            make_worker,
+            monkeypatch,
+            drafter=drafter,
+            speculative_config=spec,
+            uses_fixed_decode_window=True,
         )
         assert "kernel_size" in cap
         assert "n_model_bytes" not in cap
-        # Spec on: target = 1 + buckets(3)*num_decode_query_lens(2) = 7 (no MoE);
-        # draft = 1 + buckets(3) = 4. Total 11.
+        # A fixed decode window compiles one decode query length: target =
+        # 1 + buckets(3)*1 = 4 (no MoE); draft = 1 + buckets(3) = 4. Total 8.
+        assert cap["num_runtimes"] == 8
+
+    def test_a_variable_window_still_reserves_both_decode_lengths(
+        self, make_worker, monkeypatch
+    ):
+        # An ngram-style method keeps qlen=1 reachable, so warm-up compiles both
+        # decode query lengths and the reservation has to cover them.
+        drafter = SimpleNamespace(
+            model=SimpleNamespace(
+                parameters=lambda: iter([torch.zeros(20, dtype=torch.float16)])
+            )
+        )
+        spec = SimpleNamespace(
+            draft_model_config=SimpleNamespace(quantization=None),
+            draft_parallel_config=None,
+            method="medusa",
+        )
+        cap = self._capture(
+            make_worker, monkeypatch, drafter=drafter, speculative_config=spec
+        )
+        # Target = 1 + buckets(3)*2 = 7 (no MoE); draft = 1 + buckets(3) = 4.
         assert cap["num_runtimes"] == 11
 
     def test_draft_runtime_adds_specialized_moe_fallback(
@@ -491,8 +518,8 @@ class TestDetermineAvailableMemory:
     ):
         # The specialized-MoE-decode fallback re-runs the top bucket at a different
         # num_padded_tokens, so it adds one draft graph.
-        # Target = 1 + buckets(3)*2 + (2 + 1) = 10; draft = 1 + buckets(3) + 1 = 5;
-        # total 15.
+        # Target = 1 + buckets(3)*1 + 1 = 5; draft = 1 + buckets(3) + 1 = 5;
+        # total 10.
         drafter = SimpleNamespace(
             model=SimpleNamespace(
                 parameters=lambda: iter([torch.zeros(20, dtype=torch.float16)])
@@ -509,8 +536,9 @@ class TestDetermineAvailableMemory:
             drafter=drafter,
             speculative_config=spec,
             specialized_moe_decode=True,
+            uses_fixed_decode_window=True,
         )
-        assert cap["num_runtimes"] == 15
+        assert cap["num_runtimes"] == 10
 
     def test_draft_quantization_rejected(self, make_worker, monkeypatch):
         drafter = SimpleNamespace(
@@ -525,7 +553,11 @@ class TestDetermineAvailableMemory:
         )
         with pytest.raises(ValueError, match="draft model quantization"):
             self._capture(
-                make_worker, monkeypatch, drafter=drafter, speculative_config=spec
+                make_worker,
+                monkeypatch,
+                drafter=drafter,
+                speculative_config=spec,
+                uses_fixed_decode_window=True,
             )
 
 

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -218,6 +218,7 @@ class RBLNScheduler(Scheduler):
         encoder_compute_budget = self.max_num_encoder_input_tokens
         # Spec decode-related.
         scheduled_spec_decode_tokens: dict[str, list[int]] = {}
+        unsafe_backfill_req_ids: set[str] = set()
 
         # For logging.
         scheduled_timestamp = time.monotonic()
@@ -315,17 +316,23 @@ class RBLNScheduler(Scheduler):
                     request, num_new_tokens
                 )
 
-            # NOTE(RBLN): A decode query is written as one contiguous KV window,
-            # so the logical advance may not straddle a KV block. With a
-            # model-based drafter the runner then stages a fixed
-            # num_spec_tokens + 1 window around these tokens, padding in front of
-            # them or behind them as the block allows; the others run the clamped
-            # length as-is.
+            # NOTE(RBLN): A decode query is written as one contiguous KV window.
+            # Keep the fixed num_spec_tokens + 1 query only when the required
+            # backfill prefix stays within the current KV block. If it would reach into
+            # the previous block, remember this request and force the finalized decode
+            # batch to single-token decode only if this request remains scheduled.
             if self.num_spec_tokens > 0 and not is_prefill(request):
-                remaining_in_block = self.block_size - (
-                    request.num_computed_tokens % self.block_size
-                )
+                tokens_used_in_block = request.num_computed_tokens % self.block_size
+                remaining_in_block = self.block_size - tokens_used_in_block
                 num_new_tokens = min(remaining_in_block, num_new_tokens)
+
+                if num_new_tokens > 0:
+                    required_backfill = max(
+                        0, self.num_spec_tokens + 1 - num_new_tokens
+                    )
+                    if required_backfill > tokens_used_in_block:
+                        unsafe_backfill_req_ids.add(request.request_id)
+                        num_new_tokens = 1
 
             if num_new_tokens == 0:
                 # The request cannot be scheduled because one of the following
@@ -853,6 +860,19 @@ class RBLNScheduler(Scheduler):
                         f"decode-ready request {request_id} has "
                         f"num_new_tokens={num_new_tokens} (expected 1)."
                     )
+                    # NOTE(RBLN): This path skips the running-loop backfill guard.
+                    # A decode-ready req enters as a single-token decode (new_n==1,
+                    # asserted above) that the runner backfills to num_spec+1; if the
+                    # num_spec past tokens don't fit the current block the backfill
+                    # would cross into the previous one -> mark unsafe so the batch
+                    # drops to no-spec.
+                    if self.num_spec_tokens > 0:
+                        tokens_used_in_block = (
+                            request.num_computed_tokens % self.block_size
+                        )
+                        required_backfill = self.num_spec_tokens  # (num_spec+1)-1
+                        if required_backfill > tokens_used_in_block:
+                            unsafe_backfill_req_ids.add(request.request_id)
                     # NOTE(RBLN): this decode-ready request has just joined the
                     # decode batch (any route -- full remote-KV match or full
                     # local prefix-cache match), so count it against the shared
@@ -897,6 +917,30 @@ class RBLNScheduler(Scheduler):
             # re-queue requests skipped in this pass ahead of older skipped items.
             if step_skipped_waiting:
                 self.skipped_waiting.prepend_requests(step_skipped_waiting)
+
+        # NOTE(RBLN): The runner chooses the full-spec query path from
+        # scheduled_spec_decode_tokens. If any finally scheduled decode request cannot
+        # safely backfill within its current block, force the whole scheduled decode
+        # batch to qlen=1 by trimming logical advance and clearing drafts.
+        scheduled_running_req_ids = {req.request_id for req in scheduled_running_reqs}
+        # NOTE(RBLN): Also cover decode-ready reqs that joined via the
+        # not-is_prefill path above (new/resumed: remote-KV or prefix-cache
+        # matches): an unsafe one must force the batch to no-spec too. True
+        # prefill new reqs never enter unsafe_backfill_req_ids, so widening the
+        # set is a no-op for them.
+        scheduled_running_req_ids |= {
+            req.request_id
+            for req in itertools.chain(scheduled_new_reqs, scheduled_resumed_reqs)
+        }
+        if unsafe_backfill_req_ids & scheduled_running_req_ids:
+            for req in scheduled_running_reqs:
+                req_id = req.request_id
+
+                if (old_n := num_scheduled_tokens[req_id]) > 1:
+                    token_budget += old_n - 1
+                    num_scheduled_tokens[req_id] = 1
+
+                scheduled_spec_decode_tokens.pop(req_id, None)
 
         # Check if the scheduling constraints are satisfied.
         total_num_scheduled_tokens = sum(num_scheduled_tokens.values())

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -216,7 +216,6 @@ class RBLNScheduler(Scheduler):
         encoder_compute_budget = self.max_num_encoder_input_tokens
         # Spec decode-related.
         scheduled_spec_decode_tokens: dict[str, list[int]] = {}
-        unsafe_backfill_req_ids: set[str] = set()
 
         # For logging.
         scheduled_timestamp = time.monotonic()
@@ -314,23 +313,17 @@ class RBLNScheduler(Scheduler):
                     request, num_new_tokens
                 )
 
-            # NOTE(RBLN): A decode query is written as one contiguous KV window.
-            # Keep the fixed num_spec_tokens + 1 query only when the required
-            # backfill prefix stays within the current KV block. If it would reach into
-            # the previous block, remember this request and force the finalized decode
-            # batch to single-token decode only if this request remains scheduled.
+            # NOTE(RBLN): A decode query is written as one contiguous KV window,
+            # so the logical advance may not straddle a KV block. With a
+            # model-based drafter the runner then stages a fixed
+            # num_spec_tokens + 1 window around these tokens, padding in front of
+            # them or behind them as the block allows; the others run the clamped
+            # length as-is.
             if self.num_spec_tokens > 0 and not is_prefill(request):
-                tokens_used_in_block = request.num_computed_tokens % self.block_size
-                remaining_in_block = self.block_size - tokens_used_in_block
+                remaining_in_block = self.block_size - (
+                    request.num_computed_tokens % self.block_size
+                )
                 num_new_tokens = min(remaining_in_block, num_new_tokens)
-
-                if num_new_tokens > 0:
-                    required_backfill = max(
-                        0, self.num_spec_tokens + 1 - num_new_tokens
-                    )
-                    if required_backfill > tokens_used_in_block:
-                        unsafe_backfill_req_ids.add(request.request_id)
-                        num_new_tokens = 1
 
             if num_new_tokens == 0:
                 # The request cannot be scheduled because one of the following
@@ -858,19 +851,6 @@ class RBLNScheduler(Scheduler):
                         f"decode-ready request {request_id} has "
                         f"num_new_tokens={num_new_tokens} (expected 1)."
                     )
-                    # NOTE(RBLN): This path skips the running-loop backfill guard.
-                    # A decode-ready req enters as a single-token decode (new_n==1,
-                    # asserted above) that the runner backfills to num_spec+1; if the
-                    # num_spec past tokens don't fit the current block the backfill
-                    # would cross into the previous one -> mark unsafe so the batch
-                    # drops to no-spec.
-                    if self.num_spec_tokens > 0:
-                        tokens_used_in_block = (
-                            request.num_computed_tokens % self.block_size
-                        )
-                        required_backfill = self.num_spec_tokens  # (num_spec+1)-1
-                        if required_backfill > tokens_used_in_block:
-                            unsafe_backfill_req_ids.add(request.request_id)
                     # NOTE(RBLN): this decode-ready request has just joined the
                     # decode batch (any route -- full remote-KV match or full
                     # local prefix-cache match), so count it against the shared
@@ -915,30 +895,6 @@ class RBLNScheduler(Scheduler):
             # re-queue requests skipped in this pass ahead of older skipped items.
             if step_skipped_waiting:
                 self.skipped_waiting.prepend_requests(step_skipped_waiting)
-
-        # NOTE(RBLN): The runner chooses the full-spec query path from
-        # scheduled_spec_decode_tokens. If any finally scheduled decode request cannot
-        # safely backfill within its current block, force the whole scheduled decode
-        # batch to qlen=1 by trimming logical advance and clearing drafts.
-        scheduled_running_req_ids = {req.request_id for req in scheduled_running_reqs}
-        # NOTE(RBLN): Also cover decode-ready reqs that joined via the
-        # not-is_prefill path above (new/resumed: remote-KV or prefix-cache
-        # matches): an unsafe one must force the batch to no-spec too. True
-        # prefill new reqs never enter unsafe_backfill_req_ids, so widening the
-        # set is a no-op for them.
-        scheduled_running_req_ids |= {
-            req.request_id
-            for req in itertools.chain(scheduled_new_reqs, scheduled_resumed_reqs)
-        }
-        if unsafe_backfill_req_ids & scheduled_running_req_ids:
-            for req in scheduled_running_reqs:
-                req_id = req.request_id
-
-                if (old_n := num_scheduled_tokens[req_id]) > 1:
-                    token_budget += old_n - 1
-                    num_scheduled_tokens[req_id] = 1
-
-                scheduled_spec_decode_tokens.pop(req_id, None)
 
         # Check if the scheduling constraints are satisfied.
         total_num_scheduled_tokens = sum(num_scheduled_tokens.values())

--- a/vllm_rbln/v1/spec_decode/eagle.py
+++ b/vllm_rbln/v1/spec_decode/eagle.py
@@ -325,7 +325,6 @@ class RBLNEagleProposer(EagleProposer):
         common_attn_metadata: CommonAttentionMetadata,
         spec_decode_metadata: SpecDecodeMetadata,
         valid_sampled_tokens_count: torch.Tensor,
-        back_pad: torch.Tensor,
     ) -> tuple[CommonAttentionMetadata, torch.Tensor, torch.Tensor]:
         """
         This function is used to prepare the inputs for speculative decoding
@@ -338,7 +337,6 @@ class RBLNEagleProposer(EagleProposer):
             spec_decode_metadata.cu_num_draft_tokens,
             valid_sampled_tokens_count,
             common_attn_metadata.query_start_loc,
-            back_pad,
         )
 
         query_start_loc = common_attn_metadata.query_start_loc

--- a/vllm_rbln/v1/spec_decode/eagle.py
+++ b/vllm_rbln/v1/spec_decode/eagle.py
@@ -673,9 +673,6 @@ class RBLNEagleProposer(EagleProposer):
         if target_token_ids is not None:
             assert next_token_ids is not None
             assert num_input_tokens == target_token_ids.shape[0]
-            # Deriving this from query_start_loc would land on the query's last
-            # slot, which back padding no longer guarantees is the last
-            # scheduled token, so the caller owns it.
             assert token_indices_to_sample is not None
             token_indices_to_sample = token_indices_to_sample.to(self.device)
 

--- a/vllm_rbln/v1/spec_decode/eagle.py
+++ b/vllm_rbln/v1/spec_decode/eagle.py
@@ -141,7 +141,6 @@ class RBLNEagleProposer(EagleProposer):
                 token_indices_to_sample=token_indices_to_sample,
                 target_token_ids=target_token_ids,
                 next_token_ids=next_token_ids,
-                cad=common_attn_metadata,
             )
         )
         inputs_embeds = None
@@ -326,6 +325,7 @@ class RBLNEagleProposer(EagleProposer):
         common_attn_metadata: CommonAttentionMetadata,
         spec_decode_metadata: SpecDecodeMetadata,
         valid_sampled_tokens_count: torch.Tensor,
+        back_pad: torch.Tensor,
     ) -> tuple[CommonAttentionMetadata, torch.Tensor, torch.Tensor]:
         """
         This function is used to prepare the inputs for speculative decoding
@@ -338,6 +338,7 @@ class RBLNEagleProposer(EagleProposer):
             spec_decode_metadata.cu_num_draft_tokens,
             valid_sampled_tokens_count,
             common_attn_metadata.query_start_loc,
+            back_pad,
         )
 
         query_start_loc = common_attn_metadata.query_start_loc
@@ -670,15 +671,14 @@ class RBLNEagleProposer(EagleProposer):
         token_indices_to_sample: torch.Tensor | None = None,
         target_token_ids: torch.Tensor | None = None,
         next_token_ids: torch.Tensor | None = None,
-        cad: CommonAttentionMetadata | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
         if target_token_ids is not None:
             assert next_token_ids is not None
             assert num_input_tokens == target_token_ids.shape[0]
-
-            if token_indices_to_sample is None:
-                assert cad is not None
-                token_indices_to_sample = cad.query_start_loc[1:] - 1
+            # Deriving this from query_start_loc would land on the query's last
+            # slot, which back padding no longer guarantees is the last
+            # scheduled token, so the caller owns it.
+            assert token_indices_to_sample is not None
             token_indices_to_sample = token_indices_to_sample.to(self.device)
 
             self.input_ids[: num_input_tokens - 1] = target_token_ids[1:]

--- a/vllm_rbln/v1/spec_decode/utils.py
+++ b/vllm_rbln/v1/spec_decode/utils.py
@@ -69,8 +69,6 @@ def eagle_prepare_inputs_padded(
     valid_sampled_tokens_count: torch.Tensor,
     # [num_reqs + 1]
     query_start_loc: torch.Tensor,
-    # [num_reqs]
-    back_pad: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     This function computes the token index to sample for each request, taking into
@@ -78,10 +76,6 @@ def eagle_prepare_inputs_padded(
     (which is one more than the number of accepted tokens). It also returns the
     number of rejected tokens for each request to match upstream's padded EAGLE
     input preparation contract.
-
-    `back_pad` is the slots the target staged behind each request's scheduled
-    tokens, so the walk back from the query's last slot starts at the last
-    scheduled one.
     """
     num_draft_tokens = cu_num_draft_tokens - torch.nn.functional.pad(
         cu_num_draft_tokens[:-1], (1, 0)
@@ -93,8 +87,8 @@ def eagle_prepare_inputs_padded(
         num_draft_tokens + 1 - valid_sampled_tokens_count,
         torch.zeros_like(valid_sampled_tokens_count),
     ).to(torch.int32)
-    token_indices_to_sample = (
-        query_start_loc[1:] - 1 - back_pad - num_rejected_tokens
-    ).to(torch.int32)
+    token_indices_to_sample = (query_start_loc[1:] - 1 - num_rejected_tokens).to(
+        torch.int32
+    )
 
     return token_indices_to_sample, num_rejected_tokens

--- a/vllm_rbln/v1/spec_decode/utils.py
+++ b/vllm_rbln/v1/spec_decode/utils.py
@@ -69,6 +69,8 @@ def eagle_prepare_inputs_padded(
     valid_sampled_tokens_count: torch.Tensor,
     # [num_reqs + 1]
     query_start_loc: torch.Tensor,
+    # [num_reqs]
+    back_pad: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     This function computes the token index to sample for each request, taking into
@@ -76,6 +78,10 @@ def eagle_prepare_inputs_padded(
     (which is one more than the number of accepted tokens). It also returns the
     number of rejected tokens for each request to match upstream's padded EAGLE
     input preparation contract.
+
+    `back_pad` is the slots the target staged behind each request's scheduled
+    tokens, so the walk back from the query's last slot starts at the last
+    scheduled one.
     """
     num_draft_tokens = cu_num_draft_tokens - torch.nn.functional.pad(
         cu_num_draft_tokens[:-1], (1, 0)
@@ -87,8 +93,8 @@ def eagle_prepare_inputs_padded(
         num_draft_tokens + 1 - valid_sampled_tokens_count,
         torch.zeros_like(valid_sampled_tokens_count),
     ).to(torch.int32)
-    token_indices_to_sample = (query_start_loc[1:] - 1 - num_rejected_tokens).to(
-        torch.int32
-    )
+    token_indices_to_sample = (
+        query_start_loc[1:] - 1 - back_pad - num_rejected_tokens
+    ).to(torch.int32)
 
     return token_indices_to_sample, num_rejected_tokens

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -859,7 +859,11 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         # cheap. An ngram-style drafter finds no match often enough that padding
         # every one of those steps would cost more than the extra graph.
         use_spec_decode = len(scheduler_output.scheduled_spec_decode_tokens) > 0
-        if self.uses_fixed_decode_window and not self.is_prefill:
+        window_fixed = not self.is_prefill and (
+            self.uses_fixed_decode_window
+            or (self.num_spec_tokens > 0 and use_spec_decode)
+        )
+        if window_fixed:
             query_lengths = np.full(num_reqs, self.num_spec_tokens + 1, dtype=np.int32)
             slack = query_lengths - logical_num_tokens
 
@@ -880,8 +884,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             # this is the invariant the padding split exists to keep. It holds
             # because the front takes at most the tokens already used in the
             # block and the scheduler clamped the logical advance to what is
-            # left of it, which is also why the window never has to grow past
-            # the assert above.
+            # left of it, so both edges of the window stay inside one block.
             window_start = num_computed - front_pad
             assert np.array_equal(
                 window_start // block_size,
@@ -918,8 +921,16 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
         # -> [0, 1, M, M + 1, M + 2, M + 3, M + 4, 2 * M, 2 * M + 1, 2 * M + 2]
         # where M is the max_model_len.
+        lookup_positions = positions_np
+        if window_fixed:
+            logical_end = (
+                self.input_batch.num_computed_tokens_cpu[:num_reqs]
+                + logical_num_tokens
+                - 1
+            )
+            lookup_positions = np.minimum(positions_np, logical_end[req_indices])
         token_indices = (
-            positions_np + req_indices * self.input_batch.token_ids_cpu.shape[1]
+            lookup_positions + req_indices * self.input_batch.token_ids_cpu.shape[1]
         )
         token_indices_tensor = torch.from_numpy(token_indices)
 
@@ -960,11 +971,9 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             # from these partial requests, we do so for simplicity.
             # We will ignore the sampled tokens from the partial requests.
             # TODO: Support prompt logprobs.
-            logits_indices = (
-                self.query_start_loc[1 : num_reqs + 1]
-                - 1
-                - self.decode_back_pad[:num_reqs]
-            )
+            logits_indices = self.query_start_loc[1 : num_reqs + 1] - 1
+            if window_fixed:
+                logits_indices = logits_indices - self.decode_back_pad[:num_reqs]
             spec_decode_metadata = None
         else:
             # Get the number of draft tokens for each request.
@@ -986,7 +995,8 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 ):
                     num_decode_draft_tokens[req_idx] = len(draft_token_ids)
             spec_decode_metadata = self._calc_spec_decode_metadata(
-                num_draft_tokens, cu_num_tokens - back_pad
+                num_draft_tokens,
+                cu_num_tokens - back_pad if window_fixed else cu_num_tokens,
             )
             logits_indices = spec_decode_metadata.logits_indices
 
@@ -1852,7 +1862,10 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
 
             sample_hidden_states = hidden_states
             assert self.use_wrapped_compute_logits
-            if not self.is_prefill and spec_decode_metadata is not None:
+
+            if not self.is_prefill and (
+                spec_decode_metadata is not None or self.uses_fixed_decode_window
+            ):
                 logits = logits[logits_indices]
 
         self.execute_model_state = ExecuteModelState(
@@ -2130,8 +2143,8 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                     common_attn_metadata,
                     spec_decode_metadata,
                     valid_sampled_tokens_count,
-                    back_pad,
                 )
+                token_indices_to_sample = token_indices_to_sample - back_pad
                 total_num_tokens = common_attn_metadata.num_actual_tokens
                 target_token_ids = self.input_ids[:total_num_tokens]
                 target_positions = self.positions[:total_num_tokens]
@@ -2472,6 +2485,8 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         is_idle), then adopts the busy-decided shape and runs the same compiled
         graph the busy ranks run.
         """
+        if warmup and not is_prefill and self.uses_fixed_decode_window:
+            num_tokens_per_req = max(num_tokens_per_req, self.num_spec_tokens + 1)
         num_tokens = num_tokens_per_req * num_reqs
         assert num_reqs <= self.max_num_reqs
 
@@ -3126,9 +3141,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 "Set VLLM_RBLN_SUB_BLOCK_CACHE=false to disable."
             )
 
-        if self.uses_fixed_decode_window:
-            # The fixed decode window is placed inside one KV block, so the
-            # sequence's last block has to be able to hold it. A block-aligned
+        if self.num_spec_tokens > 0:
             # max_model_len always can; a shorter remainder cannot, and the
             # window would then have to run past max_model_len.
             window = self.num_spec_tokens + 1
@@ -3251,17 +3264,12 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
 
     @property
     def uses_fixed_decode_window(self) -> bool:
-        """Whether decode stages a fixed num_spec_tokens + 1 query.
+        """Whether *every* decode step stages a num_spec_tokens + 1 query."""
 
-        See the window construction in `_prepare_inputs`. A model-based drafter
-        proposes on every step, so a decode step that carries no draft is the
-        exception; an ngram-style one misses often, and padding every miss out to
-        the full window would cost more than the extra compiled shape.
-        """
         return (
-            self.num_spec_tokens > 0
-            and self.speculative_config is not None
-            and self.speculative_config.use_eagle()
+            self.speculative_config is not None
+            and self.num_spec_tokens > 0
+            and self.speculative_config.method in ("eagle", "eagle3", "mtp")
         )
 
     @property

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -417,10 +417,6 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         self.positions = torch.zeros(self.max_num_tokens, dtype=torch.int64)
         self.query_start_loc = torch.zeros(self.max_num_reqs + 1, dtype=torch.int32)
         self.query_start_loc_np = self.query_start_loc.numpy()
-        # Slots this step staged behind each request's scheduled tokens (see the
-        # window construction in _prepare_inputs). Everything that has to find
-        # the last scheduled token in the staged query subtracts it, so it is
-        # step state rather than a local.
         self.decode_back_pad = torch.zeros(self.max_num_reqs, dtype=torch.int32)
         self.decode_back_pad_np = self.decode_back_pad.numpy()
         self.seq_lens = torch.zeros(self.max_num_tokens, dtype=torch.int32)
@@ -842,22 +838,12 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         assert (num_reqs := self.input_batch.num_reqs) > 0
         logical_num_tokens = num_scheduled_tokens
 
-        # NOTE(RBLN): A decode query is written as one contiguous KV window, so
-        # every decode step stages the same num_spec_tokens + 1 slots and fills
-        # the slack around the scheduled tokens. The slack goes in front of them
-        # as far as the current block allows -- already-computed tokens, re-run
-        # and discarded -- and the remainder goes behind them, on slots past the
-        # logical end whose KV the next step overwrites. The two directions fail
-        # on opposite edges of a block (the front needs computed tokens inside
-        # it, the back needs free slots), so a block that can hold the window
-        # makes their union total and the window is always constructible.
-        # Holding one query length is what keeps the decode graph set at one
-        # shape instead of one per reachable length; a step that reached the
-        # logical length instead would need its own graph for every length.
-        # Only a model-based drafter takes this: it proposes on every step, so a
-        # step with no drafts is the exception and paying a full window for it is
-        # cheap. An ngram-style drafter finds no match often enough that padding
-        # every one of those steps would cost more than the extra graph.
+        # NOTE(RBLN): A decode query is one contiguous KV window, so a step that
+        # stages the fixed num_spec_tokens + 1 query splits the slack around the
+        # scheduled tokens: in front as far as the block's used tail reaches, the
+        # rest behind. That keeps the window inside one block and the decode graph
+        # set at one shape. A model-based drafter always stages it; an ngram-style
+        # one only on the steps whose drafts the scheduler kept.
         use_spec_decode = len(scheduler_output.scheduled_spec_decode_tokens) > 0
         window_fixed = not self.is_prefill and (
             self.uses_fixed_decode_window
@@ -872,27 +858,9 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 f"logical_num_tokens={logical_num_tokens}"
             )
             block_size = self.cache_config.block_size
-            assert block_size >= self.num_spec_tokens + 1, (
-                f"block_size={block_size} cannot hold a "
-                f"{self.num_spec_tokens + 1}-slot decode window"
-            )
             num_computed = self.input_batch.num_computed_tokens_cpu[:num_reqs]
             front_pad = np.minimum(slack, num_computed % block_size).astype(np.int32)
             back_pad = slack - front_pad
-
-            # The kernel writes a decode query as one range inside one block, so
-            # this is the invariant the padding split exists to keep. It holds
-            # because the front takes at most the tokens already used in the
-            # block and the scheduler clamped the logical advance to what is
-            # left of it, so both edges of the window stay inside one block.
-            window_start = num_computed - front_pad
-            assert np.array_equal(
-                window_start // block_size,
-                (window_start + query_lengths - 1) // block_size,
-            ), (
-                f"decode window straddles a KV block: starts={window_start}, "
-                f"query_lengths={query_lengths}, block_size={block_size}"
-            )
         else:
             query_lengths = logical_num_tokens
             front_pad = np.zeros_like(logical_num_tokens)
@@ -1099,9 +1067,6 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         num_draft_tokens: np.ndarray,
         cu_sample_end: np.ndarray,
     ) -> SpecDecodeMetadata:
-        # `cu_sample_end` is the exclusive end of each request's sampled slots in
-        # the staged query, which trails the staged end by whatever back padding
-        # `_prepare_inputs` added.
         # Inputs:
         # cu_sample_end:            [  4, 104, 107, 207, 209]
         # num_draft_tokens:         [  3,   0,   2,   0,   1]
@@ -2123,9 +2088,6 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             num_reqs = self.input_batch.num_reqs
             back_pad = self.decode_back_pad[:num_reqs]
             if spec_decode_metadata is None:
-                # The staged query, not the logical advance: the draft mirrors
-                # the target's window, and the back padding puts each request's
-                # scheduled token before the window's last slot.
                 num_staged_tokens = int(common_attn_metadata.query_start_loc[num_reqs])
                 token_indices_to_sample = (
                     common_attn_metadata.query_start_loc[1 : num_reqs + 1]
@@ -3146,6 +3108,11 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             # window would then have to run past max_model_len.
             window = self.num_spec_tokens + 1
             block_size = self.cache_config.block_size
+            if block_size < window:
+                raise ValueError(
+                    f"block_size={block_size} cannot hold the {window}-slot "
+                    f"speculative decode window."
+                )
             remainder = self.max_model_len % block_size
             if remainder and remainder < window:
                 raise ValueError(
@@ -3500,9 +3467,6 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             self._dummy_run(1, self.max_num_tokens, True)
 
             # 2. decode
-            # NOTE(RBLN): a fixed decode window makes qlen=1 unreachable for the
-            # target, so compiling it would leave a graph nothing executes. Every
-            # other configuration still reaches it.
             query_lens = [1]
             if self.speculative_config:
                 spec_query_len = self.speculative_config.num_speculative_tokens + 1

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -416,6 +416,12 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         self.positions = torch.zeros(self.max_num_tokens, dtype=torch.int64)
         self.query_start_loc = torch.zeros(self.max_num_reqs + 1, dtype=torch.int32)
         self.query_start_loc_np = self.query_start_loc.numpy()
+        # Slots this step staged behind each request's scheduled tokens (see the
+        # window construction in _prepare_inputs). Everything that has to find
+        # the last scheduled token in the staged query subtracts it, so it is
+        # step state rather than a local.
+        self.decode_back_pad = torch.zeros(self.max_num_reqs, dtype=torch.int32)
+        self.decode_back_pad_np = self.decode_back_pad.numpy()
         self.seq_lens = torch.zeros(self.max_num_tokens, dtype=torch.int32)
         self.seq_lens_np = self.seq_lens.numpy()
         self.discard_request_mask = torch.zeros(self.max_num_reqs, dtype=torch.bool)
@@ -835,23 +841,58 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         assert (num_reqs := self.input_batch.num_reqs) > 0
         logical_num_tokens = num_scheduled_tokens
 
-        # NOTE(RBLN): Build the fixed full-spec query only when the scheduler
-        # actually kept draft tokens. Unsafe boundary cases and zero-draft
-        # ngram/suffix steps clear scheduled_spec_decode_tokens and run with
-        # the logical query length, usually qlen=1.
+        # NOTE(RBLN): A decode query is written as one contiguous KV window, so
+        # every decode step stages the same num_spec_tokens + 1 slots and fills
+        # the slack around the scheduled tokens. The slack goes in front of them
+        # as far as the current block allows -- already-computed tokens, re-run
+        # and discarded -- and the remainder goes behind them, on slots past the
+        # logical end whose KV the next step overwrites. The two directions fail
+        # on opposite edges of a block (the front needs computed tokens inside
+        # it, the back needs free slots), so a block that can hold the window
+        # makes their union total and the window is always constructible.
+        # Holding one query length is what keeps the decode graph set at one
+        # shape instead of one per reachable length; a step that reached the
+        # logical length instead would need its own graph for every length.
+        # Only a model-based drafter takes this: it proposes on every step, so a
+        # step with no drafts is the exception and paying a full window for it is
+        # cheap. An ngram-style drafter finds no match often enough that padding
+        # every one of those steps would cost more than the extra graph.
         use_spec_decode = len(scheduler_output.scheduled_spec_decode_tokens) > 0
-        if use_spec_decode and self.num_spec_tokens > 0 and not self.is_prefill:
-            target_query_len = self.num_spec_tokens + 1
-            query_lengths = np.full(num_reqs, target_query_len, dtype=np.int32)
-            backfill = query_lengths - logical_num_tokens
+        if self.uses_fixed_decode_window and not self.is_prefill:
+            query_lengths = np.full(num_reqs, self.num_spec_tokens + 1, dtype=np.int32)
+            slack = query_lengths - logical_num_tokens
 
-            assert np.all(backfill >= 0), (
+            assert np.all(slack >= 0), (
                 f"query_lengths={query_lengths}, "
                 f"logical_num_tokens={logical_num_tokens}"
             )
+            block_size = self.cache_config.block_size
+            assert block_size >= self.num_spec_tokens + 1, (
+                f"block_size={block_size} cannot hold a "
+                f"{self.num_spec_tokens + 1}-slot decode window"
+            )
+            num_computed = self.input_batch.num_computed_tokens_cpu[:num_reqs]
+            front_pad = np.minimum(slack, num_computed % block_size).astype(np.int32)
+            back_pad = slack - front_pad
+
+            # The kernel writes a decode query as one range inside one block, so
+            # this is the invariant the padding split exists to keep. It holds
+            # because the front takes at most the tokens already used in the
+            # block and the scheduler clamped the logical advance to what is
+            # left of it, which is also why the window never has to grow past
+            # the assert above.
+            window_start = num_computed - front_pad
+            assert np.array_equal(
+                window_start // block_size,
+                (window_start + query_lengths - 1) // block_size,
+            ), (
+                f"decode window straddles a KV block: starts={window_start}, "
+                f"query_lengths={query_lengths}, block_size={block_size}"
+            )
         else:
             query_lengths = logical_num_tokens
-            backfill = np.zeros_like(logical_num_tokens)
+            front_pad = np.zeros_like(logical_num_tokens)
+            back_pad = np.zeros_like(logical_num_tokens)
 
         total_query_tokens = int(query_lengths.sum())
 
@@ -867,7 +908,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         positions_np = self.positions.numpy()[:total_query_tokens]
         np.add(
             self.input_batch.num_computed_tokens_cpu[req_indices]
-            - backfill[req_indices],
+            - front_pad[req_indices],
             arange,
             out=positions_np,
         )
@@ -890,6 +931,9 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             token_indices_tensor,
             out=self.input_ids[:total_query_tokens],
         )
+
+        self.decode_back_pad_np[:num_reqs] = back_pad
+        self.decode_back_pad_np[num_reqs:] = 0
 
         # Prepare the attention metadata.
         self.query_start_loc_np[0] = 0
@@ -915,7 +959,11 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             # from these partial requests, we do so for simplicity.
             # We will ignore the sampled tokens from the partial requests.
             # TODO: Support prompt logprobs.
-            logits_indices = self.query_start_loc[1 : num_reqs + 1] - 1
+            logits_indices = (
+                self.query_start_loc[1 : num_reqs + 1]
+                - 1
+                - self.decode_back_pad[:num_reqs]
+            )
             spec_decode_metadata = None
         else:
             # Get the number of draft tokens for each request.
@@ -937,7 +985,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 ):
                     num_decode_draft_tokens[req_idx] = len(draft_token_ids)
             spec_decode_metadata = self._calc_spec_decode_metadata(
-                num_draft_tokens, cu_num_tokens
+                num_draft_tokens, cu_num_tokens - back_pad
             )
             logits_indices = spec_decode_metadata.logits_indices
 
@@ -1038,10 +1086,13 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
     def _calc_spec_decode_metadata(
         self,
         num_draft_tokens: np.ndarray,
-        cu_num_scheduled_tokens: np.ndarray,
+        cu_sample_end: np.ndarray,
     ) -> SpecDecodeMetadata:
+        # `cu_sample_end` is the exclusive end of each request's sampled slots in
+        # the staged query, which trails the staged end by whatever back padding
+        # `_prepare_inputs` added.
         # Inputs:
-        # cu_num_scheduled_tokens:  [  4, 104, 107, 207, 209]
+        # cu_sample_end:            [  4, 104, 107, 207, 209]
         # num_draft_tokens:         [  3,   0,   2,   0,   1]
         # Outputs:
         # cu_num_draft_tokens:      [  3,   3,   5,   5,   6]
@@ -1061,7 +1112,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         )
         # Step 2. [0, 0, 0, 0, 103, 104, 104, 104, 206, 207, 207]
         logits_indices = np.repeat(
-            cu_num_scheduled_tokens - num_sampled_tokens, num_sampled_tokens
+            cu_sample_end - num_sampled_tokens, num_sampled_tokens
         )
         # Step 3. [0, 1, 2, 3, 103, 104, 105, 106, 206, 207, 208]
         logits_indices += arange
@@ -2055,11 +2106,20 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 else combined_hidden_states
             )
             num_rejected_tokens: torch.Tensor | None = None
+            num_reqs = self.input_batch.num_reqs
+            back_pad = self.decode_back_pad[:num_reqs]
             if spec_decode_metadata is None:
-                token_indices_to_sample = None
-                num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
-                target_token_ids = self.input_ids[:num_scheduled_tokens]
-                target_positions = self.positions[:num_scheduled_tokens]
+                # The staged query, not the logical advance: the draft mirrors
+                # the target's window, and the back padding puts each request's
+                # scheduled token before the window's last slot.
+                num_staged_tokens = int(common_attn_metadata.query_start_loc[num_reqs])
+                token_indices_to_sample = (
+                    common_attn_metadata.query_start_loc[1 : num_reqs + 1]
+                    - 1
+                    - back_pad
+                )
+                target_token_ids = self.input_ids[:num_staged_tokens]
+                target_positions = self.positions[:num_staged_tokens]
             else:
                 (
                     common_attn_metadata,
@@ -2069,6 +2129,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                     common_attn_metadata,
                     spec_decode_metadata,
                     valid_sampled_tokens_count,
+                    back_pad,
                 )
                 total_num_tokens = common_attn_metadata.num_actual_tokens
                 target_token_ids = self.input_ids[:total_num_tokens]
@@ -3171,6 +3232,21 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
     ####################################################################################################
 
     @property
+    def uses_fixed_decode_window(self) -> bool:
+        """Whether decode stages a fixed num_spec_tokens + 1 query.
+
+        See the window construction in `_prepare_inputs`. A model-based drafter
+        proposes on every step, so a decode step that carries no draft is the
+        exception; an ngram-style one misses often, and padding every miss out to
+        the full window would cost more than the extra compiled shape.
+        """
+        return (
+            self.num_spec_tokens > 0
+            and self.speculative_config is not None
+            and self.speculative_config.use_eagle()
+        )
+
+    @property
     def is_prefill(self) -> bool:
         """The step's prefill/decode classification, read off the scheduler
         output by step_is_prefill and stashed at the top of execute_model.
@@ -3398,9 +3474,17 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             self._dummy_run(1, self.max_num_tokens, True)
 
             # 2. decode
+            # NOTE(RBLN): a fixed decode window makes qlen=1 unreachable for the
+            # target, so compiling it would leave a graph nothing executes. Every
+            # other configuration still reaches it.
             query_lens = [1]
             if self.speculative_config:
-                query_lens.append(self.speculative_config.num_speculative_tokens + 1)
+                spec_query_len = self.speculative_config.num_speculative_tokens + 1
+                query_lens = (
+                    [spec_query_len]
+                    if self.uses_fixed_decode_window
+                    else [1, spec_query_len]
+                )
             for num_req in self.bucketing_manager.decode_batch_buckets:
                 for query_len in query_lens:
                     self._dummy_run(num_req, query_len, False)
@@ -3420,14 +3504,15 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                         False,
                         num_tokens_padded_override=self.max_num_tokens,
                     )
-                if self.speculative_config:
+                if self.speculative_config and not self.uses_fixed_decode_window:
                     # Cover DP-asymmetric decode where a peer runs spec decode.
-                    spec_query_len = self.speculative_config.num_speculative_tokens + 1
+                    # A fixed window has no such asymmetry: no rank runs qlen=1.
                     self._dummy_run(
                         num_req,
                         1,
                         False,
-                        num_tokens_padded_override=num_req * spec_query_len,
+                        num_tokens_padded_override=num_req
+                        * (self.speculative_config.num_speculative_tokens + 1),
                     )
 
             # 3. compute_logits

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -3125,6 +3125,23 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 "Set VLLM_RBLN_SUB_BLOCK_CACHE=false to disable."
             )
 
+        if self.uses_fixed_decode_window:
+            # The fixed decode window is placed inside one KV block, so the
+            # sequence's last block has to be able to hold it. A block-aligned
+            # max_model_len always can; a shorter remainder cannot, and the
+            # window would then have to run past max_model_len.
+            window = self.num_spec_tokens + 1
+            block_size = self.cache_config.block_size
+            remainder = self.max_model_len % block_size
+            if remainder and remainder < window:
+                raise ValueError(
+                    f"max_model_len={self.max_model_len} leaves {remainder} "
+                    f"token(s) in its last KV block, which cannot hold the "
+                    f"{window}-slot speculative decode window. Round "
+                    f"max_model_len to a multiple of block_size={block_size}, "
+                    f"or leave at least {window} tokens in the last block."
+                )
+
         kv_cache_config = deepcopy(kv_cache_config)
         self.kv_cache_config = kv_cache_config
         self.maybe_add_kv_sharing_layers_to_kv_cache_groups(kv_cache_config)

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -299,11 +299,14 @@ class RBLNWorker(WorkerBase):
         )
 
         spec_enabled = self.speculative_config is not None
-        num_decode_query_lens = 2 if spec_enabled else 1
+        variable_decode_query_lens = (
+            spec_enabled and not self.model_runner.uses_fixed_decode_window
+        )
+        num_decode_query_lens = 2 if variable_decode_query_lens else 1
         num_runtimes = 1 + decode_batch_buckets_count * num_decode_query_lens
         if has_specialized_moe_decode:
             num_runtimes += num_decode_query_lens
-            if spec_enabled:
+            if variable_decode_query_lens:
                 num_runtimes += 1
 
         ratio: float = 1.0


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

A model-based drafter (eagle, eagle3, mtp) proposes on *every* decode step, so its decode query is always `num_spec_tokens + 1` tokens long. Staging that window on every step drops the `qlen=1` decode: the warm-up decode calls per rank halve -- 12 -> 6 at k=1, 18 -> 9 at k=3 -- and the unique decode shapes go 6 -> 4 and 6 -> 5.

A decode query is written as one contiguous KV range inside one block, so the slack between the scheduled tokens and the fixed query length has to go somewhere that keeps the range in a single block. It is split:
- `front_pad = min(slack, num_computed % block_size)` -- as much as the block's used tail can absorb. These are tokens this request already computed, so re-running them rewrites their KV with the same value.
- `back_pad = slack - front_pad` -- the remainder, on slots the request has not reached, which attention never reads because `seq_lens` stays the logical length.

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

> *What does this PR do? What feature, fix, or improvement does it bring?*

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [x] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
